### PR TITLE
Bug in setting default linkdb path

### DIFF
--- a/src/java/org/apache/nutch/indexer/IndexingJob.java
+++ b/src/java/org/apache/nutch/indexer/IndexingJob.java
@@ -269,7 +269,6 @@ public class IndexingJob extends NutchTool implements Tool {
     List<Path> segments = new ArrayList<Path>();
 
     if(args.containsKey(Nutch.ARG_LINKDB)){
-      if(args.containsKey(Nutch.ARG_LINKDB)) {
         Object path = args.get(Nutch.ARG_LINKDB);
         if(path instanceof Path) {
           linkdb = (Path) path;
@@ -277,8 +276,7 @@ public class IndexingJob extends NutchTool implements Tool {
         else {
           linkdb = new Path(path.toString());
         }
-      }
-      else {
+    } else {
         linkdb = new Path(crawlId+"/linkdb");
       }
     }

--- a/src/java/org/apache/nutch/indexer/IndexingJob.java
+++ b/src/java/org/apache/nutch/indexer/IndexingJob.java
@@ -279,7 +279,6 @@ public class IndexingJob extends NutchTool implements Tool {
     } else {
         linkdb = new Path(crawlId+"/linkdb");
       }
-    }
 
     if(args.containsKey(Nutch.ARG_SEGMENTDIR)){
       isSegment = true;


### PR DESCRIPTION
There was an extra if condition in run( ) method where it sets linkdb path. It is evident when we use nutch REST api.

https://github.com/apache/nutch/blob/master/src/java/org/apache/nutch/indexer/IndexingJob.java#L272
