### PR TITLE
NUTCH-2250 : CommonCrawlDumper : Invalid format and skipped parts

### DIFF
--- a/src/java/org/apache/nutch/tools/CommonCrawlFormat.java
+++ b/src/java/org/apache/nutch/tools/CommonCrawlFormat.java
@@ -21,6 +21,7 @@ import org.apache.nutch.metadata.Metadata;
 import org.apache.nutch.parse.ParseData;
 import org.apache.nutch.protocol.Content;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 /**
@@ -30,7 +31,7 @@ import java.io.IOException;
  * @author gtotaro
  *
  */
-public interface CommonCrawlFormat {
+public interface CommonCrawlFormat extends Closeable {
 
   /**
    *


### PR DESCRIPTION
### Summary
+ Reads all parts of segments
+ writes single document per dump file


### What was the fix?
1. Lists all files insides segments and selects all the parts matching to pattern part-[0-9]{5} under the content directory. 
2. CommonCrawlFormat implementation for "JACKSON" type does not clear state, instead it keeps appending documents. This fix uses a new instance for each document (actually it was hard to resolve the state issue because of too many options such as compressing and archiving).