### PR TITLE
NUTCH-2335 Injector not to filter and normalize existing items/URLs in CrawlDb

### DIFF
--- a/src/java/org/apache/nutch/crawl/Injector.java
+++ b/src/java/org/apache/nutch/crawl/Injector.java
@@ -86,6 +86,9 @@ public class Injector extends NutchTool implements Tool {
   private static final Logger LOG = LoggerFactory
       .getLogger(MethodHandles.lookup().lookupClass());
 
+  /** property to pass value of command-line option -filterNormalizeAll to mapper */
+  public static final String URL_FILTER_NORMALIZE_ALL = "crawldb.inject.filter.normalize.all";
+
   /** metadata key reserved for setting a custom score for a specific URL */
   public static String nutchScoreMDName = "nutch.score";
 
@@ -114,13 +117,21 @@ public class Injector extends NutchTool implements Tool {
     private long curTime;
     private boolean url404Purging;
     private String scope;
+    private boolean filterNormalizeAll = false;
 
     public void setup(Context context) {
       Configuration conf = context.getConfiguration();
-      scope = conf.get(URL_NORMALIZING_SCOPE, URLNormalizers.SCOPE_INJECT);
-      urlNormalizers = new URLNormalizers(conf, scope);
+      boolean normalize = conf.getBoolean(CrawlDbFilter.URL_NORMALIZING, true);
+      boolean filter = conf.getBoolean(CrawlDbFilter.URL_FILTERING, true);
+      filterNormalizeAll = conf.getBoolean(URL_FILTER_NORMALIZE_ALL, false);
+      if (normalize) {
+        scope = conf.get(URL_NORMALIZING_SCOPE, URLNormalizers.SCOPE_INJECT);
+        urlNormalizers = new URLNormalizers(conf, scope);
+      }
       interval = conf.getInt("db.fetch.interval.default", 2592000);
-      filters = new URLFilters(conf);
+      if (filter) {
+        filters = new URLFilters(conf);
+      }
       scfilters = new ScoringFilters(conf);
       scoreInjected = conf.getFloat("db.score.injected", 1.0f);
       curTime = conf.getLong("injector.current.time",
@@ -132,8 +143,10 @@ public class Injector extends NutchTool implements Tool {
     private String filterNormalize(String url) {
       if (url != null) {
         try {
-          url = urlNormalizers.normalize(url, scope); // normalize the url
-          url = filters.filter(url); // filter the url
+          if (urlNormalizers != null)
+            url = urlNormalizers.normalize(url, scope); // normalize the url
+          if (filters != null)
+            url = filters.filter(url); // filter the url
         } catch (Exception e) {
           LOG.warn("Skipping " + url + ":" + e);
           url = null;
@@ -228,9 +241,13 @@ public class Injector extends NutchTool implements Tool {
         if (url404Purging && CrawlDatum.STATUS_DB_GONE == datum.getStatus())
           return;
 
-        String url = filterNormalize(key.toString());
-        if (url != null) {
-          key.set(url);
+        if (filterNormalizeAll) {
+          String url = filterNormalize(key.toString());
+          if (url != null) {
+            key.set(url);
+            context.write(key, datum);
+          }
+        } else {
           context.write(key, datum);
         }
       }
@@ -329,6 +346,13 @@ public class Injector extends NutchTool implements Tool {
 
   public void inject(Path crawlDb, Path urlDir, boolean overwrite,
       boolean update) throws IOException, ClassNotFoundException, InterruptedException {
+    inject(crawlDb, urlDir, overwrite, update, true, true, false);
+  }
+
+  public void inject(Path crawlDb, Path urlDir, boolean overwrite,
+      boolean update, boolean normalize, boolean filter,
+      boolean filterNormalizeAll)
+      throws IOException, ClassNotFoundException, InterruptedException {
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
     long start = System.currentTimeMillis();
 
@@ -344,6 +368,9 @@ public class Injector extends NutchTool implements Tool {
     conf.setLong("injector.current.time", System.currentTimeMillis());
     conf.setBoolean("db.injector.overwrite", overwrite);
     conf.setBoolean("db.injector.update", update);
+    conf.setBoolean(CrawlDbFilter.URL_NORMALIZING, normalize);
+    conf.setBoolean(CrawlDbFilter.URL_FILTERING, filter);
+    conf.setBoolean(URL_FILTER_NORMALIZE_ALL, filterNormalizeAll);
     conf.setBoolean("mapreduce.fileoutputcommitter.marksuccessfuljobs", false);
 
     // create all the required paths
@@ -411,7 +438,7 @@ public class Injector extends NutchTool implements Tool {
 
   public void usage() {
     System.err.println(
-        "Usage: Injector <crawldb> <url_dir> [-overwrite] [-update]\n");
+        "Usage: Injector <crawldb> <url_dir> [-overwrite|-update] [-noFilter] [-noNormalize] [-filterNormalizeAll]\n");
     System.err.println(
         "  <crawldb>\tPath to a crawldb directory. If not present, a new one would be created.");
     System.err.println(
@@ -437,6 +464,13 @@ public class Injector extends NutchTool implements Tool {
         " -overwrite\tOverwite existing crawldb records by the injected records. Has precedence over 'update'");
     System.err.println(
         " -update   \tUpdate existing crawldb records with the injected records. Old metadata is preserved");
+    System.err.println();
+    System.err.println(
+        " -nonormalize\tDo not normalize URLs before injecting");
+    System.err.println(
+        " -nofilter \tDo not apply URL filters to injected URLs");
+    System.err.println(
+        " -filterNormalizeAll\tNormalize and filter all URLs including the URLs of existing CrawlDb records");
   }
 
   public static void main(String[] args) throws Exception {
@@ -452,12 +486,21 @@ public class Injector extends NutchTool implements Tool {
 
     boolean overwrite = false;
     boolean update = false;
+    boolean normalize = true;
+    boolean filter = true;
+    boolean filterNormalizeAll = false;
 
     for (int i = 2; i < args.length; i++) {
       if (args[i].equals("-overwrite")) {
         overwrite = true;
       } else if (args[i].equals("-update")) {
         update = true;
+      } else if (args[i].equals("-noNormalize")) {
+        normalize = false;
+      } else if (args[i].equals("-noFilter")) {
+        filter = false;
+      } else if (args[i].equals("-filterNormalizeAll")) {
+        filterNormalizeAll = true;
       } else {
         LOG.info("Injector: Found invalid argument \"" + args[i] + "\"\n");
         usage();
@@ -466,7 +509,8 @@ public class Injector extends NutchTool implements Tool {
     }
 
     try {
-      inject(new Path(args[0]), new Path(args[1]), overwrite, update);
+      inject(new Path(args[0]), new Path(args[1]), overwrite, update, normalize,
+          filter, filterNormalizeAll);
       return 0;
     } catch (Exception e) {
       LOG.error("Injector: " + StringUtils.stringifyException(e));


### PR DESCRIPTION
Restore the default behavior before NUTCH-1712 and make the usage of URL filters and normalizers configurable via command-line options:
- `-filterNormalizeAll` : normalize and filter all URLs including the URLs of existing CrawlDb records
- `-noNormalize` and `-noFilter` : do not normalize resp. filter any URLs (new injected or existing ones)
