### PR TITLE
NUTCH-2112 Missing restlet resolver when building with gora-solr

### DIFF
--- a/ivy/ivysettings.xml
+++ b/ivy/ivysettings.xml
@@ -69,6 +69,7 @@
       <resolver ref="maven2"/>
       <resolver ref="sonatype"/>
       <resolver ref="apache-snapshot"/>
+      <resolver ref="restlet"/>
     </chain>
     <chain name="internal">
       <resolver ref="local"/>


### PR DESCRIPTION
Adding restlet as a resolver to the default chain fixes missing org.restlet.jee when building with gora-solr