### PR TITLE
NUTCH-2403: Fix spelling of phantomJS configuration

### DIFF
--- a/src/plugin/protocol-selenium/README.md
+++ b/src/plugin/protocol-selenium/README.md
@@ -14,7 +14,7 @@ There are essentially two ways in which Nutch can be used with Selenium.
 
 # Installation
 
-## Part 1: 
+## Part 1:
 
 ### A) Setting up Selenium (local mode)
 
@@ -34,34 +34,34 @@ sudo apt-get install xorg synaptic xvfb gtk2-engines-pixbuf xfonts-cyrillic xfon
 ```
 
  * Set a display for Xvfb, so that firefox believes a display is connected
- 
+
 ```
 sudo /usr/bin/Xvfb :11 -screen 0 1024x768x24 &
 sudo export DISPLAY=:11
 ```
-### B) Setting up a Selenium Grid 
+### B) Setting up a Selenium Grid
 
-Using the Selenium Grid will allow you to parallelize the job by facilitating access of several instances of browsers whether on one machine or on several machines. Note that grid facilitates heterogeneity with regards to browser types used. However, these steps have been tested using a homogenous Selenium Grid with Firefox and PhantomJS browsers. 
+Using the Selenium Grid will allow you to parallelize the job by facilitating access of several instances of browsers whether on one machine or on several machines. Note that grid facilitates heterogeneity with regards to browser types used. However, these steps have been tested using a homogenous Selenium Grid with Firefox and PhantomJS browsers.
 
  * Download the [Selenium Standalone Server](http://www.seleniumhq.org/download/) and follow the installation instructions.
- 
+
  * Some important configurations to note while setting up the selenium-hub and the selenium-nodes are:
-    * For the hub: 
+    * For the hub:
       - maxSession (how many browser sessions to allow on the grid at a time)
       - browserTimeout (how long to wait before timing out a browser session. This is dependent on the interactivity to be completed on the page)
-      
+
     * For the nodes:
       - browserName=<browser>, maxInstances (the max number of instances of the same version browser to allow per a system)
       - browserName=<browser>, maxSession (the max number of sessions of any type of browser/version to allow per a system)
-      
-  * Go headless with your selenium Grid installation. There are different ways to this. See [this resource](http://elementalselenium.com/tips/38-headless) for further details. 
- 
+
+  * Go headless with your selenium Grid installation. There are different ways to this. See [this resource](http://elementalselenium.com/tips/38-headless) for further details.
+
   * For Nutch efficiency, and optimization of the grid, consider editing the following configs in **nutch-site.xml**
     - fetcher.threads.per.queue (change value to the value of the maxSession config on the hub)
     - fetcher.threads.fetch (change value to the value of the maxSession config on the hub)
     - fetcher.server.delay (As multiple threads may be accessing a single server at a time, consider changing this value to 4-5 seconds for politeness)
     - fetcher.server.min.delay (As multiple threads may be accessing a single server at a time, consider changing this values to 4-5 seconds for politeness)
-    - Ensure all configs for the hub mentioned in Part 2 are appropriately set. 
+    - Ensure all configs for the hub mentioned in Part 2 are appropriately set.
 
   * To activate the full selenium grid, edit **$NUTCH_HOME/runtime/local/bin/crawl** script:
     - numThreads = maxSession on nodes * num of nodes
@@ -83,8 +83,8 @@ Using the Selenium Grid will allow you to parallelize the job by facilitating ac
     include.  Any plugin not matching this expression is excluded.
     In any case you need at least include the nutch-extensionpoints plugin. By
     default Nutch includes crawling just HTML and plain text via HTTP,
-    and basic indexing and search plugins. In order to use HTTPS please enable 
-    protocol-httpclient, but be aware of possible intermittent problems with the 
+    and basic indexing and search plugins. In order to use HTTPS please enable
+    protocol-httpclient, but be aware of possible intermittent problems with the
     underlying commons-httpclient library.
     </description>
   </property>
@@ -99,9 +99,9 @@ Using the Selenium Grid will allow you to parallelize the job by facilitating ac
   <name>selenium.driver</name>
   <value>firefox</value>
   <description>
-    A String value representing the flavour of Selenium 
+    A String value representing the flavour of Selenium
     WebDriver() to use. Currently the following options
-    exist - 'firefox', 'chrome', 'safari', 'opera', 'phantomJS', and 'remote'.
+    exist - 'firefox', 'chrome', 'safari', 'opera', 'phantomjs', and 'remote'.
     If 'remote' is used it is essential to also set correct properties for
     'selenium.hub.port', 'selenium.hub.path', 'selenium.hub.host' and
     'selenium.hub.protocol'.
@@ -114,8 +114,8 @@ Using the Selenium Grid will allow you to parallelize the job by facilitating ac
   <description>
     Boolean property determining whether the protocol-selenium
     WebDriver should capture a screenshot of the URL. If set to
-    true remember to define the 'selenium.screenshot.location' 
-    property as this determines the location screenshots should be 
+    true remember to define the 'selenium.screenshot.location'
+    property as this determines the location screenshots should be
     persisted to on HDFS. If that property is not set, screenshots
     are simply discarded.
   </description>
@@ -159,15 +159,15 @@ Using the Selenium Grid will allow you to parallelize the job by facilitating ac
 <property>
   <name>selenium.grid.driver</name>
   <value>firefox</value>
-  <description>A String value representing the flavour of Selenium 
+  <description>A String value representing the flavour of Selenium
     WebDriver() used on the selenium grid. Currently the following options
-    exist - 'firefox' or 'phantomJS' </description>
+    exist - 'firefox' or 'phantomjs' </description>
 </property>
 
 <property>
   <name>selenium.grid.binary</name>
   <value></value>
-  <description>A String value representing the path to the browser binary 
+  <description>A String value representing the path to the browser binary
     location for each node
  </description>
 </property>
@@ -195,12 +195,12 @@ ant runtime
 
 ## Part 3: Common Pitfalls
 
-* Be sure your browser version and selenium version are compatible (See list in 'Tested configurations' section below) 
+* Be sure your browser version and selenium version are compatible (See list in 'Tested configurations' section below)
 * Be sure to start the Xvfb window then start selenium (not a necessary step for PhantomJS)
-* Disconnecting and reconnect nodes after a hub config change has proven useful in our tests. 
-* Be sure that each browser session deallocates its webdriver resource independently of any other tests running on other broswers (check out driver.quit() and driver.close()). 
+* Disconnecting and reconnect nodes after a hub config change has proven useful in our tests.
+* Be sure that each browser session deallocates its webdriver resource independently of any other tests running on other broswers (check out driver.quit() and driver.close()).
 
-### Tested configurations 
+### Tested configurations
 
 * Firefox 31.4.0 and Selenium 2.48.2
 * PhantomJS 2.1.1 and Selenium 2.48.2


### PR DESCRIPTION
The Nutch Selenium documentation states that PhantomJS can be used as `phantomJS` for `selenium.driver`. The correct value would be `phantomjs` according to https://github.com/apache/nutch/blob/master/src/plugin/lib-selenium/src/java/org/apache/nutch/protocol/selenium/HttpWebClient.java#L124