### PR TITLE
Fix for NUTCH-2146 contributed jorgelbg

### DIFF
--- a/src/java/org/apache/nutch/parse/Outlink.java
+++ b/src/java/org/apache/nutch/parse/Outlink.java
@@ -128,4 +128,8 @@ public class Outlink implements Writable {
     return repr.toString();
   }
 
+  @Override
+  public int hashCode() {
+    return toUrl.hashCode() ^ anchor.hashCode();
+  }
 }

--- a/src/plugin/index-links/src/test/org/apache/nutch/parse/TestOutlinks.java
+++ b/src/plugin/index-links/src/test/org/apache/nutch/parse/TestOutlinks.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nutch.parse;
+
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class TestOutlinks {
+
+  @Test
+  public void testAddSameObject() throws Exception {
+    Set<Outlink> set = new HashSet<>();
+
+    Outlink o = new Outlink("http://www.example.com", "Example");
+    set.add(o);
+    set.add(o);
+
+    assertEquals("Adding the same Outlink twice", 1, set.size());
+  }
+
+  @Test
+  public void testAddOtherObjectWithSameData() throws Exception {
+    Set<Outlink> set = new HashSet<>();
+
+    Outlink o = new Outlink("http://www.example.com", "Example");
+    Outlink o1 = new Outlink("http://www.example.com", "Example");
+
+    assertTrue("The two Outlink objects are the same", o.equals(o1));
+
+    set.add(o);
+    set.add(o1);
+
+    assertEquals("The set should contain only 1 Outlink", 1, set.size());
+  }
+}


### PR DESCRIPTION
The `Outlink` class doesn't have a `hashCode()` method. This doesn't cause any trouble with the already implemented plugins but if a developer tries to use a `HashSet` of outlinks in a custom plugin, the `Outlink` instances with same data (toUrl, anchor) gets added several times. In contrast the `Inlink` class have a hashCode method. 

https://github.com/apache/nutch/blob/trunk/src/java/org/apache/nutch/crawl/Inlink.java#L75-L77

The same logic used in the `Inlink` class is implemented in this PR.
