### PR TITLE
Fix for NUTCH-2072

### DIFF
--- a/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpBase.java
+++ b/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpBase.java
@@ -495,8 +495,12 @@ public abstract class HttpBase implements Protocol {
       LOGGER.trace("inflating....");
     }
 
-    byte[] content = DeflateUtils
-        .inflateBestEffort(compressed, getMaxContent());
+    byte[] content;
+    if (getMaxContent() >= 0) {
+      content = DeflateUtils.inflateBestEffort(compressed, getMaxContent());
+    } else {
+      content = DeflateUtils.inflateBestEffort(compressed);
+    }
 
     if (content == null)
       throw new IOException("inflateBestEffort returned null");


### PR DESCRIPTION
{{HttpBase}} : mimic the behaviour of {{processGzipEncoded}} in {{processDeflateEncoded}} regarding the handling of the {{http.content.limit}} especially when it's negative (unlimited).