### PR TITLE
Nutch 2096: Explicitly indicate broswer binary to use when selecting selenium remote option in config

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1787,8 +1787,8 @@ CAUTION: Set the parser.timeout to -1 or a bigger value than 30, when using this
     WebDriver() to use. Currently the following options
     exist - 'firefox', 'chrome', 'safari', 'opera' and 'remote'.
     If 'remote' is used it is essential to also set correct properties for
-    'selenium.hub.port', 'selenium.hub.path', 'selenium.hub.host' and
-    'selenium.hub.protocol'.
+    'selenium.hub.port', 'selenium.hub.path', 'selenium.hub.host',
+    'selenium.hub.protocol', 'selenium.grid.driver' and 'selenium.grid.binary'.
   </description>
 </property>
 
@@ -1838,6 +1838,22 @@ CAUTION: Set the parser.timeout to -1 or a bigger value than 30, when using this
   <name>selenium.hub.protocol</name>
   <value>http</value>
   <description>Selenium Hub Location connection protocol</description>
+</property>
+
+<property>
+  <name>selenium.grid.driver</name>
+  <value>firefox</value>
+  <description>A String value representing the flavour of Selenium 
+    WebDriver() used on the selenium grid. Currently the following options
+    exist - 'firefox' </description>
+</property>
+
+<property>
+  <name>selenium.grid.binary</name>
+  <value></value>
+  <description>A String value representing the path to the browser binary 
+    location for each node
+ </description>
 </property>
 
 <!-- lib-selenium configuration -->

--- a/src/plugin/lib-selenium/src/java/org/apache/nutch/protocol/selenium/HttpWebClient.java
+++ b/src/plugin/lib-selenium/src/java/org/apache/nutch/protocol/selenium/HttpWebClient.java
@@ -64,6 +64,7 @@ public class HttpWebClient {
 
   public static WebDriver getDriverForPage(String url, Configuration conf) {
       WebDriver driver = null;
+      DesiredCapabilities capabilities = null;
       long pageLoadWait = conf.getLong("libselenium.page.load.delay", 3);
 
       try {
@@ -86,8 +87,22 @@ public class HttpWebClient {
             int seleniumHubPort = Integer.parseInt(conf.get("selenium.hub.port", "4444"));
             String seleniumHubPath = conf.get("selenium.hub.path", "/wd/hub");
             String seleniumHubProtocol = conf.get("selenium.hub.protocol", "http");
-            driver = new RemoteWebDriver(new URL(seleniumHubProtocol, seleniumHubHost, seleniumHubPort, seleniumHubPath), DesiredCapabilities.firefox());
-            break;
+            String seleniumGridDriver = conf.get("selenium.grid.driver","firefox");
+            String seleniumGridBinary = conf.get("selenium.grid.binary");
+
+            switch (seleniumGridDriver){
+              case "firefox":
+                capabilities = DesiredCapabilities.firefox();
+                capabilities.setBrowserName("firefox");
+                capabilities.setJavascriptEnabled(true);
+                capabilities.setCapability("firefox_binary",seleniumGridBinary);
+                driver = new RemoteWebDriver(new URL(seleniumHubProtocol, seleniumHubHost, seleniumHubPort, seleniumHubPath), capabilities);
+                break;
+              default:
+                LOG.error("The Selenium Grid WebDriver choice {} is not available... defaulting to FirefoxDriver().", driverType);
+                driver = new RemoteWebDriver(new URL(seleniumHubProtocol, seleniumHubHost, seleniumHubPort, seleniumHubPath), DesiredCapabilities.firefox());
+                break;
+            }
           default:
             LOG.error("The Selenium WebDriver choice {} is not available... defaulting to FirefoxDriver().", driverType);
             driver = new FirefoxDriver();


### PR DESCRIPTION
*Assumes that the selenium grid is homogenous i.e. uses the same browser on the hub and the nodes and these are located at a similar location