### PR TITLE
fix fetcher.throughput.threshold.check.after

### DIFF
--- a/src/java/org/apache/nutch/fetcher/FetcherReducer.java
+++ b/src/java/org/apache/nutch/fetcher/FetcherReducer.java
@@ -861,8 +861,8 @@ public class FetcherReducer extends
       LOG.info("Fetcher: throughput threshold sequence: "
           + throughputThresholdSequence);
     }
-    long throughputThresholdTimeLimit = conf.getLong(
-        "fetcher.throughput.threshold.check.after", -1);
+    long throughputThresholdTimeLimit = System.currentTimeMillis() + (conf.getLong(
+        "fetcher.throughput.threshold.check.after", 5) * 60 * 1000);
 
     do { // wait for threads to exit
       pagesLastSec = pages.get();


### PR DESCRIPTION
Without adding on System.currentTimeMillis() this can't possibly work?

According to nutch-default.xml the default value should be 5 minutes.