### PR TITLE
Fixed FileNotFoundException (Invalid Argument) Error

### DIFF
--- a/src/java/org/apache/nutch/tools/FileDumper.java
+++ b/src/java/org/apache/nutch/tools/FileDumper.java
@@ -219,8 +219,26 @@ public class FileDumper {
   
                 if (!outputFile.exists()) {
                   LOG.info("Writing: [" + outputFullPath + "]");
-                  FileOutputStream output = new FileOutputStream(outputFile);
-                  IOUtils.write(content.getContent(), output);
+
+		  // Modified to prevent FileNotFoundException (Invalid Argument) 
+		  FileOutputStream output = null;
+		  try {
+                        output = new FileOutputStream(outputFile);
+                        IOUtils.write(content.getContent(), output);
+                  }
+                  catch (Exception e) {
+                        LOG.warn("Write Error: [" + outputFullPath + "]");
+			e.printStackTrace();
+                  }
+                  finally {
+                        if (output != null) {
+                                output.flush();
+				try {
+                                	output.close();
+				} catch (Exception ignore) {
+				}
+                        }
+                  }
                   fileCount++;
                 } else {
                   LOG.info("Skipping writing: [" + outputFullPath

--- a/src/java/org/apache/nutch/util/DumpFileUtil.java
+++ b/src/java/org/apache/nutch/util/DumpFileUtil.java
@@ -80,6 +80,10 @@ public class DumpFileUtil {
             LOG.info("File extension is too long. Truncated to {} characters.", MAX_LENGTH_OF_EXTENSION);
             fileExtension = StringUtils.substring(fileExtension, 0, MAX_LENGTH_OF_EXTENSION);
         }
+	
+	// Added to prevent FileNotFoundException (Invalid Argument) - in *nix environment
+        fileBaseName = fileBaseName.replaceAll("\\?", "");
+        fileExtension = fileExtension.replaceAll("\\?", "");
 
         return String.format(FILENAME_PATTERN, md5, fileBaseName, fileExtension);
     }


### PR DESCRIPTION
Got ```FileNotFoundException``` while running nutch dump.

**Cause**: Character '?'  in file name/extension producing the below error.

**Error Details**
java.io.FileNotFoundException: /media/PATRO/Karan/nutch_12Oct/other_gun_urls/img/99/fb/97d3980f9954b597f372d092b97eff22_27tlt_recon_1_black_g_10_handle_.jpeg? (Invalid argument)
        at java.io.FileOutputStream.open(Native Method)
        at java.io.FileOutputStream.<init>(FileOutputStream.java:221)
        at java.io.FileOutputStream.<init>(FileOutputStream.java:171)
        at org.apache.nutch.tools.FileDumper.dump(FileDumper.java:222)
        at org.apache.nutch.tools.FileDumper.main(FileDumper.java:325)