### PR TITLE
Nutch 2059 - Unit test failures for protocol-http and protocol-httclient

### DIFF
--- a/src/plugin/protocol-httpclient/jsp/basic.jsp
+++ b/src/plugin/protocol-httpclient/jsp/basic.jsp
@@ -13,8 +13,7 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
---%>
-<%--
+--%><%--
   This JSP demonstrates basic authentication. When this JSP page is
   requested with no query parameters, then the user must enter the
   username as 'userx' and password as 'passx' when prompted for
@@ -25,11 +24,9 @@
   code below.
 
   Author: Susam Pal
---%>
-<%@ page
+--%><%@ page
     import = "sun.misc.BASE64Decoder"
-%>
-<%
+%><%
   String authHeader = request.getHeader("Authorization");
   String realm = null;
   String username = null;

--- a/src/plugin/protocol-httpclient/jsp/cookies.jsp
+++ b/src/plugin/protocol-httpclient/jsp/cookies.jsp
@@ -13,8 +13,7 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
---%>
-<%--
+--%><%--
   This JSP tests whether the client can remember cookies. When the JSP
   is fetched for the first time without any query parameters, it sets
   a few cookies in the client. On a second request, with the query
@@ -23,8 +22,7 @@
   If the cookies are not found, HTTP 403 response is returned.
 
   Author: Susam Pal
---%>
-<%
+--%><%
   String cookieParam = request.getParameter("cookie");
   if (!"yes".equals(cookieParam)) { // Send cookies
     response.addCookie(new Cookie("var1", "val1"));

--- a/src/plugin/protocol-httpclient/jsp/digest.jsp
+++ b/src/plugin/protocol-httpclient/jsp/digest.jsp
@@ -13,8 +13,7 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
---%>
-<%--
+--%><%--
   This JSP tests digest authentication. It generates an HTTP response
   with authorization header for digest authentication and checks the
   user-name supplied by the client. It does not check the other
@@ -23,12 +22,10 @@
   be tested.
 
   Author: Susam Pal
---%>
-<%@ page
+--%><%@ page
     import = "java.util.StringTokenizer"
     import = "java.util.HashMap"
-%>
-<%
+%><%
   String username = "digest_user";
   String authHeader = request.getHeader("Authorization");
   

--- a/src/plugin/protocol-httpclient/jsp/noauth.jsp
+++ b/src/plugin/protocol-httpclient/jsp/noauth.jsp
@@ -13,16 +13,14 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
---%>
-<%--
+--%><%--
   This JSP tests whether the client is sending any pre-emptive
   authentication headers. The client is expected not to send pre-emptive
   authentication headers. If such authentication headers are found, this
   JSP will return an HTTP 403 response; HTTP 200 response otherwise.
 
   Author: Susam Pal
---%>
-<%
+--%><%
   if (request.getHeader("Authorization") != null) {
     response.sendError(response.SC_UNAUTHORIZED);
   } else {

--- a/src/plugin/protocol-httpclient/jsp/ntlm.jsp
+++ b/src/plugin/protocol-httpclient/jsp/ntlm.jsp
@@ -13,8 +13,7 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
---%>
-<%--
+--%><%--
   This JSP tests NTLM authentication. It generates an HTTP response
   with authorization header for NTLM authentication and checks the
   user-name supplied by the client. It does not check the other
@@ -23,12 +22,10 @@
   be tested.
 
   Author: Susam Pal
---%>
-<%@ page
+--%><%@ page
     import = "sun.misc.BASE64Decoder"
     import = "sun.misc.BASE64Encoder"
-%>
-<%
+%><%
   String authHeader = request.getHeader("Authorization");
   String username = null;
   String domain = null;


### PR DESCRIPTION
This also incorporates the suggestion in NUTCH-1836, except that the parameters used to do the suggested computation changed to use the current parameter name.

Note that while this eliminates some exceptions that were logged during protocol-httpclient testing, its not certain if this will make any material difference regarding the Jenkins unit test failures.  The test are passing on my sandbox with or without these changes.