### PR TITLE
Fix for NUTCH-2353 contributed by jorgelbg

### DIFF
--- a/src/java/org/apache/nutch/service/model/request/SeedUrl.java
+++ b/src/java/org/apache/nutch/service/model/request/SeedUrl.java
@@ -17,6 +17,8 @@
 package org.apache.nutch.service.model.request;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -29,6 +31,8 @@ public class SeedUrl implements Serializable {
   private SeedList seedList;
 
   private String url;
+
+  private Map<String, String> metadata = new HashMap<>();
 
   public SeedUrl() {}
 
@@ -51,6 +55,10 @@ public class SeedUrl implements Serializable {
   public void setUrl(String url) {
     this.url = url;
   }
+
+  public Map<String,String> getMetadata() { return metadata; }
+
+  public void setMetadata(Map<String,String> metadata) { this.metadata = metadata; }
 
   @JsonIgnore
   public SeedList getSeedList() {

--- a/src/java/org/apache/nutch/service/resources/SeedResource.java
+++ b/src/java/org/apache/nutch/service/resources/SeedResource.java
@@ -18,6 +18,7 @@ package org.apache.nutch.service.resources;
 
 import java.io.OutputStream;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 
 import javax.ws.rs.Consumes;
@@ -104,6 +105,16 @@ public class SeedResource extends AbstractResource {
     if (CollectionUtils.isNotEmpty(seedUrls)) {
       for (SeedUrl seedUrl : seedUrls) {
         os.write(seedUrl.getUrl().getBytes());
+
+        Map<String,String> metadata = seedUrl.getMetadata();
+        Iterator<String> keyIterator = metadata.keySet().iterator();
+
+        while (keyIterator.hasNext()) {
+          String key = keyIterator.next();
+
+          os.write(String.format("\t%s=%s", key, metadata.get(key)).getBytes());
+        }
+
         os.write("\n".getBytes());
       }
     }

--- a/src/java/org/apache/nutch/webui/model/SeedUrl.java
+++ b/src/java/org/apache/nutch/webui/model/SeedUrl.java
@@ -17,6 +17,8 @@
 package org.apache.nutch.webui.model;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -43,6 +45,9 @@ public class SeedUrl implements Serializable {
   @Column
   private String url;
 
+  @Column
+  private Map<String, String> metadata = new HashMap<>();
+
   public Long getId() {
     return id;
   }
@@ -58,6 +63,10 @@ public class SeedUrl implements Serializable {
   public void setUrl(String url) {
     this.url = url;
   }
+
+  public Map<String,String> getMetadata() { return metadata; }
+
+  public void setMetadata(Map<String,String> metadata) { this.metadata = metadata; }
 
   @JsonIgnore
   public SeedList getSeedList() {


### PR DESCRIPTION
This PR adds the possibility of attaching metadata to the seed file created using the REST API as showed on https://issues.apache.org/jira/browse/NUTCH-2353, the supported syntax is:

```json
{
    "name":"name-of-seedlist", 
    "seedUrls":[
        {
            "url" : "http://example.com",
            "metadata" : {
                "key1" : "value1",
                "key2" : "value2",
                "key3" : "value3"
            }
        }
    ]
}
```

Also the old syntax is supported:

```json
{
    "name":"name-of-seedlist", 
    "seedUrls":["http://www.example.com", "http://www.example1.com"]
}
```