### PR TITLE
NUTCH-2280 fix the cookie policy issue in post form authentication

### DIFF
--- a/conf/httpclient-auth.xml.template
+++ b/conf/httpclient-auth.xml.template
@@ -82,6 +82,9 @@
      <removedFormFields>
        <field name="ctl00$MainContent$LoginUser$RememberMe"/>
      </removedFormFields>
+     <loginCookie>
+       <policy>BROWSER_COMPATIBILITY</policy>
+     </loginCookie>
    </credentials>
  
  it is critical that the following fields are substituted:
@@ -98,6 +101,9 @@
     the field and password respectively
   * <field name="ctl00$MainContent$LoginUser$RememberMe"/>
     - form element attributes for which we wish to skip fields
+  * <policy> value from <loginCookie> is a constant value symbol from 
+    org.apache.commons.httpclient.cookie.CookiePolicy, like BROWSER_COMPATIBILITY,
+    DEFAULT, RFC_2109, etc.
  
  More information on HTTP POST can be located at
  https://wiki.apache.org/nutch/HttpPostAuthentication

--- a/src/plugin/protocol-httpclient/src/java/org/apache/nutch/protocol/httpclient/HttpFormAuthConfigurer.java
+++ b/src/plugin/protocol-httpclient/src/java/org/apache/nutch/protocol/httpclient/HttpFormAuthConfigurer.java
@@ -33,14 +33,20 @@ public class HttpFormAuthConfigurer {
    */
   private Map<String, String> additionalPostHeaders;
   /**
-   * If http post login returns redirect code: 301 or 302, 
-   * Http Client will automatically follow the redirect.
+   * If http post login returns redirect code: 301 or 302, Http Client will
+   * automatically follow the redirect.
    */
   private boolean loginRedirect;
   /**
    * Used when we need remove some form fields.
    */
   private Set<String> removedFormFields;
+
+  /**
+   * Use this cookie policy to set the HttpClient cookie policy. This value
+   * should be DEFAULT BROWSER_COMPATIBILITY NETSCAPE RFC_2109
+   */
+  private String cookiePolicy;
 
   public HttpFormAuthConfigurer() {
   }
@@ -102,5 +108,14 @@ public class HttpFormAuthConfigurer {
   public HttpFormAuthConfigurer setRemovedFormFields(
       Set<String> removedFormFields) {
     this.removedFormFields = removedFormFields;
-    return this; }
+    return this;
+  }
+
+  public void setCookiePolicy(String policy) {
+    this.cookiePolicy = policy;
+  }
+
+  public String getCookiePolicy() {
+    return this.cookiePolicy;
+  }
 }

--- a/src/plugin/protocol-httpclient/src/java/org/apache/nutch/protocol/httpclient/HttpFormAuthentication.java
+++ b/src/plugin/protocol-httpclient/src/java/org/apache/nutch/protocol/httpclient/HttpFormAuthentication.java
@@ -51,8 +51,7 @@ public class HttpFormAuthentication {
 
   static {
     defaultLoginHeaders.put("User-Agent", "Mozilla/5.0");
-    defaultLoginHeaders
-    .put("Accept",
+    defaultLoginHeaders.put("Accept",
         "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
     defaultLoginHeaders.put("Accept-Language", "en-US,en;q=0.5");
     defaultLoginHeaders.put("Connection", "keep-alive");
@@ -79,15 +78,12 @@ public class HttpFormAuthentication {
       Set<String> removedFormFields) {
     this.authConfigurer.setLoginUrl(loginUrl);
     this.authConfigurer.setLoginFormId(loginForm);
-    this.authConfigurer
-    .setLoginPostData(loginPostData == null ? new HashMap<String, String>()
-        : loginPostData);
-    this.authConfigurer
-    .setAdditionalPostHeaders(additionalPostHeaders == null ? new HashMap<String, String>()
-        : additionalPostHeaders);
-    this.authConfigurer
-    .setRemovedFormFields(removedFormFields == null ? new HashSet<String>()
-        : removedFormFields);
+    this.authConfigurer.setLoginPostData(
+        loginPostData == null ? new HashMap<String, String>() : loginPostData);
+    this.authConfigurer.setAdditionalPostHeaders(additionalPostHeaders == null
+        ? new HashMap<String, String>() : additionalPostHeaders);
+    this.authConfigurer.setRemovedFormFields(
+        removedFormFields == null ? new HashSet<String>() : removedFormFields);
     this.client = new HttpClient();
   }
 
@@ -118,11 +114,11 @@ public class HttpFormAuthentication {
       // Entity enclosing requests cannot be redirected without user
       // intervention
       setLoginHeader(post);
-      
+
       // NUTCH-2280
       LOGGER.debug("FormAuth: set cookie policy");
       this.setCookieParams(authConfigurer, post.getParams());
-            
+
       post.addParameters(params.toArray(new NameValuePair[0]));
       int rspCode = client.executeMethod(post);
       if (LOGGER.isDebugEnabled()) {
@@ -143,25 +139,34 @@ public class HttpFormAuthentication {
       }
     }
   }
-  
+
   /**
+   * NUTCH-2280 Set the cookie policy value from httpclient-auth.xml for the
+   * Post httpClient action.
+   * 
+   * @param fromConfigurer
+   *          - the httpclient-auth.xml values
+   * 
+   * @param params
+   *          - the HttpMethodParams from the current httpclient instance
+   * 
    * @throws NoSuchFieldException
    * @throws SecurityException
    * @throws IllegalArgumentException
    * @throws IllegalAccessException
    */
   private void setCookieParams(HttpFormAuthConfigurer formConfigurer,
-		  HttpMethodParams params)
-  		throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
-  	// NUTCH-2280 - set the HttpClient cookie policy
-        if (formConfigurer.getCookiePolicy() != null) {
-      	  String policy = formConfigurer.getCookiePolicy();
-      	  Object p = FieldUtils.readDeclaredStaticField(CookiePolicy.class, policy);
-      	  if(null != p) {
-      		  LOGGER.debug("reflection of cookie value: " + p.toString());
-      		  params.setParameter(HttpMethodParams.COOKIE_POLICY, p);
-      	  }
-        }
+      HttpMethodParams params) throws NoSuchFieldException, SecurityException,
+      IllegalArgumentException, IllegalAccessException {
+    // NUTCH-2280 - set the HttpClient cookie policy
+    if (formConfigurer.getCookiePolicy() != null) {
+      String policy = formConfigurer.getCookiePolicy();
+      Object p = FieldUtils.readDeclaredStaticField(CookiePolicy.class, policy);
+      if (null != p) {
+        LOGGER.debug("reflection of cookie value: " + p.toString());
+        params.setParameter(HttpMethodParams.COOKIE_POLICY, p);
+      }
+    }
   }
 
   private void setLoginHeader(PostMethod post) {
@@ -204,12 +209,13 @@ public class HttpFormAuthentication {
     if (loginform == null) {
       LOGGER.debug("No form element found with 'id' = {}, trying 'name'.",
           authConfigurer.getLoginFormId());
-      loginform = doc.select("form[name="+ authConfigurer.getLoginFormId() + "]").first();
+      loginform = doc
+          .select("form[name=" + authConfigurer.getLoginFormId() + "]").first();
       if (loginform == null) {
         LOGGER.debug("No form element found with 'name' = {}",
             authConfigurer.getLoginFormId());
-        throw new IllegalArgumentException("No form exists: "
-            + authConfigurer.getLoginFormId());
+        throw new IllegalArgumentException(
+            "No form exists: " + authConfigurer.getLoginFormId());
       }
     }
     Elements inputElements = loginform.getElementsByTag("input");


### PR DESCRIPTION
Fix the [NUTCH-2280](https://issues.apache.org/jira/browse/NUTCH-2280).
When a HTTP post receives session cookie from server, it might hit an issue when the server has a domain name set as ".domain.com". The "." at beginning will cause HttpClient reject this cookie.
