### PR TITLE
NUTCH-2164 NUTCH-2242 Inconsistent 'Modified Time' in crawl db / last…

### DIFF
--- a/src/java/org/apache/nutch/crawl/AdaptiveFetchSchedule.java
+++ b/src/java/org/apache/nutch/crawl/AdaptiveFetchSchedule.java
@@ -116,6 +116,7 @@ public class AdaptiveFetchSchedule extends AbstractFetchSchedule {
       switch (state) {
       case FetchSchedule.STATUS_MODIFIED:
         interval *= (1.0f - DEC_RATE);
+        modifiedTime = fetchTime;
         break;
       case FetchSchedule.STATUS_NOTMODIFIED:
         interval *= (1.0f + INC_RATE);

--- a/src/java/org/apache/nutch/crawl/DefaultFetchSchedule.java
+++ b/src/java/org/apache/nutch/crawl/DefaultFetchSchedule.java
@@ -39,6 +39,10 @@ public class DefaultFetchSchedule extends AbstractFetchSchedule {
       datum.setFetchInterval(defaultInterval);
     }
     datum.setFetchTime(fetchTime + (long) datum.getFetchInterval() * 1000);
+    if (modifiedTime <= 0 || state == FetchSchedule.STATUS_MODIFIED) {
+      // Set modifiedTime to fetchTime on first successful fetch
+      modifiedTime = fetchTime;
+    }
     datum.setModifiedTime(modifiedTime);
     return datum;
   }

--- a/src/java/org/apache/nutch/protocol/ProtocolOutput.java
+++ b/src/java/org/apache/nutch/protocol/ProtocolOutput.java
@@ -17,6 +17,11 @@
 
 package org.apache.nutch.protocol;
 
+import java.text.ParseException;
+
+import org.apache.nutch.net.protocols.HttpDateFormat;
+import org.apache.nutch.net.protocols.Response;
+
 /**
  * Simple aggregate to pass from protocol plugins both content and protocol
  * status.
@@ -35,6 +40,15 @@ public class ProtocolOutput {
   public ProtocolOutput(Content content) {
     this.content = content;
     this.status = ProtocolStatus.STATUS_SUCCESS;
+    String lastModifiedDate = content.getMetadata().get(Response.LAST_MODIFIED);
+    if (lastModifiedDate != null) {
+      try {
+        long lastModified = HttpDateFormat.toLong(lastModifiedDate);
+        status.setLastModified(lastModified);
+      } catch (ParseException e) {
+        // last-modified still unset
+      }
+    }
   }
 
   public Content getContent() {


### PR DESCRIPTION
…Modified not always set

 - set modified time (time of last successful fetch) by DefaultFetchSchedule and AdaptiveFetchSchedule
   but only if the document is actually modified
 - update unit tests to check whether modification time is properly set
 - set modified time (sent by responding server in HTTP header) in ProtocolOutput:
   FetchSchedule implementations can access the HTTP modified time from CrawlDatum's
   metadata (PROTO_STATUS_KEY = "_pst_")