### PR TITLE
deal with http response header Transfer-Encoding：chunked

### DIFF
--- a/src/java/org/apache/nutch/metadata/HttpHeaders.java
+++ b/src/java/org/apache/nutch/metadata/HttpHeaders.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.io.Text;
  *      Protocol -- HTTP/1.1 (RFC 2616)</a>
  */
 public interface HttpHeaders {
+  public final static String TRANSFER_ENCODING = "Transfer-Encoding";
 
   public final static String CONTENT_ENCODING = "Content-Encoding";
   

--- a/src/plugin/protocol-http/src/java/org/apache/nutch/protocol/http/HttpResponse.java
+++ b/src/plugin/protocol-http/src/java/org/apache/nutch/protocol/http/HttpResponse.java
@@ -172,7 +172,12 @@ public class HttpResponse implements Response {
         haveSeenNonContinueStatus= code != 100; // 100 is "Continue"
       }
 
-      readPlainContent(in);
+	  String transferEncoding = getHeader(Response.TRANSFER_ENCODING); 
+	  if(transferEncoding != null && "chunked".equalsIgnoreCase(transferEncoding.trim())){    	  
+		 readChunkedContent(in, line);  
+	  }else{
+		 readPlainContent(in);  
+	  }
 
       String contentEncoding = getHeader(Response.CONTENT_ENCODING);
       if ("gzip".equals(contentEncoding) || "x-gzip".equals(contentEncoding)) {


### PR DESCRIPTION
fix can't fetch page if response header contains Transfer-Encoding：chunked
tips: property http.content.limit  in nutch-site.xml must greater than 0
