### PR TITLE
NUTCH-2373 Index writer plugin for hbase implemented

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -202,6 +202,7 @@
       <packageset dir="${plugins.dir}/index-metadata/src/java"/>
       <packageset dir="${plugins.dir}/index-more/src/java"/>
       <packageset dir="${plugins.dir}/indexer-elastic/src/java"/>
+      <packageset dir="${plugins.dir}/indexer-hbase/src/java"/>
       <packageset dir="${plugins.dir}/indexer-solr/src/java"/>
       <packageset dir="${plugins.dir}/language-identifier/src/java"/>
       <packageset dir="${plugins.dir}/lib-http/src/java"/>

--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1395,7 +1395,7 @@
 
 <property>
   <name>hbase.indexer.commit.size</name>
-  <value>250</value>
+  <value>500</value>
   <description>
   Defines the number of documents to send to Hbase in a single write batch.
   Decrease when handling very large documents to prevent Nutch from running

--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -94,7 +94,7 @@
     <dependency org="org.jdom" name="jdom" rev="1.1" conf="test->default"/>
     <dependency org="org.mockito" name="mockito-all" rev="1.9.5" conf="test->default"/>
     <dependency org="org.springframework" name="spring-test" rev="4.0.4.RELEASE" conf="test->default"/>
-  
+	
 
     <!--================-->
     <!-- Gora artifacts -->
@@ -148,11 +148,11 @@
     <dependency org="org.springframework" name="spring-web" rev="4.0.4.RELEASE" conf="*->default" />
 
     <dependency org="com.sun.jersey" name="jersey-client" rev="1.8" conf="*->default" />
-  
+	
     <dependency org="com.j256.ormlite" name="ormlite-jdbc" rev="4.48" conf="*->default" />
     <dependency org="com.h2database" name="h2" rev="1.4.180" conf="*->default" />
     <dependency org="org.eclipse.persistence" name="javax.persistence" rev="2.0.0" conf="*->default" />
-  
+	
     <dependency org="org.apache.wicket" name="wicket-core" rev="6.16.0" conf="*->default" />
     <dependency org="org.apache.wicket" name="wicket-spring" rev="6.16.0" conf="*->default" />
     <dependency org="org.apache.wicket" name="wicket-auth-roles" rev="6.16.0" conf="*->default" />

--- a/ivy/mvn.template
+++ b/ivy/mvn.template
@@ -73,6 +73,11 @@
 			<email>fenglu@apache.org</email>
 		</developer>
 		<developer>
+          <id>kamaci</id>
+          <name>Furkan KAMACI</name>
+          <email>kamaci@apache.org</email>
+        </developer>
+		<developer>
 			<id>kiranch</id>
 			<name>Kiran Chitturi</name>
 			<email>kiranch@apache.org</email>

--- a/src/java/org/apache/nutch/indexer/CleaningJob.java
+++ b/src/java/org/apache/nutch/indexer/CleaningJob.java
@@ -125,10 +125,10 @@ public class CleaningJob extends NutchTool implements Tool {
 
     @Override
     public void cleanup(Context context) throws IOException {
-      writers.close();
       if (numDeletes > 0 && commit) {
         writers.commit();
       }
+      writers.close();
       LOG.info("CleaningJob: deleted a total of " + numDeletes + " documents");
     }
   }

--- a/src/java/org/apache/nutch/metadata/Metadata.java
+++ b/src/java/org/apache/nutch/metadata/Metadata.java
@@ -190,7 +190,7 @@ public class Metadata implements Writable, CreativeCommons, DublinCore,
       return false;
     }
 
-    if (this.getClass() != o.getClass()) {
+    if (!Metadata.class.isAssignableFrom(o.getClass())) {
       return false;
     }
 

--- a/src/plugin/indexer-hbase/src/java/org/apache/nutch/indexwriter/hbase/HBaseIndexWriter.java
+++ b/src/plugin/indexer-hbase/src/java/org/apache/nutch/indexwriter/hbase/HBaseIndexWriter.java
@@ -80,21 +80,22 @@ public class HBaseIndexWriter implements IndexWriter {
     try {
       hBaseAdmin = new HBaseAdmin(hbaseConfig);
     } catch (MasterNotRunningException ex) {
-      LOG.error(ex.toString());
+      LOG.error("{}", ex.toString());
       throw ex;
     } catch (ZooKeeperConnectionException ex) {
-      LOG.error(ex.toString());
+      LOG.error("{}", ex.toString());
       throw ex;
     }
 
     if (!hBaseAdmin.tableExists(hbaseMapping.getTableName())) {
-      String msg = "Table '" + hbaseMapping.getTableName()
-          + "' doesn't exist in hbase";
+      String msg = String.format("Table '%s' doesn't exist in HBase",
+          hbaseMapping.getTableName());
       LOG.error(msg);
       throw new RuntimeException(msg);
     }
     if (hBaseAdmin.isTableDisabled(hbaseMapping.getTableName())) {
-      String msg = "Table '" + hbaseMapping.getTableName() + "' is disabled";
+      String msg = String.format("Table '%s' is disabled",
+          hbaseMapping.getTableName());
       LOG.error(msg);
       throw new RuntimeException(msg);
     }
@@ -107,7 +108,7 @@ public class HBaseIndexWriter implements IndexWriter {
     byte[] rowKey = Bytes.toBytes(doc.getFieldValue(hbaseMapping.getRowKey()));
     while (entries.hasNext()) {
       Entry<String, List<String>> entry = entries.next();
-      LOG.info(entry.getKey() + " => " + entry.getValue());
+      LOG.info("{} => {}", entry.getKey(), entry.getValue());
       Put put = new Put(rowKey);
       put.add(Bytes.toBytes(hbaseMapping.getFamily(entry.getKey())),
           Bytes.toBytes(hbaseMapping.getMappedKey(entry.getKey())),

--- a/src/plugin/indexer-hbase/src/java/org/apache/nutch/indexwriter/hbase/HBaseIndexWriter.java
+++ b/src/plugin/indexer-hbase/src/java/org/apache/nutch/indexwriter/hbase/HBaseIndexWriter.java
@@ -53,6 +53,7 @@ public class HBaseIndexWriter implements IndexWriter {
   private HBaseAdmin hBaseAdmin;
   private HTable hTable;
   private static List<Put> puts = new ArrayList<Put>();
+  private static long documentCount = 0L;
 
   @Override
   public Configuration getConf() {
@@ -114,6 +115,7 @@ public class HBaseIndexWriter implements IndexWriter {
           Bytes.toBytes(entry.getValue().toString()));
       puts.add(put);
     }
+    documentCount++;
     if (puts.size() >= batchSize) {
       commit();
     }
@@ -133,17 +135,18 @@ public class HBaseIndexWriter implements IndexWriter {
   @Override
   public void commit() throws IOException {
     if (!puts.isEmpty()) {
-      int documentCount = puts.size(); 
       hTable.put(puts);
       puts.clear();
-      LOG.info("Total {} {} added.", documentCount, 
-              (documentCount > 1 ? "documents are" : "document is"));
     }
   }
 
   @Override
   public void close() throws IOException {
     commit();
+    if(documentCount > 0L) {
+      LOG.info("Total {} {} added.", documentCount,
+          (documentCount > 1 ? "documents are" : "document is"));
+    }
     hTable.close();
     hBaseAdmin.close();
   }

--- a/src/plugin/indexer-hbase/src/java/org/apache/nutch/indexwriter/hbase/HBaseIndexWriter.java
+++ b/src/plugin/indexer-hbase/src/java/org/apache/nutch/indexwriter/hbase/HBaseIndexWriter.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 
 public class HBaseIndexWriter implements IndexWriter {
 
-  private static final Logger LOG = LoggerFactory
+  public static final Logger LOG = LoggerFactory
       .getLogger(MethodHandles.lookup().lookupClass());
 
   private Configuration config;
@@ -108,7 +108,6 @@ public class HBaseIndexWriter implements IndexWriter {
     byte[] rowKey = Bytes.toBytes(doc.getFieldValue(hbaseMapping.getRowKey()));
     while (entries.hasNext()) {
       Entry<String, List<String>> entry = entries.next();
-      LOG.debug("{} => {}", entry.getKey(), entry.getValue());
       Put put = new Put(rowKey);
       put.add(Bytes.toBytes(hbaseMapping.getFamily(entry.getKey())),
           Bytes.toBytes(hbaseMapping.getMappedKey(entry.getKey())),
@@ -134,8 +133,11 @@ public class HBaseIndexWriter implements IndexWriter {
   @Override
   public void commit() throws IOException {
     if (!puts.isEmpty()) {
+      int documentCount = puts.size(); 
       hTable.put(puts);
       puts.clear();
+      LOG.info("Total {} {} added.", documentCount, 
+              (documentCount > 1 ? "documents are" : "document is"));
     }
   }
 

--- a/src/plugin/indexer-hbase/src/java/org/apache/nutch/indexwriter/hbase/HBaseIndexWriter.java
+++ b/src/plugin/indexer-hbase/src/java/org/apache/nutch/indexwriter/hbase/HBaseIndexWriter.java
@@ -108,7 +108,7 @@ public class HBaseIndexWriter implements IndexWriter {
     byte[] rowKey = Bytes.toBytes(doc.getFieldValue(hbaseMapping.getRowKey()));
     while (entries.hasNext()) {
       Entry<String, List<String>> entry = entries.next();
-      LOG.info("{} => {}", entry.getKey(), entry.getValue());
+      LOG.debug("{} => {}", entry.getKey(), entry.getValue());
       Put put = new Put(rowKey);
       put.add(Bytes.toBytes(hbaseMapping.getFamily(entry.getKey())),
           Bytes.toBytes(hbaseMapping.getMappedKey(entry.getKey())),

--- a/src/plugin/indexer-hbase/src/java/org/apache/nutch/indexwriter/hbase/HBaseMappingReader.java
+++ b/src/plugin/indexer-hbase/src/java/org/apache/nutch/indexwriter/hbase/HBaseMappingReader.java
@@ -82,19 +82,19 @@ public class HBaseMappingReader {
           .getElementsByTagName(HBaseConstants.TAG_TABLE);
       if (tableItems.getLength() == 0) {
         LOG.warn(
-            "No table definition found in hbase index mapping, using default table name: '"
-                + HBaseConstants.DEFAULT_ROW_KEY + "'");
+            "No table definition found in hbase index mapping, using default table name: '{}'",
+            HBaseConstants.DEFAULT_ROW_KEY);
       } else if (tableItems.getLength() > 1) {
         LOG.warn(
-            "More than one table definition found in hbase index mapping, using default table name: '"
-                + HBaseConstants.DEFAULT_ROW_KEY + "'");
+            "More than one table definition found in hbase index mapping, using default table name: '{}'",
+            HBaseConstants.DEFAULT_ROW_KEY);
       } else {
         Element tableElement = (Element) tableItems.item(0);
         tableName = tableElement.getAttribute(HBaseConstants.ATTR_NAME);
         if (tableName.isEmpty()) {
           LOG.warn(
-              "Table name not found/empty in hbase index mapping, using default table name: '"
-                  + HBaseConstants.DEFAULT_ROW_KEY + "'");
+              "Table name not found/empty in hbase index mapping, using default table name: '{}'",
+              HBaseConstants.DEFAULT_ROW_KEY);
           tableName = HBaseConstants.DEFAULT_TABLE_NAME;
         }
       }
@@ -106,15 +106,14 @@ public class HBaseMappingReader {
         String src = fieldElement.getAttribute(HBaseConstants.ATTR_SRC);
         String columnFamily = fieldElement
             .getAttribute(HBaseConstants.ATTR_FAMILY);
-        if(defaultFamily == null) {
+        if (defaultFamily == null) {
           defaultFamily = columnFamily;
         }
         String qualifier = fieldElement
             .getAttribute(HBaseConstants.ATTR_QUALIFIER);
-        LOG.info("Field source: " + src + ", dest: "
-            + fieldElement.getAttribute(HBaseConstants.ATTR_DEST)
-            + ", column-family: " + columnFamily + ", qualifier: " + qualifier);
-
+        LOG.info("Field source: {}, dest: {}, column-family: {}, qualifier: {}",
+            src, fieldElement.getAttribute(HBaseConstants.ATTR_DEST),
+            columnFamily, qualifier);
         keyMap.put(src, qualifier.isEmpty()
             ? fieldElement.getAttribute(HBaseConstants.ATTR_DEST) : qualifier);
         if (!columnFamily.isEmpty()) {
@@ -126,28 +125,28 @@ public class HBaseMappingReader {
           .getElementsByTagName(HBaseConstants.TAG_ROW);
       if (rowItems.getLength() > 1) {
         LOG.warn(
-            "More than one row key definitions found in hbase index mapping, using default configuration '"
-                + HBaseConstants.DEFAULT_ROW_KEY + "'");
+            "More than one row key definitions found in hbase index mapping, using default configuration '{}'",
+            HBaseConstants.DEFAULT_ROW_KEY);
       } else if (rowItems.getLength() == 0) {
         LOG.warn(
-            "No row key definitions found in hbase index mapping, using default configuration '"
-                + HBaseConstants.DEFAULT_ROW_KEY + "'");
+            "No row key definitions found in hbase index mapping, using default configuration '{}'",
+            HBaseConstants.DEFAULT_ROW_KEY);
       } else {
         rowKey = ((Element) rowItems.item(0)).getTextContent();
         if (rowKey.isEmpty()) {
           LOG.warn(
-              "Row key is not found/empty in hbase index mapping, using default configuration '"
-                  + HBaseConstants.DEFAULT_ROW_KEY + "'");
+              "Row key is not found/empty in hbase index mapping, using default configuration '{}'",
+              HBaseConstants.DEFAULT_ROW_KEY);
           rowKey = HBaseConstants.DEFAULT_ROW_KEY;
         }
       }
 
     } catch (SAXException ex) {
-      LOG.warn(ex.toString());
+      LOG.warn("{}", ex.toString());
     } catch (IOException ex) {
-      LOG.warn(ex.toString());
+      LOG.warn("{}", ex.toString());
     } catch (ParserConfigurationException ex) {
-      LOG.warn(ex.toString());
+      LOG.warn("{}", ex.toString());
     }
   }
 

--- a/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpBase.java
+++ b/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpBase.java
@@ -354,7 +354,7 @@ public abstract class HttpBase implements Protocol {
 
   public String getUserAgent() {
     if (userAgentNames!=null) {
-      return userAgentNames.get(ThreadLocalRandom.current().nextInt(userAgentNames.size()-1));
+      return userAgentNames.get(ThreadLocalRandom.current().nextInt(userAgentNames.size()));
     }
     return userAgent;
   }

--- a/src/plugin/urlnormalizer-basic/src/java/org/apache/nutch/net/urlnormalizer/basic/BasicURLNormalizer.java
+++ b/src/plugin/urlnormalizer-basic/src/java/org/apache/nutch/net/urlnormalizer/basic/BasicURLNormalizer.java
@@ -79,7 +79,7 @@ public class BasicURLNormalizer extends Configured implements URLNormalizer {
     if ("http".equals(protocol) || "https".equals(protocol)
         || "ftp".equals(protocol)) {
 
-      if (host != null) {
+      if (host != null && url.getAuthority() != null) {
         String newHost = host.toLowerCase(Locale.ROOT); // lowercase host
         if (!host.equals(newHost)) {
           host = newHost;
@@ -89,6 +89,9 @@ public class BasicURLNormalizer extends Configured implements URLNormalizer {
           // etc.) which will likely cause a change if left away
           changed = true;
         }
+      } else {
+        // no host or authority: recompose the URL from components
+        changed = true;
       }
 
       if (port == url.getDefaultPort()) { // uses default port

--- a/src/plugin/urlnormalizer-basic/src/test/org/apache/nutch/net/urlnormalizer/basic/TestBasicURLNormalizer.java
+++ b/src/plugin/urlnormalizer-basic/src/test/org/apache/nutch/net/urlnormalizer/basic/TestBasicURLNormalizer.java
@@ -100,6 +100,12 @@ public class TestBasicURLNormalizer {
         "http://foo.com/aa/bb/foo.html");
     normalizeTest("http://foo.com/aa?referer=http://bar.com",
         "http://foo.com/aa?referer=http://bar.com");
+    // check for NPEs when normalizing URLs without host (authority)
+    normalizeTest("file:///foo/bar.txt", "file:///foo/bar.txt");
+    normalizeTest("ftp:/", "ftp:/");
+    normalizeTest("http:", "http:/");
+    normalizeTest("http:////", "http:/");
+    normalizeTest("http:///////", "http:/");
   }
 
   private void normalizeTest(String weird, String normal) throws Exception {


### PR DESCRIPTION
An index writer for HBase like index writer for Solr, ElasticSearch etc. Expected HBase table description and NutchDocument to HBase mapping is read using a _indexer-solr_ alike mapping file and write NutchDocument fields into the table of a HBase server.

TODO: Functionality to send and set kerberos authentication configuration for secure hdfs