### PR TITLE
fix for NUTCH-2141 contributed by Balaji Gurumurthy

### DIFF
--- a/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/HttpResponse.java
+++ b/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/HttpResponse.java
@@ -277,8 +277,7 @@ public class HttpResponse implements Response {
 
         WebDriver driver = HttpWebClient.getDriverForPage(url.toString(), conf);
 
-        handler.processDriver(driver);
-        processedPage += HttpWebClient.getHTMLContent(driver, conf);
+        processedPage += handler.processDriver(driver);
 
         HttpWebClient.cleanUpDriver(driver);
     }

--- a/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/handlers/DefalultMultiInteractionHandler.java
+++ b/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/handlers/DefalultMultiInteractionHandler.java
@@ -32,10 +32,11 @@ public class DefalultMultiInteractionHandler implements
   private static final Logger LOG = LoggerFactory
       .getLogger(DefalultMultiInteractionHandler.class);
 
-  public void processDriver(WebDriver driver) {
+  public String processDriver(WebDriver driver) {
+    // loop and get multiple pages in this string
+    String accumulatedData = "";
     try {
-      // loop and get multiple pages in this string
-      String accumulatedData = "";
+      
       // append the string to the last page's driver
       JavascriptExecutor jsx = (JavascriptExecutor) driver;
       jsx.executeScript("document.body.innerHTML=document.body.innerHTML "
@@ -43,6 +44,7 @@ public class DefalultMultiInteractionHandler implements
     } catch (Exception e) {
       LOG.info(StringUtils.stringifyException(e));
     }
+    return accumulatedData;
   }
 
   public boolean shouldProcessURL(String URL) {

--- a/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/handlers/DefaultClickAllAjaxLinksHandler.java
+++ b/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/handlers/DefaultClickAllAjaxLinksHandler.java
@@ -38,10 +38,11 @@ public class DefaultClickAllAjaxLinksHandler implements InteractiveSeleniumHandl
   private static final Logger LOG = LoggerFactory
       .getLogger(DefaultClickAllAjaxLinksHandler.class);
 
-  public void processDriver(WebDriver driver) {
-
+  public String processDriver(WebDriver driver) {
+    
+    String accumulatedData = "";
     try {
-      String accumulatedData = "";
+      
 
       driver.findElement(By.tagName("body")).getAttribute("innerHTML");
       Configuration conf = NutchConfiguration.create();
@@ -78,6 +79,7 @@ public class DefaultClickAllAjaxLinksHandler implements InteractiveSeleniumHandl
     } catch (Exception e) {
       LOG.info(StringUtils.stringifyException(e));
     }
+    return accumulatedData;
   }
 
   public boolean shouldProcessURL(String URL) {

--- a/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/handlers/DefaultHandler.java
+++ b/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/handlers/DefaultHandler.java
@@ -20,7 +20,9 @@ package org.apache.nutch.protocol.interactiveselenium;
 import org.openqa.selenium.WebDriver;
 
 public class DefaultHandler implements InteractiveSeleniumHandler {
-    public void processDriver(WebDriver driver) {}
+    public String processDriver(WebDriver driver) {
+      return null;
+    }
 
     public boolean shouldProcessURL(String URL) {
         return true;

--- a/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/handlers/InteractiveSeleniumHandler.java
+++ b/src/plugin/protocol-interactiveselenium/src/java/org/apache/nutch/protocol/interactiveselenium/handlers/InteractiveSeleniumHandler.java
@@ -20,6 +20,6 @@ package org.apache.nutch.protocol.interactiveselenium;
 import org.openqa.selenium.WebDriver;
 
 public interface InteractiveSeleniumHandler {
-    public void processDriver(WebDriver driver);
+    public String processDriver(WebDriver driver);
     public boolean shouldProcessURL(String URL);
 }


### PR DESCRIPTION
The return type of interactiveselenium handler is changed from void to String.
Returning the pageContent from the handler gives more options with respect to manipulating the page content using selenium in cases such as going through all pages by clicking on a pagination bar.