### PR TITLE
Nutch 2397

### DIFF
--- a/src/plugin/parse-html/src/java/org/apache/nutch/parse/html/DOMContentUtils.java
+++ b/src/plugin/parse-html/src/java/org/apache/nutch/parse/html/DOMContentUtils.java
@@ -157,14 +157,57 @@ public class DOMContentUtils {
         text = text.replaceAll("\\s+", " ");
         text = text.trim();
         if (text.length() > 0) {
-          if (sb.length() > 0)
-            sb.append(' ');
+          appendSpace(sb);
           sb.append(text);
+        } else {
+          appendParagraphSeparator(sb);
         }
       }
     }
 
     return abort;
+  }
+
+  /**
+   * Conditionally append a paragraph/line break to StringBuffer unless last
+   * character a already indicates a paragraph break. Also remove trailing space
+   * before paragraph break.
+   *
+   * @param buffer
+   *          StringBuffer to append paragraph break
+   */
+  private void appendParagraphSeparator(StringBuffer buffer) {
+    if (buffer.length() == 0) {
+      return;
+    }
+    char lastChar = buffer.charAt(buffer.length() - 1);
+    if ('\n' != lastChar) {
+      // remove white space before paragraph break
+      while (lastChar == ' ') {
+        buffer.deleteCharAt(buffer.length() - 1);
+        lastChar = buffer.charAt(buffer.length() - 1);
+      }
+      if ('\n' != lastChar) {
+        buffer.append('\n');
+      }
+    }
+  }
+
+  /**
+   * Conditionally append a space to StringBuffer unless last character is a
+   * space or line/paragraph break.
+   *
+   * @param buffer
+   *          StringBuffer to append space
+   */
+  private void appendSpace(StringBuffer buffer) {
+    if (buffer.length() == 0) {
+      return;
+    }
+    char lastChar = buffer.charAt(buffer.length() - 1);
+    if (' ' != lastChar && '\n' != lastChar) {
+      buffer.append(' ');
+    }
   }
 
   /**

--- a/src/plugin/parse-tika/src/java/org/apache/nutch/parse/tika/DOMContentUtils.java
+++ b/src/plugin/parse-tika/src/java/org/apache/nutch/parse/tika/DOMContentUtils.java
@@ -162,16 +162,57 @@ public class DOMContentUtils {
         text = text.replaceAll("\\s+", " ");
         text = text.trim();
         if (text.length() > 0) {
-          if (sb.length() > 0)
-            sb.append(' ');
+          appendSpace(sb);
           sb.append(text);
         } else {
-          sb.append("\n");
+          appendParagraphSeparator(sb);
         }
       }
     }
 
     return abort;
+  }
+
+  /**
+   * Conditionally append a paragraph/line break to StringBuffer unless last
+   * character a already indicates a paragraph break. Also remove trailing space
+   * before paragraph break.
+   *
+   * @param buffer
+   *          StringBuffer to append paragraph break
+   */
+  private void appendParagraphSeparator(StringBuffer buffer) {
+    if (buffer.length() == 0) {
+      return;
+    }
+    char lastChar = buffer.charAt(buffer.length() - 1);
+    if ('\n' != lastChar) {
+      // remove white space before paragraph break
+      while (lastChar == ' ') {
+        buffer.deleteCharAt(buffer.length() - 1);
+        lastChar = buffer.charAt(buffer.length() - 1);
+      }
+      if ('\n' != lastChar) {
+        buffer.append('\n');
+      }
+    }
+  }
+
+  /**
+   * Conditionally append a space to StringBuffer unless last character is a
+   * space or line/paragraph break.
+   *
+   * @param buffer
+   *          StringBuffer to append space
+   */
+  private void appendSpace(StringBuffer buffer) {
+    if (buffer.length() == 0) {
+      return;
+    }
+    char lastChar = buffer.charAt(buffer.length() - 1);
+    if (' ' != lastChar && '\n' != lastChar) {
+      buffer.append(' ');
+    }
   }
 
   /**

--- a/src/plugin/parse-zip/src/test/org/apache/nutch/parse/zip/TestZipParser.java
+++ b/src/plugin/parse-zip/src/test/org/apache/nutch/parse/zip/TestZipParser.java
@@ -46,7 +46,7 @@ public class TestZipParser {
 
   private String[] sampleFiles = { "test.zip" };
 
-  private String expectedText = "textfile.txt This is text file number 1 ";
+  private String expectedText = "textfile.txt This is text file number 1";
 
   @Test
   public void testIt() throws ProtocolException, ParseException {
@@ -64,7 +64,10 @@ public class TestZipParser {
           new CrawlDatum()).getContent();
       parse = new ParseUtil(conf).parseByExtensionId("parse-zip", content).get(
           content.getUrl());
-      Assert.assertTrue(parse.getText().equals(expectedText));
+      Assert.assertTrue(
+          "Extracted text does not start with <" + expectedText + ">: <"
+              + parse.getText() + ">",
+          parse.getText().startsWith(expectedText));
     }
   }
 


### PR DESCRIPTION
(improved solution contributed by Vipul Behl):
 - do not add superfluous line breaks and space in parsed text
 - fix units tests
 - also fix parse-html in addition to parse-tika