### PR TITLE
NUTCH-2414 - Allow LanguageIndexingFilter to actually filter documents by language

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1566,6 +1566,16 @@ visit https://wiki.apache.org/nutch/SimilarityScoringFilter-->
   </description>
 </property>
 
+<property>
+  <name>lang.index.languages</name>
+  <value></value>
+  <description>If not empty, should be a comma separated list of language codes.
+  Only documents with one of these language codes will be indexed.
+  "unknown" is a valid language code, will match documents where language
+  detection failed.
+  </description>
+</property>
+
 <!-- index-static plugin properties -->
 
 <property>

--- a/src/plugin/language-identifier/src/java/org/apache/nutch/analysis/lang/LanguageIndexingFilter.java
+++ b/src/plugin/language-identifier/src/java/org/apache/nutch/analysis/lang/LanguageIndexingFilter.java
@@ -27,6 +27,9 @@ import org.apache.nutch.parse.Parse;
 import org.apache.nutch.metadata.Metadata;
 import org.apache.nutch.net.protocols.Response;
 
+import java.util.HashSet;
+import java.util.Set;
+
 // Hadoop imports
 import org.apache.hadoop.conf.Configuration;
 
@@ -49,6 +52,7 @@ import org.apache.hadoop.conf.Configuration;
 public class LanguageIndexingFilter implements IndexingFilter {
 
   private Configuration conf;
+  private Set<String> indexLangs;
 
   /**
    * Constructs a new Language Indexing Filter.
@@ -73,6 +77,10 @@ public class LanguageIndexingFilter implements IndexingFilter {
       lang = "unknown";
     }
 
+    if (!indexLangs.isEmpty() && !indexLangs.contains(lang)) {
+    	return null;
+    }
+    
     doc.add("lang", lang);
 
     return doc;
@@ -80,6 +88,7 @@ public class LanguageIndexingFilter implements IndexingFilter {
 
   public void setConf(Configuration conf) {
     this.conf = conf;
+    indexLangs = new HashSet<>(conf.getStringCollection("lang.index.languages"));
   }
 
   public Configuration getConf() {


### PR DESCRIPTION
Added property lang.index.languages. If exists and is not empty, it is treated as a comma-separated list of languages to index. A document in another language will not be indexed.
"unknown" is a valid language code.