### PR TITLE
NUTCH-2004: Update parsechecker to handle redirects

### DIFF
--- a/src/java/org/apache/nutch/parse/ParserChecker.java
+++ b/src/java/org/apache/nutch/parse/ParserChecker.java
@@ -34,6 +34,7 @@ import org.apache.nutch.protocol.Content;
 import org.apache.nutch.protocol.Protocol;
 import org.apache.nutch.protocol.ProtocolFactory;
 import org.apache.nutch.protocol.ProtocolOutput;
+import org.apache.nutch.protocol.ProtocolStatus;
 import org.apache.nutch.scoring.ScoringFilters;
 import org.apache.nutch.util.NutchConfiguration;
 import org.apache.nutch.util.URLUtil;
@@ -135,9 +136,30 @@ public class ParserChecker implements Tool {
     Text turl = new Text(url);
     ProtocolOutput output = protocol.getProtocolOutput(turl, cd);
 
+    // If the configuration permits, handle redirects until we either run
+    // out of allowed redirects or we stop getting redirect statuses.
+    int maxRedirects = conf.getInt("http.redirect.max", 0);
+    int numRedirects = 0;
+    while (output.getStatus().isRedirect() && numRedirects < maxRedirects) {
+        String newURL = URLUtil.toASCII(output.getStatus().getArgs()[0]);
+        LOG.info("Handling redirect to " + newURL);
+
+        protocol = factory.getProtocol(newURL);
+        turl = new Text(newURL);
+        output = protocol.getProtocolOutput(turl, cd);
+
+        numRedirects++;
+    }
+
     if (!output.getStatus().isSuccess()) {
       System.err.println("Fetch failed with protocol status: "
           + output.getStatus());
+
+      if (output.getStatus().isRedirect()) {
+          System.err.println("Redirect(s) not handled due to configuration.");
+          System.err.println("Max Redirects to handle per config: " + maxRedirects);
+          System.err.println("Number of Redirects handled: " + numRedirects);
+      }
       return (-1);
     }
 

--- a/src/java/org/apache/nutch/protocol/ProtocolStatus.java
+++ b/src/java/org/apache/nutch/protocol/ProtocolStatus.java
@@ -227,6 +227,10 @@ public class ProtocolStatus implements Writable {
         || code == ROBOTS_DENIED;
   }
 
+  public boolean isRedirect() {
+      return code == MOVED || code == TEMP_MOVED;
+  }
+
   public String getMessage() {
     if (args != null && args.length > 0)
       return args[0];


### PR DESCRIPTION
- Parsechecker now handles redirects if the configuration has a value
  greater than 0 set for http.redirect.max.
- Add minor convenience function to ProtocolStatus for checking if a
  particular status is a redirect.