### PR TITLE
NUTCH-2266 Dead link in build.xml for javadoc is fixed.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -636,7 +636,9 @@
       <packageset dir="${plugins.dir}/urlnormalizer-regex/src/java"/>
 
    <link href="${javadoc.link.java}" />
-   <link href="${javadoc.link.lucene}" />
+   <link href="${javadoc.link.lucene.core}" />
+   <link href="${javadoc.link.lucene.analyzers-common}" />
+   <link href="${javadoc.link.solr-solrj}" />
    <link href="${javadoc.link.hadoop}" />
 
    <classpath refid="classpath" />

--- a/default.properties
+++ b/default.properties
@@ -45,6 +45,9 @@ javadoc.proxy.host=-J-DproxyHost=
 javadoc.proxy.port=-J-DproxyPort=
 javadoc.link.java=http://docs.oracle.com/javase/7/docs/api/
 javadoc.link.hadoop=http://hadoop.apache.org/docs/r1.2.0/api/
+javadoc.link.lucene.core=https://lucene.apache.org/core/4_6_0/core/
+javadoc.link.lucene.analyzers-common=https://lucene.apache.org/core/4_6_0/analyzers-common/
+javadoc.link.solr-solrj=https://lucene.apache.org/solr/4_6_0/solr-solrj/
 javadoc.packages=org.apache.nutch.*
 
 dist.dir=./dist


### PR DESCRIPTION
Created javadoc.link.solr instead of javadoc.link.lucene and pointed to solrj api documentation since its used at Nutch.