### PR TITLE
Nutch requires a logs folder to run exception free

### DIFF
--- a/docker/hbase/Dockerfile
+++ b/docker/hbase/Dockerfile
@@ -73,7 +73,7 @@ RUN tar xvfz /root/hbase-0.98.8-hadoop2-bin.tar.gz -C /opt && \
 # link binaries, create logs directory
 RUN ln -s /opt/hbase-0.98.8-hadoop2 /opt/hbase &&  mkdir /opt/hbase/logs && \
   chown -R hduser:hadoop /opt/hbase/logs && \
-  mkdir /opt/nutch/logs && chown -R hduser:hadoop /opt/nutch/log
+  mkdir /opt/nutch/logs && chown -R hduser:hadoop /opt/nutch/logs
 
  # Deploy and setup file permissions
 RUN mv /root/nutch-sources /opt/apache-nutch-2.x && \

--- a/docker/hbase/Dockerfile
+++ b/docker/hbase/Dockerfile
@@ -72,7 +72,8 @@ RUN tar xvfz /root/hbase-0.98.8-hadoop2-bin.tar.gz -C /opt && \
 
 # link binaries, create logs directory
 RUN ln -s /opt/hbase-0.98.8-hadoop2 /opt/hbase &&  mkdir /opt/hbase/logs && \
-  chown -R hduser:hadoop /opt/hbase/logs
+  chown -R hduser:hadoop /opt/hbase/logs && \
+  mkdir /opt/nutch/logs && chown -R hduser:hadoop /opt/nutch/log
 
  # Deploy and setup file permissions
 RUN mv /root/nutch-sources /opt/apache-nutch-2.x && \


### PR DESCRIPTION
When running a inject, throws exception

```
hduser@028ce34179ee:/opt/nutch$ bin/nutch inject urls/seed.txt 
log4j:ERROR setFile(null,true) call failed.
java.io.FileNotFoundException: /opt/nutch/logs/hadoop.log (No such file or directory)
	at java.io.FileOutputStream.open(Native Method)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:221)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:142)
	at org.apache.log4j.FileAppender.setFile(FileAppender.java:294)
	at org.apache.log4j.FileAppender.activateOptions(FileAppender.java:165)
	at org.apache.log4j.DailyRollingFileAppender.activateOptions(DailyRollingFileAppender.java:223)
	at org.apache.log4j.config.PropertySetter.activate(PropertySetter.java:307)
	at org.apache.log4j.config.PropertySetter.setProperties(PropertySetter.java:172)
	at org.apache.log4j.config.PropertySetter.setProperties(PropertySetter.java:104)
	at org.apache.log4j.PropertyConfigurator.parseAppender(PropertyConfigurator.java:842)
	at org.apache.log4j.PropertyConfigurator.parseCategory(PropertyConfigurator.java:768)
	at org.apache.log4j.PropertyConfigurator.configureRootCategory(PropertyConfigurator.java:648)
	at org.apache.log4j.PropertyConfigurator.doConfigure(PropertyConfigurator.java:514)
	at org.apache.log4j.PropertyConfigurator.doConfigure(PropertyConfigurator.java:580)
	at org.apache.log4j.helpers.OptionConverter.selectAndConfigure(OptionConverter.java:526)
	at org.apache.log4j.LogManager.<clinit>(LogManager.java:127)
	at org.slf4j.impl.Log4jLoggerFactory.getLogger(Log4jLoggerFactory.java:66)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:277)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:288)
	at org.apache.nutch.crawl.InjectorJob.<clinit>(InjectorJob.java:64)
log4j:ERROR Either File or DatePattern options are not set for appender [DRFA].
```

Folder is now set in Dockerfile