### PR TITLE
NUTCH-2088 - Add URL Processing Check to Interactive Selenium Handlers

### DIFF
--- a/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/HttpResponse.java
+++ b/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/HttpResponse.java
@@ -271,6 +271,10 @@ public class HttpResponse implements Response {
     String processedPage = "";
 
     for (InteractiveSeleniumHandler handler : this.handlers) {
+        if (! handler.shouldProcessURL(url.toString())) {
+            continue;
+        }
+
         WebDriver driver = HttpWebClient.getDriverForPage(url.toString(), conf);
 
         handler.processDriver(driver);

--- a/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/handlers/DefaultHandler.java
+++ b/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/handlers/DefaultHandler.java
@@ -21,4 +21,8 @@ import org.openqa.selenium.WebDriver;
 
 public class DefaultHandler implements InteractiveSeleniumHandler {
     public void processDriver(WebDriver driver) {}
+
+    public boolean shouldProcessURL(String URL) {
+        return true;
+    }
 }

--- a/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/handlers/InteractiveSeleniumHandler.java
+++ b/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/handlers/InteractiveSeleniumHandler.java
@@ -21,4 +21,5 @@ import org.openqa.selenium.WebDriver;
 
 public interface InteractiveSeleniumHandler {
     public void processDriver(WebDriver driver);
+    public boolean shouldProcessURL(String URL);
 }


### PR DESCRIPTION
- Add shouldProcessURL to Handler interface. Handlers may now check URLs to determine if they should interact with them prior to loading the necessary WebDriver.