### PR TITLE
NUTCH-2391 Spurious Duplications for MD5

### DIFF
--- a/src/java/org/apache/nutch/crawl/MD5Signature.java
+++ b/src/java/org/apache/nutch/crawl/MD5Signature.java
@@ -32,7 +32,7 @@ public class MD5Signature extends Signature {
 
   public byte[] calculate(Content content, Parse parse) {
     byte[] data = content.getContent();
-    if (data == null)
+    if (data == null || (data.length == 0))
       data = content.getUrl().getBytes();
     return MD5Hash.digest(data).getDigest();
   }


### PR DESCRIPTION
[NUTCH-2391](https://issues.apache.org/jira/browse/NUTCH-2391): use URL for MD5 digest as fall-back if content is empty, i.e., content length is zero (contributed by David Johnson)