### PR TITLE
fix for NUTCH-2111 contributed by kwhitehall

### DIFF
--- a/src/plugin/lib-selenium/src/java/org/apache/nutch/protocol/selenium/HttpWebClient.java
+++ b/src/plugin/lib-selenium/src/java/org/apache/nutch/protocol/selenium/HttpWebClient.java
@@ -33,6 +33,7 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.safari.SafariDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
+import org.openqa.selenium.io.TemporaryFilesystem;
 
 import com.opera.core.systems.OperaDriver;
 
@@ -96,6 +97,7 @@ public class HttpWebClient {
                 capabilities.setBrowserName("firefox");
                 capabilities.setJavascriptEnabled(true);
                 capabilities.setCapability("firefox_binary",seleniumGridBinary);
+                System.setProperty("webdriver.reap_profile", "false");
                 driver = new RemoteWebDriver(new URL(seleniumHubProtocol, seleniumHubHost, seleniumHubPort, seleniumHubPath), capabilities);
                 break;
               default:
@@ -131,6 +133,7 @@ public class HttpWebClient {
       if (driver != null) {
           try {
               driver.quit();
+              TemporaryFilesystem.getDefaultTmpFS().deleteTemporaryFiles();
           } catch (Exception e) {
               throw new RuntimeException(e);
           }
@@ -161,6 +164,7 @@ public class HttpWebClient {
 
       // I'm sure this catch statement is a code smell ; borrowing it from lib-htmlunit
     } catch (Exception e) {
+      TemporaryFilesystem.getDefaultTmpFS().deleteTemporaryFiles();
       throw new RuntimeException(e);
     } finally {
       cleanUpDriver(driver);


### PR DESCRIPTION
Further investigation showed that changing the temporary path does not get rid of the tmp files that eat up space. Further, if a selenium grid is utilized, the location chosen on a given node may not be available on all nodes. As such, it is best to stay with the default /tmp location and handle deleting the files there instead. The patch submitted does this.