### PR TITLE
NUTCH-2283 Fix bad substitution bash error for cassandra docker scripts

### DIFF
--- a/docker/cassandra/bin/restart.sh
+++ b/docker/cassandra/bin/restart.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/docker/cassandra/bin/start.sh
+++ b/docker/cassandra/bin/start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/docker/cassandra/bin/stop.sh
+++ b/docker/cassandra/bin/stop.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
"Bad substitution" error appears when running the following docker scripts:
    docker/cassandra/bin/start.sh
    docker/cassandra/bin/stop.sh
    docker/cassandra/bin/restart.sh

e.g.
./bin/start.sh: 18: ./bin/start.sh: Bad substitution
