### PR TITLE
NUTCH-2089 Move Nutch to compile on JDK 8

### DIFF
--- a/default.properties
+++ b/default.properties
@@ -43,8 +43,8 @@ test.build.javadoc = ${test.build.dir}/docs/api
 # Proxy Host and Port to use for building JavaDoc
 javadoc.proxy.host=-J-DproxyHost=
 javadoc.proxy.port=-J-DproxyPort=
-javadoc.link.java=http://docs.oracle.com/javase/7/docs/api/
-javadoc.link.hadoop=http://hadoop.apache.org/docs/r1.2.0/api/
+javadoc.link.java=http://docs.oracle.com/javase/8/docs/api/
+javadoc.link.hadoop=http://hadoop.apache.org/docs/r2.5.2/api/
 javadoc.packages=org.apache.nutch.*
 
 dist.dir=./dist
@@ -54,7 +54,7 @@ bin.dist.version.dir=${dist.dir}/${final.name}-bin
 javac.debug=on
 javac.optimize=on
 javac.deprecation=on
-javac.version= 1.7
+javac.version= 1.8
 
 runtime.dir=./runtime
 runtime.deploy=${runtime.dir}/deploy
@@ -146,7 +146,6 @@ plugins.index=\
    org.apache.nutch.indexer.anchor*:\
    org.apache.nutch.indexer.basic*:\
    org.apache.nutch.indexer.feed*:\
-   org.apache.nutch.indexer.html*:\
    org.apache.nutch.indexer.metadata*:\
    org.apache.nutch.indexer.more*:\
    org.apache.nutch.indexer.subcollection*:\


### PR DESCRIPTION
This issue partly addresses https://issues.apache.org/jira/browse/NUTCH-2089
There are lots of Javadoc warnings and a few errors