### PR TITLE
NUTCH-2267 - Solr and Hadoop JAR mismatch

### DIFF
--- a/src/plugin/indexer-solr/src/java/org/apache/nutch/indexwriter/solr/SolrUtils.java
+++ b/src/plugin/indexer-solr/src/java/org/apache/nutch/indexwriter/solr/SolrUtils.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.http.impl.client.SystemDefaultHttpClient;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
@@ -60,7 +61,8 @@ public class SolrUtils {
   }
 
   public static CloudSolrClient getCloudSolrClient(String url) throws MalformedURLException {
-    CloudSolrClient sc = new CloudSolrClient(url.replace('|', ','));
+    SystemDefaultHttpClient httpClient = new SystemDefaultHttpClient();
+    CloudSolrClient sc = new CloudSolrClient(url.replace('|', ','), httpClient);
     sc.setParallelUpdates(true);
     sc.connect();
     return sc;

--- a/src/plugin/indexer-solr/src/java/org/apache/nutch/indexwriter/solr/SolrUtils.java
+++ b/src/plugin/indexer-solr/src/java/org/apache/nutch/indexwriter/solr/SolrUtils.java
@@ -32,6 +32,7 @@ import java.net.MalformedURLException;
 public class SolrUtils {
 
   public static Logger LOG = LoggerFactory.getLogger(SolrUtils.class);
+  private static HttpClient HTTP_CLIENT = new SystemDefaultHttpClient();
 
   /**
    *
@@ -52,7 +53,7 @@ public class SolrUtils {
       }
     } else {
       for (int i = 0; i < urls.length; i++) {
-        SolrClient sc = new HttpSolrClient(urls[i]);
+        SolrClient sc = new HttpSolrClient(urls[i], HTTP_CLIENT);
         solrClients.add(sc);
       }
     }
@@ -61,15 +62,14 @@ public class SolrUtils {
   }
 
   public static CloudSolrClient getCloudSolrClient(String url) throws MalformedURLException {
-    SystemDefaultHttpClient httpClient = new SystemDefaultHttpClient();
-    CloudSolrClient sc = new CloudSolrClient(url.replace('|', ','), httpClient);
+    CloudSolrClient sc = new CloudSolrClient(url.replace('|', ','), HTTP_CLIENT);
     sc.setParallelUpdates(true);
     sc.connect();
     return sc;
   }
 
   public static SolrClient getHttpSolrClient(String url) throws MalformedURLException {
-    SolrClient sc =new HttpSolrClient(url);
+    SolrClient sc =new HttpSolrClient(url, HTTP_CLIENT);
     return sc;
   }
   


### PR DESCRIPTION
Explicitly pass in an instance of SystemDefaultHttpClient to CloudSolrClient, otherwise SolrJ will use a default implementation of CloseableHttpClient, which is not present in the HttpClient and HttpCore JARs in Hadoop < 2.8 (see https://issues.apache.org/jira/browse/SOLR-7948 and https://issues.apache.org/jira/browse/HADOOP-12767).