### PR TITLE
fix for NUTCH-2269 contributed by r0ann3l

### DIFF
--- a/src/java/org/apache/nutch/indexer/CleaningJob.java
+++ b/src/java/org/apache/nutch/indexer/CleaningJob.java
@@ -117,11 +117,11 @@ public class CleaningJob implements Tool {
       // totalDeleted += numDeletes;
       // }
 
-      writers.close();
-
       if (totalDeleted > 0 && !noCommit) {
         writers.commit();
       }
+
+      writers.close();
 
       LOG.info("CleaningJob: deleted a total of " + totalDeleted + " documents");
     }


### PR DESCRIPTION
I found when you try to commit the documents, the writers are closed. This is because the close method is invoked first and then the commit method. Then, the following exception is thrown: java.lang.IllegalStateException: Connection pool shut down