### PR TITLE
NUTCH-1957 using MD5 as part of file path to solve filename collision issue

### DIFF
--- a/src/java/org/apache/nutch/util/DumpFileUtil.java
+++ b/src/java/org/apache/nutch/util/DumpFileUtil.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nutch.util;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.io.MD5Hash;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+
+public class DumpFileUtil {
+    private static final Logger LOG = LoggerFactory.getLogger(DumpFileUtil.class
+            .getName());
+
+    private final static String DIR_PATTERN = "%s/%s/%s";
+    private final static String FILENAME_PATTERN = "%s_%s.%s";
+    private final static Integer MAX_LENGTH_OF_FILENAME = 32;
+
+    public static String getUrlMD5(String url) {
+        byte[] digest = MD5Hash.digest(url).getDigest();
+
+        StringBuffer sb = new StringBuffer();
+        for (byte b : digest) {
+            sb.append(String.format("%02x", b & 0xff));
+        }
+
+        return sb.toString();
+    }
+
+    public static String createTwoLevelsDirectory(String basePath, String md5) {
+        String firstLevelDirName = new StringBuilder().append(md5.charAt(0)).append(md5.charAt(8)).toString();
+        String secondLevelDirName = new StringBuilder().append(md5.charAt(16)).append(md5.charAt(24)).toString();
+
+        String fullDirPath = String.format(DIR_PATTERN, basePath, firstLevelDirName, secondLevelDirName);
+
+        try {
+            FileUtils.forceMkdir(new File(fullDirPath));
+        } catch (IOException e) {
+            LOG.error("Failed to create dir: {}", fullDirPath);
+            fullDirPath = null;
+        }
+
+        return fullDirPath;
+    }
+
+    public static String createFileName(String md5, String fileBaseName, String fileExtension) {
+        if (fileBaseName.length() > MAX_LENGTH_OF_FILENAME) {
+            LOG.info("File name is too long. Truncated to {} characters.", MAX_LENGTH_OF_FILENAME);
+            return String.format(FILENAME_PATTERN, md5, StringUtils.substring(fileBaseName, 0, MAX_LENGTH_OF_FILENAME), fileExtension);
+        } else {
+            return String.format(FILENAME_PATTERN, md5, fileBaseName, fileExtension);
+        }
+    }
+}

--- a/src/test/org/apache/nutch/util/DumpFileUtilTest.java
+++ b/src/test/org/apache/nutch/util/DumpFileUtilTest.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nutch.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DumpFileUtilTest {
+
+    @Test
+    public void testGetUrlMD5() throws Exception {
+        String testUrl = "http://apache.org";
+
+        String result = DumpFileUtil.getUrlMD5(testUrl);
+
+        assertEquals("991e599262e04ea2ec76b6c5aed499a7", result);
+    }
+
+    @Test
+    public void testCreateTwoLevelsDirectory() throws Exception {
+        String testUrl = "http://apache.org";
+        String basePath = "/tmp";
+        String fullDir = DumpFileUtil.createTwoLevelsDirectory(basePath, DumpFileUtil.getUrlMD5(testUrl));
+
+        assertEquals("/tmp/96/ea", fullDir);
+
+        String basePath2 = "/this/path/is/not/existed/just/for/testing";
+        String fullDir2 = DumpFileUtil.createTwoLevelsDirectory(basePath2, DumpFileUtil.getUrlMD5(testUrl));
+
+        assertNull(fullDir2);
+    }
+
+    @Test
+    public void testCreateFileName() throws Exception {
+        String testUrl = "http://apache.org";
+        String baseName = "test";
+        String extension = "html";
+        String fullDir = DumpFileUtil.createFileName(DumpFileUtil.getUrlMD5(testUrl), baseName, extension);
+
+        assertEquals("991e599262e04ea2ec76b6c5aed499a7_test.html", fullDir);
+
+        String tooLongBaseName = "testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest";
+        String fullDir2 = DumpFileUtil.createFileName(DumpFileUtil.getUrlMD5(testUrl), tooLongBaseName, extension);
+
+        assertEquals("991e599262e04ea2ec76b6c5aed499a7_testtesttesttesttesttesttesttest.html", fullDir2);
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NUTCH-1957

Based on the comment by Sebastian Nagel on this issue, instead of storing files into "baseName"."extension", now storing files in /\<1st char of md5\>\<9th char of md5>/\<16th char of md5\>\<24th char of md5\>/\<md5\>_\<baseName\>.\<extension\>.

md5 is the MD5 sum of the file url. So given a url with MD5 sum 3f74a26653f33ea32c23d96236d6859a, with base name 24632121 and extension html, the output full path will be: 35/23/3f74a26653f33ea32c23d96236d6859a_24632121.html

If the base name is longer than 32 characters, then it will be truncated to 32 characters to avoid file name too long issue. 