### PR TITLE
NUTCH-2359 RegexParseFilter: ill-formed rules raise error

### DIFF
--- a/src/plugin/parsefilter-regex/README.txt
+++ b/src/plugin/parsefilter-regex/README.txt
@@ -1,0 +1,37 @@
+Parsefilter-regex plugin
+
+Allow parsing and set custom defined fields using regex. Rules can be defined in a separate rule file or in the nutch configuration.
+
+If a rule file is used, should create a text file regex-parsefilter.txt (which is the default name of the rules file). To use a different filename, either update the file value in plugin’s build.xml or add parsefilter.regex.file config to the nutch config.
+
+ie:
+    <property>
+      <name>parsefilter.regex.file</name>
+      <value>
+	/path/to/rulefile
+      </value>
+    </property
+
+
+Format of rules: <name>\t<source>\t<regex>\n
+
+ie:
+	my_first_field		html	h1
+	my_second_field		text	my_pattern
+
+
+If a rule file is not used, rules can be directly set in the nutch config:
+
+ie:
+    <property>
+      <name>parsefilter.regex.rules</name>
+      <value>
+	my_first_field		html	h1
+	my_second_field		text	my_pattern
+      </value>
+    </property
+
+source can be either html or text. If source is html, the regex is applied to
+the entire HTML tree. If source is text, the regex is applied to the
+extracted text.
+

--- a/src/plugin/parsefilter-regex/src/java/org/apache/nutch/parsefilter/regex/RegexParseFilter.java
+++ b/src/plugin/parsefilter-regex/src/java/org/apache/nutch/parsefilter/regex/RegexParseFilter.java
@@ -179,13 +179,17 @@ public class RegexParseFilter implements HtmlParseFilter {
     while ((line = reader.readLine()) != null) {
       if (StringUtils.isNotBlank(line) && !line.startsWith("#")) {
         line = line.trim();
-        String[] parts = line.split("\t");
+        String[] parts = line.split("\\s");
 
-        String field = parts[0].trim();
-        String source = parts[1].trim();
-        String regex = parts[2].trim();
-        
-        rules.put(field, new RegexRule(source, regex));
+        if (parts.length == 3) {
+            String field = parts[0].trim();
+            String source = parts[1].trim();
+            String regex = parts[2].trim();
+            
+            rules.put(field, new RegexRule(source, regex));
+        } else {
+            LOG.info("RegexParseFilter rule is invalid. " + line);
+        }
       }
     }
   }


### PR DESCRIPTION
  - README
  - Using any whitespace character(\s) instead of tab(\t) as rule delimiter

Issue: https://issues.apache.org/jira/browse/NUTCH-2359