### PR TITLE
NUTCH-1986 - Update and clarify default Elasticsearch conf values

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1573,22 +1573,32 @@
 
 <property>
   <name>elastic.host</name>
-  <value></value>
-  <description>The hostname to send documents to using TransportClient. Either host
-  and port must be defined or cluster.</description>
+  <value>localhost</value>
+  <description>
+  The hostname to send documents to using TransportClient. Either host
+  and port must be defined or cluster to connect.
+  </description>
 </property>
 
 <property> 
   <name>elastic.port</name>
-  <value>9300</value>The port to connect to using TransportClient.<description>
+  <value>9300</value>
+  <description>
+  The port to connect to using TransportClient. Note, the default port
+  for HTTP is 9200. The TransportClient port is NOT the same. By default
+  it should be 9300.
   </description>
 </property>
 
 <property> 
   <name>elastic.cluster</name>
-  <value></value>
-  <description>The cluster name to discover. Either host and potr must be defined
-  or cluster.</description>
+  <value>elasticsearch</value>
+  <description>
+  The cluster name to discover. Either host and port must be defined
+  or cluster. The default Elasticsearch cluster name is 'elasticsearch'. If
+  yours is different be sure to update this value even if you specified a host
+  and port for connection otherwise you may encounter issues.
+  </description>
 </property>
 
 <property> 


### PR DESCRIPTION
- Host value is now defaulted to 'localhost'.
- Update port description to make it apparent that 9300 is more likely
  the value you want to use. This should keep people from setting this
  to the potentially more commonly seen 9200 and messing up connections.
- Set the cluster default value to the default Elasticsearch cluster
  name of 'elasticsearch'. Also updated the description to make it
  evident that this value still needs to be changed if you're connecting
  via host/port and your cluster name is something other than the
  default.