### PR TITLE
fix for NUTCH-2333 contributed by r0ann3l

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -188,6 +188,7 @@
       <packageset dir="${plugins.dir}/indexer-dummy/src/java"/>
       <packageset dir="${plugins.dir}/indexer-elastic/src/java/" />
       <packageset dir="${plugins.dir}/indexer-solr/src/java"/>
+      <packageset dir="${plugins.dir}/indexer-rabbit/src/java"/>
       <packageset dir="${plugins.dir}/language-identifier/src/java"/>
       <packageset dir="${plugins.dir}/lib-htmlunit/src/java"/>
       <packageset dir="${plugins.dir}/lib-http/src/java"/>
@@ -633,6 +634,7 @@
       <packageset dir="${plugins.dir}/indexer-dummy/src/java"/>
       <packageset dir="${plugins.dir}/indexer-elastic/src/java/" />
       <packageset dir="${plugins.dir}/indexer-solr/src/java"/>
+      <packageset dir="${plugins.dir}/indexer-rabbit/src/java"/>
       <packageset dir="${plugins.dir}/language-identifier/src/java"/>
       <packageset dir="${plugins.dir}/lib-htmlunit/src/java"/>
       <packageset dir="${plugins.dir}/lib-http/src/java"/>
@@ -1033,6 +1035,7 @@
         <source path="${plugins.dir}/mimetype-filter/src/test/" />
         <source path="${plugins.dir}/indexer-dummy/src/java/" />
         <source path="${plugins.dir}/indexer-solr/src/java/" />
+        <source path="${plugins.dir}/indexer-rabbit/src/java/" />
         <source path="${plugins.dir}/indexer-elastic/src/java/" />
         <source path="${plugins.dir}/indexer-elastic/src/test/" />
         <source path="${plugins.dir}/index-metadata/src/java/" />

--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1886,7 +1886,62 @@ visit https://wiki.apache.org/nutch/SimilarityScoringFilter-->
   last operation.</description>
 </property>
 
-<!-- subcollection properties -->
+<!-- RabbitMQ indexer properties -->
+
+<property>
+  <name>rabbitmq.indexer.server.host</name>
+  <value></value>
+  <description>
+    Host on which the RabbitMQ server is running. Default "localhost".
+  </description>
+</property>
+
+<property>
+  <name>rabbitmq.indexer.server.port</name>
+</property>
+
+<property>
+  <name>rabbitmq.indexer.exchange.server</name>
+  <value></value>
+  <description>
+    Name for the exchange server to use. Default - "fetcher_log"
+  </description>
+</property>
+
+<property>
+  <name>rabbitmq.indexer.exchange.type</name>
+  <value></value>
+  <description>
+    There are a few exchange types available: direct, topic, headers and fanout. Default "fanout".
+  </description>
+</property>
+
+<property>
+  <name>rabbitmq.indexer.queue.durable</name>
+  <value></value>
+  <description>
+    Choose the type of Queue being used (ex - RabbitMQ, ActiveMq, Kafka, etc).
+    Currently there exists an implemtation for RabbitMQ producer.
+  </description>
+</property>
+
+<property>
+  <name>rabbitmq.indexer.queue.routingkey</name>
+  <value></value>
+  <description>
+    The routingKey used by publisher to publish messages to specific queues. If the exchange type is "fanout", then this property is ignored.
+  </description>
+</property>
+
+<property>
+  <name>rabbitmq.indexer.commit.size</name>
+  <value></value>
+  <description>
+    The routingKey used by publisher to publish messages to specific queues. If the exchange type is "fanout", then this property is ignored.
+  </description>
+</property>
+
+  <!-- subcollection properties -->
 
 <property>
   <name>subcollection.default.fieldname</name>

--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1898,9 +1898,9 @@ visit https://wiki.apache.org/nutch/SimilarityScoringFilter-->
 
 <property>
   <name>rabbitmq.indexer.server.port</name>
-  <value>15672</value>
+  <value>5672</value>
   <description>
-    Port on which the RabbitMQ server is listening. Default "15672".
+    Port on which the RabbitMQ server is listening. Default "5672".
   </description>
 </property>
 
@@ -1908,7 +1908,7 @@ visit https://wiki.apache.org/nutch/SimilarityScoringFilter-->
   <name>rabbitmq.indexer.server.virtualhost</name>
   <value></value>
   <description>
-    Virtual host
+    Virtual Host where the exchange is and the user has access. Default "/".
   </description>
 </property>
 
@@ -1932,7 +1932,7 @@ visit https://wiki.apache.org/nutch/SimilarityScoringFilter-->
   <name>rabbitmq.indexer.exchange.server</name>
   <value></value>
   <description>
-    Name for the exchange server to use. Default "fetcher_log"
+    Name for the exchange server to use. Default "nutch.exchange"
   </description>
 </property>
 
@@ -1940,7 +1940,7 @@ visit https://wiki.apache.org/nutch/SimilarityScoringFilter-->
   <name>rabbitmq.indexer.exchange.type</name>
   <value></value>
   <description>
-    There are a few exchange types available: direct, topic, headers and fanout. Default "fanout".
+    Type of the exchange. Default "direct".
   </description>
 </property>
 
@@ -1948,8 +1948,15 @@ visit https://wiki.apache.org/nutch/SimilarityScoringFilter-->
   <name>rabbitmq.indexer.queue.durable</name>
   <value></value>
   <description>
-    Choose the type of Queue being used (ex - RabbitMQ, ActiveMq, Kafka, etc).
-    Currently there exists an implemtation for RabbitMQ producer.
+    Message durability into the queue. Default "true".
+  </description>
+</property>
+
+<property>
+  <name>rabbitmq.indexer.queue.name</name>
+  <value></value>
+  <description>
+    Name of the queue where the messages will be sent. Default "nutch.queue"
   </description>
 </property>
 
@@ -1957,15 +1964,16 @@ visit https://wiki.apache.org/nutch/SimilarityScoringFilter-->
   <name>rabbitmq.indexer.queue.routingkey</name>
   <value></value>
   <description>
-    The routingKey used by publisher to publish messages to specific queues. If the exchange type is "fanout", then this property is ignored.
+    The routingKey used by indexer to publish messages to specific queues.
+    If the exchange type is "fanout", then this property is ignored. Default is "nutch.key"
   </description>
 </property>
 
 <property>
   <name>rabbitmq.indexer.commit.size</name>
-  <value></value>
+  <value>250</value>
   <description>
-    The routingKey used by publisher to publish messages to specific queues. If the exchange type is "fanout", then this property is ignored.
+    Amount of documents to send into each message. Default "250"
   </description>
 </property>
 

--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1890,7 +1890,7 @@ visit https://wiki.apache.org/nutch/SimilarityScoringFilter-->
 
 <property>
   <name>rabbitmq.indexer.server.host</name>
-  <value></value>
+  <value>localhost</value>
   <description>
     Host on which the RabbitMQ server is running. Default "localhost".
   </description>
@@ -1898,13 +1898,41 @@ visit https://wiki.apache.org/nutch/SimilarityScoringFilter-->
 
 <property>
   <name>rabbitmq.indexer.server.port</name>
+  <value>15672</value>
+  <description>
+    Port on which the RabbitMQ server is listening. Default "15672".
+  </description>
+</property>
+
+<property>
+  <name>rabbitmq.indexer.server.virtualhost</name>
+  <value></value>
+  <description>
+    Virtual host
+  </description>
+</property>
+
+<property>
+  <name>rabbitmq.indexer.server.username</name>
+  <value>admin</value>
+  <description>
+    Username for RabbitMQ server. Default "admin"
+  </description>
+</property>
+
+<property>
+  <name>rabbitmq.indexer.server.password</name>
+  <value>admin</value>
+  <description>
+    Password for RabbitMQ server. Default "admin"
+  </description>
 </property>
 
 <property>
   <name>rabbitmq.indexer.exchange.server</name>
   <value></value>
   <description>
-    Name for the exchange server to use. Default - "fetcher_log"
+    Name for the exchange server to use. Default "fetcher_log"
   </description>
 </property>
 

--- a/src/plugin/build.xml
+++ b/src/plugin/build.xml
@@ -42,6 +42,7 @@
      <ant dir="indexer-dummy" target="deploy"/>
      <ant dir="indexer-elastic" target="deploy"/>
      <ant dir="indexer-solr" target="deploy"/>
+     <ant dir="indexer-rabbit" target="deploy"/>
      <ant dir="language-identifier" target="deploy"/>
      <ant dir="lib-http" target="deploy"/>
      <ant dir="lib-nekohtml" target="deploy"/>
@@ -161,6 +162,7 @@
     <ant dir="indexer-dummy" target="clean"/>
     <ant dir="indexer-elastic" target="clean"/>
     <ant dir="indexer-solr" target="clean"/>
+    <ant dir="indexer-rabbit" target="clean"/>
     <ant dir="language-identifier" target="clean"/>
     <!-- <ant dir="lib-commons-httpclient" target="clean"/> -->
     <ant dir="lib-http" target="clean"/>

--- a/src/plugin/indexer-rabbit/build-ivy.xml
+++ b/src/plugin/indexer-rabbit/build-ivy.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project name="indexer-rabbit" default="deps-jar" xmlns:ivy="antlib:org.apache.ivy.ant">
+
+    <property name="ivy.install.version" value="2.1.0" />
+    <condition property="ivy.home" value="${env.IVY_HOME}">
+      <isset property="env.IVY_HOME" />
+    </condition>
+    <property name="ivy.home" value="${user.home}/.ant" />
+    <property name="ivy.checksums" value="" />
+    <property name="ivy.jar.dir" value="${ivy.home}/lib" />
+    <property name="ivy.jar.file" value="${ivy.jar.dir}/ivy.jar" />
+
+    <target name="download-ivy" unless="offline">
+
+        <mkdir dir="${ivy.jar.dir}"/>
+        <!-- download Ivy from web site so that it can be used even without any special installation -->
+        <get src="http://repo2.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar" 
+             dest="${ivy.jar.file}" usetimestamp="true"/>
+    </target>
+
+    <target name="init-ivy" depends="download-ivy">
+      <!-- try to load ivy here from ivy home, in case the user has not already dropped
+              it into ant's lib dir (note that the latter copy will always take precedence).
+              We will not fail as long as local lib dir exists (it may be empty) and
+              ivy is in at least one of ant's lib dir or the local lib dir. -->
+        <path id="ivy.lib.path">
+            <fileset dir="${ivy.jar.dir}" includes="*.jar"/>
+
+        </path>
+        <taskdef resource="org/apache/ivy/ant/antlib.xml"
+                 uri="antlib:org.apache.ivy.ant" classpathref="ivy.lib.path"/>
+    </target>
+
+  <target name="deps-jar" depends="init-ivy">
+    <ivy:retrieve pattern="lib/[artifact]-[revision].[ext]"/>
+  </target>
+
+</project>

--- a/src/plugin/indexer-rabbit/build.xml
+++ b/src/plugin/indexer-rabbit/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project name="indexer-rabbit" default="jar-core">
+
+  <import file="../build-plugin.xml" />
+
+</project>

--- a/src/plugin/indexer-rabbit/ivy.xml
+++ b/src/plugin/indexer-rabbit/ivy.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<ivy-module version="1.0">
+  <info organisation="org.apache.nutch" module="${ant.project.name}">
+    <license name="Apache 2.0"/>
+    <ivyauthor name="Apache Nutch Team" url="http://nutch.apache.org"/>
+    <description>
+        Apache Nutch
+    </description>
+  </info>
+
+  <configurations>
+    <include file="../../..//ivy/ivy-configurations.xml"/>
+  </configurations>
+
+  <publications>
+    <!--get the artifact from our module name-->
+    <artifact conf="master"/>
+  </publications>
+
+  <dependencies>
+    <dependency org="com.rabbitmq" name="amqp-client" rev="3.6.5"/>
+    <dependency org="com.google.code.gson" name="gson" rev="2.7"/>
+  </dependencies>
+  
+</ivy-module>

--- a/src/plugin/indexer-rabbit/plugin.xml
+++ b/src/plugin/indexer-rabbit/plugin.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+  
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<plugin id="indexer-rabbit" name="RabbitIndexWriter" version="1.0.0" provider-name="nutch.apache.org">
+
+  <runtime>
+    <library name="indexer-rabbit.jar">
+      <export name="*" />
+    </library>
+    <library name="amqp-client-3.6.5.jar"/>
+    <library name="gson-2.7.jar"/>
+  </runtime>
+
+  <requires>
+    <import plugin="nutch-extensionpoints" />
+  </requires>
+
+  <extension id="org.apache.nutch.indexer.rabbit"
+    name="Rabbit Index Writer"
+    point="org.apache.nutch.indexer.IndexWriter">
+    <implementation id="RabbitIndexWriter"
+      class="org.apache.nutch.indexwriter.rabbit.RabbitIndexWriter" />
+  </extension>
+
+</plugin>

--- a/src/plugin/indexer-rabbit/src/java/org/apache/nutch/indexwriter/rabbit/RabbitDocument.java
+++ b/src/plugin/indexer-rabbit/src/java/org/apache/nutch/indexwriter/rabbit/RabbitDocument.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nutch.indexwriter.rabbit;
+
+import java.util.LinkedList;
+import java.util.List;
+
+class RabbitDocument {
+    private List<RabbitDocumentField> fields;
+
+    private float documentBoost;
+
+    RabbitDocument() {
+        this.fields = new LinkedList<>();
+    }
+
+    List<RabbitDocumentField> getFields() {
+        return fields;
+    }
+
+    void setDocumentBoost(float documentBoost) {
+        this.documentBoost = documentBoost;
+    }
+
+    void addField(RabbitDocumentField field) {
+        fields.add(field);
+    }
+
+    static class RabbitDocumentField {
+        private String key;
+        private float weight;
+        private List<Object> values;
+
+        RabbitDocumentField(String key, float weight, List<Object> values) {
+            this.key = key;
+            this.weight = weight;
+            this.values = values;
+        }
+    }
+}

--- a/src/plugin/indexer-rabbit/src/java/org/apache/nutch/indexwriter/rabbit/RabbitIndexWriter.java
+++ b/src/plugin/indexer-rabbit/src/java/org/apache/nutch/indexwriter/rabbit/RabbitIndexWriter.java
@@ -185,7 +185,7 @@ public class RabbitIndexWriter implements IndexWriter {
 
     public String describe() {
         return "RabbitIndexWriter\n" +
-                "\t" + RabbitMQConstants.SERVER_URL + " : URL of RabbitMQ server\n" +
+                "\t" + serverHost +  ":" + serverPort + " : URL of RabbitMQ server\n" +
                 "\t" + RabbitMQConstants.SERVER_VIRTUAL_HOST + " : Virtualhost name\n" +
                 "\t" + RabbitMQConstants.SERVER_USERNAME + " : Username for authentication\n" +
                 "\t" + RabbitMQConstants.SERVER_PASSWORD + " : Password for authentication\n" +

--- a/src/plugin/indexer-rabbit/src/java/org/apache/nutch/indexwriter/rabbit/RabbitIndexWriter.java
+++ b/src/plugin/indexer-rabbit/src/java/org/apache/nutch/indexwriter/rabbit/RabbitIndexWriter.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nutch.indexwriter.rabbit;
+
+import java.io.IOException;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.nutch.indexer.NutchDocument;
+
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.nutch.indexer.IndexWriter;
+
+import org.apache.nutch.indexer.NutchField;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.TimeoutException;
+
+public class RabbitIndexWriter implements IndexWriter {
+
+    private String serverHost;
+    private int serverPort;
+    private String serverVirtualHost;
+    private String serverUsername;
+    private String serverPassword;
+
+    private String exchangeServer;
+    private String exchangeType;
+
+    private String queueName;
+    private boolean queueDurable;
+    private String queueRoutingKey;
+
+    private int commitSize;
+
+    public static final Logger LOG = LoggerFactory.getLogger(RabbitIndexWriter.class);
+
+    private Configuration config;
+
+    private RabbitMessage rabbitMessage = new RabbitMessage();
+
+    private Channel channel;
+    private Connection connection;
+
+    @Override
+    public Configuration getConf() {
+        return config;
+    }
+
+    @Override
+    public void setConf(Configuration conf) {
+        config = conf;
+
+        serverHost = conf.get(RabbitMQConstants.SERVER_HOST, "localhost");
+        serverPort = conf.getInt(RabbitMQConstants.SERVER_PORT, 15672);
+        serverVirtualHost = conf.get(RabbitMQConstants.SERVER_VIRTUAL_HOST, null);
+
+        serverUsername = conf.get(RabbitMQConstants.SERVER_USERNAME, "admin");
+        serverPassword = conf.get(RabbitMQConstants.SERVER_PASSWORD, "admin");
+
+        exchangeServer = conf.get(RabbitMQConstants.EXCHANGE_SERVER, "nutch.exchange");
+        exchangeType = conf.get(RabbitMQConstants.EXCHANGE_TYPE, "direct");
+
+        queueName = conf.get(RabbitMQConstants.QUEUE_NAME, "nutch.queue");
+        queueDurable = conf.getBoolean(RabbitMQConstants.QUEUE_DURABLE, true);
+        queueRoutingKey = conf.get(RabbitMQConstants.QUEUE_ROUTING_KEY, "nutch.key");
+
+        commitSize = conf.getInt(RabbitMQConstants.COMMIT_SIZE, 250);
+    }
+
+    @Override
+    public void open(JobConf JobConf, String name) throws IOException {
+        ConnectionFactory factory = new ConnectionFactory();
+        factory.setHost(serverHost);
+        factory.setPort(serverPort);
+
+        if(serverVirtualHost != null) {
+            factory.setVirtualHost(serverVirtualHost);
+        }
+
+        factory.setUsername(serverUsername);
+        factory.setPassword(serverPassword);
+
+        try {
+            connection = factory.newConnection();
+            channel = connection.createChannel();
+
+            channel.exchangeDeclare(exchangeServer, exchangeType, true);
+            channel.queueDeclare(queueName, queueDurable, false, false, null);
+            channel.queueBind(queueName, exchangeServer, queueRoutingKey);
+
+        } catch (TimeoutException | IOException ex) {
+            throw makeIOException(ex);
+        }
+    }
+
+    @Override
+    public void update(NutchDocument doc) throws IOException {
+        RabbitDocument rabbitDocument = new RabbitDocument();
+
+        for (final Map.Entry<String, NutchField> e : doc) {
+            RabbitDocument.RabbitDocumentField field = new RabbitDocument.RabbitDocumentField(
+                    e.getKey(),
+                    e.getValue().getWeight(),
+                    e.getValue().getValues());
+            rabbitDocument.addField(field);
+        }
+        rabbitDocument.setDocumentBoost(doc.getWeight());
+
+        rabbitMessage.addDocToUpdate(rabbitDocument);
+        if(rabbitMessage.size() >= commitSize) {
+            commit();
+        }
+    }
+
+    @Override
+    public void commit() throws IOException {
+        if (!rabbitMessage.isEmpty()) {
+            channel.basicPublish(exchangeServer, queueRoutingKey, null, rabbitMessage.getBytes());
+        }
+        rabbitMessage.clear();
+    }
+
+    @Override
+    public void write(NutchDocument doc) throws IOException {
+        RabbitDocument rabbitDocument = new RabbitDocument();
+
+        for (final Map.Entry<String, NutchField> e : doc) {
+            RabbitDocument.RabbitDocumentField field = new RabbitDocument.RabbitDocumentField(
+                    e.getKey(),
+                    e.getValue().getWeight(),
+                    e.getValue().getValues());
+            rabbitDocument.addField(field);
+        }
+        rabbitDocument.setDocumentBoost(doc.getWeight());
+
+        rabbitMessage.addDocToWrite(rabbitDocument);
+
+        if(rabbitMessage.size() >= commitSize) {
+            commit();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        commit();//TODO: This is because indexing job never call commit method. It should be fixed.
+        try {
+            channel.close();
+            connection.close();
+        } catch (IOException | TimeoutException e) {
+            throw makeIOException(e);
+        }
+    }
+
+    @Override
+    public void delete(String url) throws IOException {
+        rabbitMessage.addDocToDelete(url);
+
+        if(rabbitMessage.size() >= commitSize) {
+            commit();
+        }
+    }
+
+    private static IOException makeIOException(Exception e) {
+        return new IOException(e);
+    }
+
+    public String describe() {
+        return "RabbitIndexWriter\n" +
+                "\t" + RabbitMQConstants.SERVER_URL + " : URL of RabbitMQ server\n" +
+                "\t" + RabbitMQConstants.SERVER_VIRTUAL_HOST + " : Virtualhost name\n" +
+                "\t" + RabbitMQConstants.SERVER_USERNAME + " : Username for authentication\n" +
+                "\t" + RabbitMQConstants.SERVER_PASSWORD + " : Password for authentication\n" +
+                "\t" + RabbitMQConstants.COMMIT_SIZE + " : Buffer size when sending to RabbitMQ (default 250)\n";
+    }
+}

--- a/src/plugin/indexer-rabbit/src/java/org/apache/nutch/indexwriter/rabbit/RabbitMQConstants.java
+++ b/src/plugin/indexer-rabbit/src/java/org/apache/nutch/indexwriter/rabbit/RabbitMQConstants.java
@@ -41,6 +41,4 @@ interface RabbitMQConstants {
 
 
     String COMMIT_SIZE = RABBIT_PREFIX + "commit.size";
-
-    String SERVER_URL = SERVER_HOST + ":" + SERVER_PORT;
 }

--- a/src/plugin/indexer-rabbit/src/java/org/apache/nutch/indexwriter/rabbit/RabbitMQConstants.java
+++ b/src/plugin/indexer-rabbit/src/java/org/apache/nutch/indexwriter/rabbit/RabbitMQConstants.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nutch.indexwriter.rabbit;
+
+interface RabbitMQConstants {
+    String RABBIT_PREFIX = "rabbitmq.indexer";
+
+    String SERVER_HOST = RABBIT_PREFIX + "server.host";
+
+    String SERVER_PORT = RABBIT_PREFIX + "server.port";
+
+    String SERVER_VIRTUAL_HOST = RABBIT_PREFIX + "server.virtualhost";
+
+    String SERVER_USERNAME = RABBIT_PREFIX + "server.username";
+
+    String SERVER_PASSWORD = RABBIT_PREFIX + "server.password";
+
+    String EXCHANGE_SERVER = RABBIT_PREFIX + "exchange.server";
+
+    String EXCHANGE_TYPE = RABBIT_PREFIX + "exchange.type";
+
+    String QUEUE_NAME = RABBIT_PREFIX + "queue.name";
+
+    String QUEUE_DURABLE = RABBIT_PREFIX + "queue.durable";
+
+    String QUEUE_ROUTING_KEY = RABBIT_PREFIX + "queue.routingkey";
+
+
+    String COMMIT_SIZE = RABBIT_PREFIX + "commit.size";
+
+    String SERVER_URL = SERVER_HOST + ":" + SERVER_PORT;
+}

--- a/src/plugin/indexer-rabbit/src/java/org/apache/nutch/indexwriter/rabbit/RabbitMessage.java
+++ b/src/plugin/indexer-rabbit/src/java/org/apache/nutch/indexwriter/rabbit/RabbitMessage.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nutch.indexwriter.rabbit;
+
+import com.google.gson.Gson;
+
+import java.util.LinkedList;
+import java.util.List;
+
+class RabbitMessage {
+    private List<RabbitDocument> docsToWrite = new LinkedList<>();
+    private List<RabbitDocument> docsToUpdate = new LinkedList<>();
+    private List<String> docsToDelete = new LinkedList<>();
+
+    boolean addDocToWrite (RabbitDocument doc) {
+        return docsToWrite.add(doc);
+    }
+
+    boolean addDocToUpdate (RabbitDocument doc) {
+        return docsToUpdate.add(doc);
+    }
+
+    boolean addDocToDelete (String url) {
+        return docsToDelete.add(url);
+    }
+
+    byte[] getBytes() {
+        Gson gson = new Gson();
+        return gson.toJson(this).getBytes();
+    }
+
+    boolean isEmpty () {
+        return docsToWrite.isEmpty() && docsToUpdate.isEmpty() && docsToDelete.isEmpty();
+    }
+
+    public List<RabbitDocument> getDocsToWrite() {
+        return docsToWrite;
+    }
+
+    public List<RabbitDocument> getDocsToUpdate() {
+        return docsToUpdate;
+    }
+
+    public List<String> getDocsToDelete() {
+        return docsToDelete;
+    }
+
+    public int size () {
+        return docsToWrite.size() + docsToUpdate.size() + docsToDelete.size();
+    }
+
+    public void clear() {
+        docsToWrite.clear();
+        docsToUpdate.clear();
+        docsToDelete.clear();
+    }
+}


### PR DESCRIPTION
An indexer for RabbitMQ is for sending crawled documents to a queue into a server of RabbitMQ. Just like solr-indexer or elastic-indexer do. This indexer send a lot of documents to RabbitMQ, not one by one, according to rabbitmq.indexer.commit.size value.