### PR TITLE
NUTCH-2357 Index metadata throw Exception because writable object can…

### DIFF
--- a/src/plugin/index-metadata/src/java/org/apache/nutch/indexer/metadata/MetadataIndexer.java
+++ b/src/plugin/index-metadata/src/java/org/apache/nutch/indexer/metadata/MetadataIndexer.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
 import org.apache.nutch.crawl.CrawlDatum;
 import org.apache.nutch.crawl.Inlinks;
 import org.apache.nutch.indexer.IndexingException;
@@ -55,7 +56,7 @@ public class MetadataIndexer implements IndexingFilter {
     // add the fields from crawldb
     if (dbFieldnames != null) {
       for (String metatag : dbFieldnames) {
-        Text metadata = (Text) datum.getMetaData().get(new Text(metatag));
+        Writable metadata = datum.getMetaData().get(new Text(metatag));
         if (metadata != null)
           doc.add(metatag, metadata.toString());
       }


### PR DESCRIPTION
…not be cast to Text

- do not cast CrawlDatum metadata values from o.a.hadoop.io.Writable to o.a.hadoop.io.Text
(contributed by Eyeris Rodriguez Rueda)