### PR TITLE
NUTCH-2376 Improve configurability of HTTP Accept* header fields

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -313,13 +313,25 @@
   <description>Value of the "Accept-Language" request header field.
   This allows selecting non-English language as default one to retrieve.
   It is a useful setting for search engines build for certain national group.
+  To send requests without "Accept-Language" header field, thi  property must
+  be configured to contain a space character because an empty property does
+  not overwrite the default.
   </description>
 </property>
 
 <property>
   <name>http.accept</name>
   <value>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</value>
-  <description>Value of the "Accept" request header field.
+  <description>Value of the "Accept" request header field. A space character
+  as value will cause that no "Accept" header field is sent in the request.
+  </description>
+</property>
+
+<property>
+  <name>http.accept.charset</name>
+  <value>utf-8,iso-8859-1;q=0.7,*;q=0.7</value>
+  <description>Value of the "Accept-Charset" request header field. A space character
+  as value will cause that no "Accept-Charset" header field is sent in the request.
   </description>
 </property>
 

--- a/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpBase.java
+++ b/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpBase.java
@@ -94,6 +94,9 @@ public abstract class HttpBase implements Protocol {
   /** The "Accept-Language" request header value. */
   protected String acceptLanguage = "en-us,en-gb,en;q=0.7,*;q=0.3";
 
+  /** The "Accept-Language" request header value. */
+  protected String acceptCharset = "utf-8,iso-8859-1;q=0.7,*;q=0.7";
+
   /** The "Accept" request header value. */
   protected String accept = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
 
@@ -156,8 +159,10 @@ public abstract class HttpBase implements Protocol {
     this.userAgent = getAgentString(conf.get("http.agent.name"),
         conf.get("http.agent.version"), conf.get("http.agent.description"),
         conf.get("http.agent.url"), conf.get("http.agent.email"));
-    this.acceptLanguage = conf.get("http.accept.language", acceptLanguage);
-    this.accept = conf.get("http.accept", accept);
+    this.acceptLanguage = conf.get("http.accept.language", acceptLanguage)
+        .trim();
+    this.acceptCharset = conf.get("http.accept.charset", accept).trim();
+    this.accept = conf.get("http.accept", accept).trim();
     // backward-compatible default setting
     this.useHttp11 = conf.getBoolean("http.useHttp11", false);
     this.responseTime = conf.getBoolean("http.store.responsetime", true);
@@ -398,6 +403,10 @@ public abstract class HttpBase implements Protocol {
    */
   public String getAcceptLanguage() {
     return acceptLanguage;
+  }
+
+  public String getAcceptCharset() {
+    return acceptCharset;
   }
 
   public String getAccept() {

--- a/src/plugin/protocol-http/src/java/org/apache/nutch/protocol/http/HttpResponse.java
+++ b/src/plugin/protocol-http/src/java/org/apache/nutch/protocol/http/HttpResponse.java
@@ -52,8 +52,6 @@ public class HttpResponse implements Response {
   private Configuration conf;
   private HttpBase http;
   private URL url;
-  private String orig;
-  private String base;
   private byte[] content;
   private int code;
   private Metadata headers = new SpellCheckedMetadata();
@@ -78,8 +76,6 @@ public class HttpResponse implements Response {
 
     this.http = http;
     this.url = url;
-    this.orig = url.toString();
-    this.base = url.toString();
 
     Scheme scheme = null;
 
@@ -189,16 +185,31 @@ public class HttpResponse implements Response {
         reqStr.append("\r\n");
       }
 
-      reqStr.append("Accept-Language: ");
-      reqStr.append(this.http.getAcceptLanguage());
-      reqStr.append("\r\n");
+      String acceptLanguage = http.getAcceptLanguage();
+      if (!acceptLanguage.isEmpty()) {
+        reqStr.append("Accept-Language: ");
+        reqStr.append(acceptLanguage);
+        reqStr.append("\r\n");
+      }
 
-      reqStr.append("Accept: ");
-      reqStr.append(this.http.getAccept());
-      reqStr.append("\r\n");
-      
-      if (http.isCookieEnabled() && datum.getMetaData().containsKey(http.COOKIE)) {
-        String cookie = ((Text)datum.getMetaData().get(http.COOKIE)).toString();
+      String acceptCharset = http.getAcceptCharset();
+      if (!acceptCharset.isEmpty()) {
+        reqStr.append("Accept-Charset: ");
+        reqStr.append(acceptCharset);
+        reqStr.append("\r\n");
+      }
+
+      String accept = http.getAccept();
+      if (!accept.isEmpty()) {
+        reqStr.append("Accept: ");
+        reqStr.append(accept);
+        reqStr.append("\r\n");
+      }
+
+      if (http.isCookieEnabled()
+          && datum.getMetaData().containsKey(HttpBase.COOKIE)) {
+        String cookie = ((Text) datum.getMetaData().get(HttpBase.COOKIE))
+            .toString();
         reqStr.append("Cookie: ");
         reqStr.append(cookie);
         reqStr.append("\r\n");
@@ -321,11 +332,10 @@ public class HttpResponse implements Response {
         throw new HttpException("bad content length: " + contentLengthString);
       }
     }
-    if (http.getMaxContent() >= 0 && contentLength > http
-        .getMaxContent()) // limit
-      // download
-      // size
+    if (http.getMaxContent() >= 0 && contentLength > http.getMaxContent()) {
+      // limit the download size
       contentLength = http.getMaxContent();
+    }
 
     ByteArrayOutputStream out = new ByteArrayOutputStream(Http.BUFFER_SIZE);
     byte[] bytes = new byte[Http.BUFFER_SIZE];

--- a/src/plugin/protocol-httpclient/src/java/org/apache/nutch/protocol/httpclient/Http.java
+++ b/src/plugin/protocol-httpclient/src/java/org/apache/nutch/protocol/httpclient/Http.java
@@ -222,15 +222,16 @@ public class Http extends HttpBase {
 
     HostConfiguration hostConf = client.getHostConfiguration();
     ArrayList<Header> headers = new ArrayList<Header>();
-    // Set the User Agent in the header
-    // headers.add(new Header("User-Agent", userAgent)); //NUTCH-1941
-    // prefer English
-    headers.add(new Header("Accept-Language", acceptLanguage));
-    // prefer UTF-8
-    headers.add(new Header("Accept-Charset", "utf-8,ISO-8859-1;q=0.7,*;q=0.7"));
-    // prefer understandable formats
-    headers.add(new Header("Accept",
-        "text/html,application/xml;q=0.9,application/xhtml+xml,text/xml;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"));
+    // Note: some header fields (e.g., "User-Agent") are set per GET request
+    if (!acceptLanguage.isEmpty()) {
+      headers.add(new Header("Accept-Language", acceptLanguage));
+    }
+    if (!acceptCharset.isEmpty()) {
+      headers.add(new Header("Accept-Charset", acceptCharset));
+    }
+    if (!accept.isEmpty()) {
+      headers.add(new Header("Accept", accept));
+    }
     // accept gzipped content
     headers.add(new Header("Accept-Encoding", "x-gzip, gzip, deflate"));
     hostConf.getParams().setParameter("http.default-headers", headers);


### PR DESCRIPTION
- Accept, Accept-Language and Accept-Charset are configured and used the
  same way for both protocol-http and protocol-httpclient
- a space as value will unset these header fields (not sent in request)
  I've tried to overwrite the default by an empty value but that's not possible with the Hadoop configuration mechanism. Of course, one could configure instead `*` as "Accept-Language" or "Accept-Charset" (resp. `*/*` as "Accept" content type) but that will unnecessarily blow up the HTTP requests.