### PR TITLE
NUTCH-2184 Enable IndexingJob to function with no crawldb

### DIFF
--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -1,136 +1,176 @@
 <?xml version="1.0" ?>
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
-	license agreements. See the NOTICE file distributed with this work for additional 
-	information regarding copyright ownership. The ASF licenses this file to 
-	You under the Apache License, Version 2.0 (the "License"); you may not use 
-	this file except in compliance with the License. You may obtain a copy of 
-	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
-	by applicable law or agreed to in writing, software distributed under the 
-	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
-	OF ANY KIND, either express or implied. See the License for the specific 
-	language governing permissions and limitations under the License. -->
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
 
 <ivy-module version="1.0" xmlns:maven="http://ant.apache.org/ivy/maven">
-	<info organisation="org.apache.nutch" module="nutch">
-		<license name="Apache 2.0"
-			url="http://www.apache.org/licenses/LICENSE-2.0.txt/" />
-		<ivyauthor name="Apache Nutch Team" url="http://nutch.apache.org" />
-		<description homepage="http://nutch.apache.org">Nutch is an open source web-search
-			software. It builds on
-			Hadoop, Tika and Solr, adding web-specifics,
-			such as a crawler, a link-graph
-			database etc.
-		</description>
-	</info>
-	
-	<configurations>
-		<include file="${basedir}/ivy/ivy-configurations.xml" />
-	</configurations>
-	
-	<publications>
-		<!--get the artifact from our module name -->
-		<artifact conf="master" />
-	</publications>
-	
-	<dependencies>
-		<dependency org="org.slf4j" name="slf4j-api" rev="1.6.1" conf="*->master" />
-		<dependency org="org.slf4j" name="slf4j-log4j12" rev="1.6.1" conf="*->master" />
-		
-		<!--dependency org="log4j" name="log4j" rev="1.2.15" conf="*->default">
-			<exclude org="javax.jms" name="jms" />
-			<exclude org="com.sun.jdmk" name="jmxtools" />
-			<exclude org="com.sun.jmx" name="jmxri" />
-		</dependency-->
-		
-		<dependency org="commons-lang" name="commons-lang" rev="2.6" conf="*->default" />
-		<dependency org="commons-collections" name="commons-collections" rev="3.2.1" conf="*->master" />
-		<dependency org="commons-httpclient" name="commons-httpclient" rev="3.1" conf="*->master" />
-		<dependency org="commons-codec" name="commons-codec" rev="1.10" conf="*->default" />
-        <dependency org="org.apache.commons" name="commons-compress" rev="1.9" conf="*->default" />
-        <dependency org="org.apache.commons" name="commons-jexl" rev="2.1.1" />
-        <dependency org="com.tdunning" name="t-digest" rev="3.1" />
-            
-        <!-- Hadoop Dependencies -->
-		<dependency org="org.apache.hadoop" name="hadoop-common" rev="2.4.0" conf="*->default">
-			<exclude org="hsqldb" name="hsqldb" />
-			<exclude org="net.sf.kosmosfs" name="kfs" />
-			<exclude org="net.java.dev.jets3t" name="jets3t" />
-			<exclude org="org.eclipse.jdt" name="core" />
-			<exclude org="org.mortbay.jetty" name="jsp-*" />
-			<exclude org="ant" name="ant" />
-		</dependency>
-        <dependency org="org.apache.hadoop" name="hadoop-hdfs" rev="2.4.0" conf="*->default"/>
-        <dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-core" rev="2.4.0" conf="*->default"/>
-        <dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-jobclient" rev="2.4.0" conf="*->default"/>
-        <!-- End of Hadoop Dependencies -->
+  <info organisation="org.apache.nutch" module="nutch">
+    <license name="Apache 2.0"
+      url="http://www.apache.org/licenses/LICENSE-2.0.txt/" />
+    <ivyauthor name="Apache Nutch Team" url="http://nutch.apache.org" />
+    <description homepage="http://nutch.apache.org">Nutch is an open source web-search
+      software. It builds on
+      Hadoop, Tika and Solr, adding web-specifics,
+      such as a crawler, a link-graph
+      database etc.
+    </description>
+  </info>
 
-		<dependency org="org.apache.tika" name="tika-core" rev="1.12" />
-		<dependency org="com.ibm.icu" name="icu4j" rev="55.1" />
+  <configurations>
+    <include file="${basedir}/ivy/ivy-configurations.xml" />
+  </configurations>
 
-		<dependency org="xerces" name="xercesImpl" rev="2.11.0" />
-		<dependency org="xerces" name="xmlParserAPIs" rev="2.6.2" />
-		<dependency org="oro" name="oro" rev="2.0.8" />
+  <publications>
+    <!--get the artifact from our module name -->
+    <artifact conf="master" />
+  </publications>
 
-		<dependency org="com.google.guava" name="guava" rev="16.0.1" />
+  <dependencies>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.6.1"
+      conf="*->master" />
+    <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.6.1"
+      conf="*->master" />
 
-		<dependency org="com.github.crawler-commons" name="crawler-commons" rev="0.6" />
+    <dependency org="commons-lang" name="commons-lang" rev="2.6"
+      conf="*->default" />
+    <dependency org="commons-collections" name="commons-collections"
+      rev="3.2.1" conf="*->master" />
+    <dependency org="commons-httpclient" name="commons-httpclient"
+      rev="3.1" conf="*->master" />
+    <dependency org="commons-codec" name="commons-codec" rev="1.10"
+      conf="*->default" />
+    <dependency org="org.apache.commons" name="commons-compress"
+      rev="1.9" conf="*->default" />
+    <dependency org="org.apache.commons" name="commons-jexl"
+      rev="2.1.1" />
+    <dependency org="com.tdunning" name="t-digest" rev="3.1" />
 
-		<dependency org="com.martinkl.warc" name="warc-hadoop" rev="0.1.0" />
-		
-        <!--dependency org="org.apache.cxf" name="cxf" rev="3.0.4" conf="*->default"/-->
-        <dependency org="org.apache.cxf" name="cxf-rt-frontend-jaxws" rev="3.0.4" conf="*->default"/>
-        <dependency org="org.apache.cxf" name="cxf-rt-frontend-jaxrs" rev="3.0.4" conf="*->default"/>
-        <dependency org="org.apache.cxf" name="cxf-rt-transports-http" rev="3.0.4" conf="*->default"/>
-        <dependency org="org.apache.cxf" name="cxf-rt-transports-http-jetty" rev="3.0.4" conf="*->default"/>
-        <dependency org="org.apache.cxf" name="cxf-rt-rs-client" rev="3.0.4" conf="test->default"/>
-        <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.5.1"  conf="*->default"/> 
-        <dependency org="com.fasterxml.jackson.dataformat" name="jackson-dataformat-cbor" rev="2.5.1" conf="*->default"/>
-        <dependency org="com.fasterxml.jackson.jaxrs" name="jackson-jaxrs-json-provider" rev="2.5.1" conf="*->default"/>	
-        
-        <dependency org="org.apache.lucene" name="lucene-analyzers-common" rev="4.10.2" conf="*->default"></dependency>
-		<!-- WARC artifacts needed  -->
-		<dependency org="org.netpreserve.commons" name="webarchive-commons" rev="1.1.5" conf="*->default">
-			<exclude module="hadoop-core"/>
-			<exclude org="com.google.guava"/>
-			<exclude org="junit"/>
-		</dependency>
+    <!-- Hadoop Dependencies -->
+    <dependency org="org.apache.hadoop" name="hadoop-common"
+      rev="2.4.0" conf="*->default">
+      <exclude org="hsqldb" name="hsqldb" />
+      <exclude org="net.sf.kosmosfs" name="kfs" />
+      <exclude org="net.java.dev.jets3t" name="jets3t" />
+      <exclude org="org.eclipse.jdt" name="core" />
+      <exclude org="org.mortbay.jetty" name="jsp-*" />
+      <exclude org="ant" name="ant" />
+    </dependency>
+    <dependency org="org.apache.hadoop" name="hadoop-hdfs"
+      rev="2.4.0" conf="*->default" />
+    <dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-core"
+      rev="2.4.0" conf="*->default" />
+    <dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-jobclient"
+      rev="2.4.0" conf="*->default" />
+    <!-- End of Hadoop Dependencies -->
 
-		<!--artifacts needed for testing -->
-		<dependency org="junit" name="junit" rev="4.11" conf="test->default" />
-		<dependency org="org.apache.mrunit" name="mrunit" rev="1.1.0" conf="test->default">
-			<artifact name="mrunit" maven:classifier="hadoop2" />
-			<exclude org="log4j" module="log4j" />
-		</dependency>
-		<dependency org="org.mortbay.jetty" name="jetty-client" rev="6.1.22" conf="test->default" />
-		<dependency org="org.mortbay.jetty" name="jetty" rev="6.1.22" conf="test->default" />
-		<dependency org="org.mortbay.jetty" name="jetty-util" rev="6.1.22" conf="test->default" />
-		<!-- end of test artifacts -->
+    <dependency org="org.apache.tika" name="tika-core" rev="1.12" />
+    <dependency org="com.ibm.icu" name="icu4j" rev="55.1" />
 
-		<!-- web app dependencies -->
+    <dependency org="xerces" name="xercesImpl" rev="2.11.0" />
+    <dependency org="xerces" name="xmlParserAPIs" rev="2.6.2" />
+    <dependency org="oro" name="oro" rev="2.0.8" />
 
-    	<dependency org="org.apache.commons" name="commons-collections4" rev="4.0" conf="*->default" />
-    	<dependency org="org.springframework" name="spring-core" rev="4.0.4.RELEASE" conf="*->default" />
-    	<dependency org="org.springframework" name="spring-context" rev="4.0.4.RELEASE" conf="*->default" />
-    	<dependency org="org.springframework" name="spring-web" rev="4.0.4.RELEASE" conf="*->default" />
+    <dependency org="com.google.guava" name="guava" rev="16.0.1" />
 
-    	<dependency org="com.sun.jersey" name="jersey-client" rev="1.8" conf="*->default" />
-	
-    	<dependency org="com.j256.ormlite" name="ormlite-jdbc" rev="4.48" conf="*->default" />
-    	<dependency org="com.h2database" name="h2" rev="1.4.180" conf="*->default" />
-    	<dependency org="org.eclipse.persistence" name="javax.persistence" rev="2.0.0" conf="*->default" />
-	
-    	<dependency org="org.apache.wicket" name="wicket-core" rev="6.16.0" conf="*->default" />
-    	<dependency org="org.apache.wicket" name="wicket-spring" rev="6.16.0" conf="*->default" />
-    	<dependency org="de.agilecoders.wicket" name="wicket-bootstrap-core" rev="0.9.2" conf="*->default" />
-    	<dependency org="de.agilecoders.wicket" name="wicket-bootstrap-extensions" rev="0.9.2" conf="*->default" />
+    <dependency org="com.github.crawler-commons" name="crawler-commons"
+      rev="0.6" />
 
-		<!--global exclusion -->
-		<exclude module="jmxtools" />
-		<exclude module="jms" />
-		<exclude module="jmxri" />
-		<exclude org="com.thoughtworks.xstream"/>
+    <dependency org="com.martinkl.warc" name="warc-hadoop"
+      rev="0.1.0" />
 
-	</dependencies>
+    <!--dependency org="org.apache.cxf" name="cxf" rev="3.0.4" conf="*->default"/ -->
+    <dependency org="org.apache.cxf" name="cxf-rt-frontend-jaxws"
+      rev="3.0.4" conf="*->default" />
+    <dependency org="org.apache.cxf" name="cxf-rt-frontend-jaxrs"
+      rev="3.0.4" conf="*->default" />
+    <dependency org="org.apache.cxf" name="cxf-rt-transports-http"
+      rev="3.0.4" conf="*->default" />
+    <dependency org="org.apache.cxf" name="cxf-rt-transports-http-jetty"
+      rev="3.0.4" conf="*->default" />
+    <dependency org="org.apache.cxf" name="cxf-rt-rs-client"
+      rev="3.0.4" conf="test->default" />
+    <dependency org="com.fasterxml.jackson.core" name="jackson-databind"
+      rev="2.5.1" conf="*->default" />
+    <dependency org="com.fasterxml.jackson.dataformat" name="jackson-dataformat-cbor"
+      rev="2.5.1" conf="*->default" />
+    <dependency org="com.fasterxml.jackson.jaxrs" name="jackson-jaxrs-json-provider"
+      rev="2.5.1" conf="*->default" />
+
+    <dependency org="org.apache.lucene" name="lucene-analyzers-common"
+      rev="4.10.2" conf="*->default"></dependency>
+    <!-- WARC artifacts needed -->
+    <dependency org="org.netpreserve.commons" name="webarchive-commons"
+      rev="1.1.5" conf="*->default">
+      <exclude module="hadoop-core" />
+      <exclude org="com.google.guava" />
+      <exclude org="junit" />
+    </dependency>
+
+    <!--artifacts needed for testing -->
+    <dependency org="junit" name="junit" rev="4.11" conf="test->default" />
+    <dependency org="org.apache.mrunit" name="mrunit" rev="1.1.0"
+      conf="test->default">
+      <artifact name="mrunit" maven:classifier="hadoop2" />
+      <exclude org="log4j" module="log4j" />
+    </dependency>
+    <dependency org="org.mortbay.jetty" name="jetty-client"
+      rev="6.1.22" conf="test->default" />
+    <dependency org="org.mortbay.jetty" name="jetty" rev="6.1.22"
+      conf="test->default" />
+    <dependency org="org.mortbay.jetty" name="jetty-util"
+      rev="6.1.22" conf="test->default" />
+    <!-- end of test artifacts -->
+
+    <!-- web app dependencies -->
+
+    <dependency org="org.apache.commons" name="commons-collections4"
+      rev="4.0" conf="*->default" />
+    <dependency org="org.springframework" name="spring-core"
+      rev="4.0.4.RELEASE" conf="*->default" />
+    <dependency org="org.springframework" name="spring-context"
+      rev="4.0.4.RELEASE" conf="*->default" />
+    <dependency org="org.springframework" name="spring-web"
+      rev="4.0.4.RELEASE" conf="*->default" />
+
+    <dependency org="com.sun.jersey" name="jersey-client"
+      rev="1.8" conf="*->default" />
+
+    <dependency org="com.j256.ormlite" name="ormlite-jdbc"
+      rev="4.48" conf="*->default" />
+    <dependency org="com.h2database" name="h2" rev="1.4.180"
+      conf="*->default" />
+    <dependency org="org.eclipse.persistence" name="javax.persistence"
+      rev="2.0.0" conf="*->default" />
+
+    <dependency org="org.apache.wicket" name="wicket-core"
+      rev="6.16.0" conf="*->default" />
+    <dependency org="org.apache.wicket" name="wicket-spring"
+      rev="6.16.0" conf="*->default" />
+    <dependency org="de.agilecoders.wicket" name="wicket-bootstrap-core"
+      rev="0.9.2" conf="*->default" />
+    <dependency org="de.agilecoders.wicket" name="wicket-bootstrap-extensions"
+      rev="0.9.2" conf="*->default" />
+
+    <!--global exclusion -->
+    <exclude module="jmxtools" />
+    <exclude module="jms" />
+    <exclude module="jmxri" />
+    <exclude org="com.thoughtworks.xstream" />
+
+  </dependencies>
 
 </ivy-module>

--- a/src/java/org/apache/nutch/crawl/CrawlDatum.java
+++ b/src/java/org/apache/nutch/crawl/CrawlDatum.java
@@ -23,7 +23,6 @@ import java.util.Map.Entry;
 
 import org.apache.commons.jexl2.JexlContext;
 import org.apache.commons.jexl2.Expression;
-import org.apache.commons.jexl2.JexlEngine;
 import org.apache.commons.jexl2.MapContext;
 
 import org.apache.hadoop.io.*;

--- a/src/java/org/apache/nutch/indexer/NutchIndexAction.java
+++ b/src/java/org/apache/nutch/indexer/NutchIndexAction.java
@@ -37,6 +37,9 @@ public class NutchIndexAction implements Writable {
   public NutchDocument doc = null;
   public byte action = ADD;
 
+  public NutchIndexAction() {
+  }
+  
   public NutchIndexAction(NutchDocument doc, byte action) {
     this.doc = doc;
     this.action = action;

--- a/src/java/org/apache/nutch/tools/FileDumper.java
+++ b/src/java/org/apache/nutch/tools/FileDumper.java
@@ -333,8 +333,11 @@ public class FileDumper {
         "output directory (which will be created) to host the raw data")
     .create("outputDir");
     @SuppressWarnings("static-access")
-    Option segOpt = OptionBuilder.withArgName("segment").hasArgs()
-    .withDescription("the segment(s) to use").create("segment");
+    Option segOpt = OptionBuilder
+    .withArgName("segment")
+    .hasArgs()
+    .withDescription(
+        "the segment(s) to use").create("segment");
     @SuppressWarnings("static-access")
     Option mimeOpt = OptionBuilder
     .withArgName("mimetype")

--- a/src/plugin/scoring-link/src/java/org/apache/nutch/scoring/link/LinkAnalysisScoringFilter.java
+++ b/src/plugin/scoring-link/src/java/org/apache/nutch/scoring/link/LinkAnalysisScoringFilter.java
@@ -63,8 +63,12 @@ public class LinkAnalysisScoringFilter implements ScoringFilter {
 
   public float indexerScore(Text url, NutchDocument doc, CrawlDatum dbDatum,
       CrawlDatum fetchDatum, Parse parse, Inlinks inlinks, float initScore)
-      throws ScoringFilterException {
-    return (normalizedScore * dbDatum.getScore());
+          throws ScoringFilterException {
+    if (dbDatum != null) {
+      return (normalizedScore * dbDatum.getScore());
+    } else {
+      return initScore;
+    }
   }
 
   public void initialScore(Text url, CrawlDatum datum)
@@ -79,7 +83,7 @@ public class LinkAnalysisScoringFilter implements ScoringFilter {
   public void passScoreAfterParsing(Text url, Content content, Parse parse)
       throws ScoringFilterException {
     parse.getData().getContentMeta()
-        .set(Nutch.SCORE_KEY, content.getMetadata().get(Nutch.SCORE_KEY));
+    .set(Nutch.SCORE_KEY, content.getMetadata().get(Nutch.SCORE_KEY));
   }
 
   public void passScoreBeforeParsing(Text url, CrawlDatum datum, Content content)

--- a/src/plugin/scoring-opic/src/java/org/apache/nutch/scoring/opic/OPICScoringFilter.java
+++ b/src/plugin/scoring-opic/src/java/org/apache/nutch/scoring/opic/OPICScoringFilter.java
@@ -112,7 +112,7 @@ public class OPICScoringFilter implements ScoringFilter {
   /** Copy the value from Content metadata under Fetcher.SCORE_KEY to parseData. */
   public void passScoreAfterParsing(Text url, Content content, Parse parse) {
     parse.getData().getContentMeta()
-        .set(Nutch.SCORE_KEY, content.getMetadata().get(Nutch.SCORE_KEY));
+    .set(Nutch.SCORE_KEY, content.getMetadata().get(Nutch.SCORE_KEY));
   }
 
   /**
@@ -167,7 +167,11 @@ public class OPICScoringFilter implements ScoringFilter {
   /** Dampen the boost value by scorePower. */
   public float indexerScore(Text url, NutchDocument doc, CrawlDatum dbDatum,
       CrawlDatum fetchDatum, Parse parse, Inlinks inlinks, float initScore)
-      throws ScoringFilterException {
-    return (float) Math.pow(dbDatum.getScore(), scorePower) * initScore;
+          throws ScoringFilterException {
+    if (dbDatum != null) {
+      return (float) Math.pow(dbDatum.getScore(), scorePower) * initScore;
+    } else {
+      return (float) initScore;
+    }
   }
 }

--- a/src/test/org/apache/nutch/indexer/TestIndexerMapReduce.java
+++ b/src/test/org/apache/nutch/indexer/TestIndexerMapReduce.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nutch.indexer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mrunit.MapDriver;
+import org.apache.hadoop.mrunit.MapReduceDriver;
+import org.apache.hadoop.mrunit.ReduceDriver;
+import org.apache.nutch.crawl.CrawlDatum;
+import org.apache.nutch.crawl.NutchWritable;
+import org.apache.nutch.indexer.IndexerMapReduce.IndexerMapReduceMapper;
+import org.apache.nutch.indexer.IndexerMapReduce.IndexerMapReduceReducer;
+import org.apache.nutch.metadata.HttpHeaders;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test the MapReduce functionality of the 
+ * {@link org.apache.nutch.indexer.IndexingJob} by asserting data
+ * at various stages of {@link org.apache.nutch.indexer.IndexerMapReduce}.
+ * Specifically, we test data at various stages in both the
+ * {@link org.apache.nutch.indexer.IndexerMapReduce.IndexerMapReduceMapper}
+ * and {@link org.apache.nutch.indexer.IndexerMapReduce.IndexerMapReduceReducer}.
+ * Finally, we test the entire MapReduce workflow asserting that the input
+ * key and value map and reduce to an expected result. 
+ */
+public class TestIndexerMapReduce {
+
+  private static Text key = new Text("http://www.thethrillseekers.co.uk/");
+
+  MapDriver<Text, Writable, Text, NutchWritable> mapDriver;
+  ReduceDriver<Text, NutchWritable, Text, NutchIndexAction> reduceDriver;
+  MapReduceDriver<Text, Writable, Text, NutchWritable, Text, NutchIndexAction> mapReduceDriver;
+
+  @Before
+  public void setUp() {
+    IndexerMapReduceMapper mapper = new IndexerMapReduceMapper();
+    IndexerMapReduceReducer reducer = new IndexerMapReduceReducer();
+    mapDriver = MapDriver.newMapDriver(mapper);
+    reduceDriver = ReduceDriver.newReduceDriver(reducer);
+    mapReduceDriver = MapReduceDriver.newMapReduceDriver(mapper, reducer);
+  }
+
+  @Test
+  public void testMapper() throws IOException {
+    Writable crawlDatum = TestIndexerMapReduce.createCrawlDatum();
+    mapDriver.withInput(key, crawlDatum);
+    mapDriver.withOutput(key, new NutchWritable(crawlDatum)).run();
+    //Assert.assertTrue(crawlDatum.compareTo(that));
+  }
+
+  @Test
+  public void testReducer() throws IOException {
+    List<NutchWritable> crawlDatums = TestIndexerMapReduce.createCrawlDatums();
+    reduceDriver.withInput(key, crawlDatums);
+    reduceDriver.withOutput(key, createNutchIndexAction()).run();
+  }
+
+  @Test
+  public void testMapReduce() throws IOException {
+    mapReduceDriver.withInput(key, TestIndexerMapReduce.createCrawlDatum());
+    mapReduceDriver.withOutput(key, createNutchIndexAction()).run();
+  }
+  
+  private static List<NutchWritable> createCrawlDatums() {
+    List<NutchWritable> crawlDatums = new ArrayList<NutchWritable>();
+    Writable crawlDatum1 = TestIndexerMapReduce.createCrawlDatum();
+    Writable crawlDatum2 = TestIndexerMapReduce.createCrawlDatum();
+    Writable crawlDatum3 = TestIndexerMapReduce.createCrawlDatum();
+    crawlDatums.add(new NutchWritable(crawlDatum1));
+    crawlDatums.add(new NutchWritable(crawlDatum2));
+    crawlDatums.add(new NutchWritable(crawlDatum3));
+    return crawlDatums;
+  }
+
+  private static Writable createCrawlDatum() {
+    // create a date as of now, subtract 2 days from it for modified time
+    Date date = new Date();
+    CrawlDatum crawlDatum = new CrawlDatum();
+    crawlDatum.setFetchInterval(0);
+    crawlDatum.setFetchTime(date.getTime());
+    // create metadata
+    org.apache.hadoop.io.MapWritable md = new org.apache.hadoop.io.MapWritable();
+    md.put(HttpHeaders.WRITABLE_CONTENT_TYPE, new Text(
+        "text/html; charset=utf-8"));
+    md.put(new Text("music_genre"), new Text("trance"));
+    crawlDatum.setMetaData(md);
+    Calendar calendar = Calendar.getInstance(Locale.getDefault());
+    calendar.setTime(date);
+    calendar.add(Calendar.DATE, -2);
+    date.setTime(calendar.getTime().getTime());
+    crawlDatum.setModifiedTime(date.getTime());
+    crawlDatum.setRetriesSinceFetch(0);
+    crawlDatum.setScore((float)0.0);
+    crawlDatum.setSignature("4857485dd3a440180b1cc54b6b226b0b".getBytes());
+    crawlDatum.setStatus(65);
+    return crawlDatum;
+  }
+
+  private static NutchIndexAction createNutchIndexAction() {
+    NutchDocument nDoc = new NutchDocument();
+    NutchIndexAction nAction = new NutchIndexAction(nDoc, NutchIndexAction.ADD);
+    return nAction;
+  }
+
+}


### PR DESCRIPTION
OK folks, this issue addresses https://issues.apache.org/jira/browse/NUTCH-2184 by
- rebasing the [NUTCH-2184v2.patch](https://issues.apache.org/jira/secure/attachment/12784260/NUTCH-2184v2.patch) against master branch
- making the IndexerMapReduceMapper and IndexerMapReduceReducer in IndexerMapReduce code explicit so that these functions can be tested
- adding in some mrunit tests for testing the IndexerMapReduceMapper and IndexerMapReduceReducer
- removing some trivial imports which are unsed
- formatting ivy.xml which has somehow (again) become a dogs dinner
- adding default constructor to NutchIndexAction()

Any questions, then please let me know. I would really appreciate if people could pull this code and try it out within your test or local environment.
Thanks, also thanks Markus for the original suggestions for tests, etc.
