### PR TITLE
NUTCH-2398: Save content of redirected robots.txt under redirect target URL

### DIFF
--- a/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpRobotRulesParser.java
+++ b/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpRobotRulesParser.java
@@ -147,7 +147,7 @@ public class HttpRobotRulesParser extends RobotRulesParser {
             response = ((HttpBase) http).getResponse(redir, new CrawlDatum(),
                 true);
             if (robotsTxtContent != null) {
-              addRobotsContent(robotsTxtContent, robotsUrl, response);
+              addRobotsContent(robotsTxtContent, redir, response);
             }
           }
         }


### PR DESCRIPTION
do not use original URL (http://example.com/robots.txt) to store both
redirect response (HTTP 301) and response of redirect target

See also commoncrawl/nutch#4.