### PR TITLE
NUTCH-2222 re-fetch deletes all metadata except _csh_ and _rs_

### DIFF
--- a/src/java/org/apache/nutch/crawl/GeneratorJob.java
+++ b/src/java/org/apache/nutch/crawl/GeneratorJob.java
@@ -240,9 +240,17 @@ public class GeneratorJob extends NutchTool implements Tool {
 
   /**
    * Mark URLs ready for fetching.
-   * 
-   * @throws ClassNotFoundException
-   * @throws InterruptedException
+   * @param topN
+   *          top threshold for maximum number of URLs permitted in a batch
+   * @param curTime
+   *          the current time in milliseconds
+   * @param filter
+   *          optional filtering of URLs within the generated batch
+   * @param norm
+   *          optional normalization of URls within the generated batch
+   * @param sitemap
+   *          flag indicating whether a URL is a sitemap and hence processed accordingly
+   * @throws Exception
    * */
   public String generate(long topN, long curTime, boolean filter, boolean norm,
       boolean sitemap) throws Exception {

--- a/src/test/nutch-site.xml
+++ b/src/test/nutch-site.xml
@@ -22,4 +22,11 @@
   <description>Default in-memory datastore class for temp test data.</description>
 </property>
 
+<property>
+  <name>db.fetch.interval.default</name>
+  <value>1</value>
+  <description>The default number of seconds between re-fetches of a page (30 days).
+  </description>
+</property>
+
 </configuration>


### PR DESCRIPTION
Hi Folks,
This pull request formalizes the contribution from Adnane B. over on [NUTCH-2222](https://issues.apache.org/jira/browse/NUTCH-2222). I am not sure that this is catching the bug however and it seems like the bug only rears it's head when we use a persistent datastore. 
Right now this patch uses the MemStore implementation which is what we agreed tests would be like. I think we need to do add to the tests in order to have a persistent datastore setup and that data is persisted into the datastore. 