### PR TITLE
NUTCH-2349 urlnormalizer-basic: NPE for URLs without authority

### DIFF
--- a/src/plugin/urlnormalizer-basic/src/java/org/apache/nutch/net/urlnormalizer/basic/BasicURLNormalizer.java
+++ b/src/plugin/urlnormalizer-basic/src/java/org/apache/nutch/net/urlnormalizer/basic/BasicURLNormalizer.java
@@ -111,7 +111,7 @@ public class BasicURLNormalizer extends Configured implements URLNormalizer {
     if ("http".equals(protocol) || "https".equals(protocol)
         || "ftp".equals(protocol)) {
 
-      if (host != null) {
+      if (host != null && url.getAuthority() != null) {
         String newHost = host.toLowerCase(Locale.ROOT); // lowercase host
         if (!host.equals(newHost)) {
           host = newHost;
@@ -121,6 +121,9 @@ public class BasicURLNormalizer extends Configured implements URLNormalizer {
           // etc.) which will likely cause a change if left away
           changed = true;
         }
+      } else {
+        // no host or authority: recompose the URL from components
+        changed = true;
       }
 
       if (port == url.getDefaultPort()) { // uses default port

--- a/src/plugin/urlnormalizer-basic/src/test/org/apache/nutch/net/urlnormalizer/basic/TestBasicURLNormalizer.java
+++ b/src/plugin/urlnormalizer-basic/src/test/org/apache/nutch/net/urlnormalizer/basic/TestBasicURLNormalizer.java
@@ -164,6 +164,12 @@ public class TestBasicURLNormalizer {
         "http://foo.com/aa/bb/foo.html");
     normalizeTest("http://foo.com/aa?referer=http://bar.com",
         "http://foo.com/aa?referer=http://bar.com");
+    // check for NPEs when normalizing URLs without host (authority)
+    normalizeTest("file:///foo/bar.txt", "file:///foo/bar.txt");
+    normalizeTest("ftp:/", "ftp:/");
+    normalizeTest("http:", "http:/");
+    normalizeTest("http:////", "http:/");
+    normalizeTest("http:///////", "http:/");
   }
 
   private void normalizeTest(String weird, String normal) throws Exception {


### PR DESCRIPTION
- check whether URL.getAuthority() returns null
- recompose URLs without authority with empty authority/host