### PR TITLE
NUTCH-2388 bin/crawl indexing only webpages of current batch instead of all

### DIFF
--- a/src/bin/crawl
+++ b/src/bin/crawl
@@ -170,7 +170,7 @@ do
 
   if [ -n "$SOLRURL" ]; then
     echo "Indexing $CRAWL_ID on SOLR index -> $SOLRURL"
-    __bin_nutch index $commonOptions -D solr.server.url=$SOLRURL -all -crawlId "$CRAWL_ID"
+    __bin_nutch index $commonOptions -D solr.server.url=$SOLRURL $batchId -crawlId "$CRAWL_ID"
 
     echo "SOLR dedup -> $SOLRURL"
     __bin_nutch solrdedup $commonOptions $SOLRURL


### PR DESCRIPTION
During each iteration, after generating, fetching, parsing and updating the current batch into DB, the indexer is supposed to index the current batch too. But its indexing all currently.
```shell
__bin_nutch index $commonOptions -D solr.server.url=$SOLRURL -all -crawlId "$CRAWL_ID"
```

It should be like below i guess -
```shell
__bin_nutch index $commonOptions -D solr.server.url=$SOLRURL $batchId -crawlId "$CRAWL_ID"
```