### PR TITLE
Nutch 2433 - New configuration for HTML parser to keep the HTML nodes in outlinks metadata

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1309,7 +1309,7 @@
 
 <property>
 	<name>parser.html.outlinks.htmlnode_metadata_name</name>
-	<value>htmlnode</value>
+	<value></value>
 	<description>if not empty, the source nodename of a found outlink will
 		be set in the metadata with this name into the outlink</description>
 </property>

--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1308,6 +1308,13 @@
 </property>
 
 <property>
+	<name>parser.html.outlinks.htmlnode_metadata_name</name>
+	<value>htmlnode</value>
+	<description>if not empty, the source nodename of a found outlink will
+		be set in the metadata with this name into the outlink</description>
+</property>
+
+<property>
   <name>htmlparsefilter.order</name>
   <value></value>
   <description>The order by which HTMLParse filters are applied.

--- a/src/plugin/parse-html/src/java/org/apache/nutch/parse/html/DOMContentUtils.java
+++ b/src/plugin/parse-html/src/java/org/apache/nutch/parse/html/DOMContentUtils.java
@@ -436,15 +436,16 @@ public class DOMContentUtils {
               try {
 
                 URL url = URLUtil.resolveURL(base, target);
-                outlinks.add(new Outlink(url.toString(), linkText.toString()
-                    .trim()));
-										
-                // NUTCH-2433 - Keep the node name where the URL was found into 
+                Outlink outlink = new Outlink(url.toString(), linkText
+                    .toString().trim());
+                outlinks.add(outlink);
+
+                // NUTCH-2433 - Keep the node name where the URL was found into
                 // the outlink metadata
                 if (keepNodenames) {
                   MapWritable metadata = new MapWritable();
                   metadata.put(new Text(srcTagMetaName), new Text(nodeName));
-                  outlinks.get(outlinks.size() - 1).setMetadata(metadata);
+                  outlink.setMetadata(metadata);
                 }
 
               } catch (MalformedURLException e) {

--- a/src/plugin/parse-html/src/java/org/apache/nutch/parse/html/DOMContentUtils.java
+++ b/src/plugin/parse-html/src/java/org/apache/nutch/parse/html/DOMContentUtils.java
@@ -28,6 +28,8 @@ import org.apache.nutch.parse.Outlink;
 import org.apache.nutch.util.NodeWalker;
 import org.apache.nutch.util.URLUtil;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.MapWritable;
+import org.apache.hadoop.io.Text;
 
 import org.w3c.dom.*;
 
@@ -39,6 +41,9 @@ import org.w3c.dom.*;
  * 
  */
 public class DOMContentUtils {
+  
+  private String srcTagMetaName;
+  private boolean keepNodenames;
 
   public static class LinkParams {
     public String elName;
@@ -88,6 +93,11 @@ public class DOMContentUtils {
       if (!forceTags.contains(ignoreTags[i]))
         linkParams.remove(ignoreTags[i]);
     }
+    
+    //NUTCH-2433 - Should we keep the html node where the outlinks are found?
+    srcTagMetaName = this.conf
+        .get("parser.html.outlinks.htmlnode_metadata_name");
+    keepNodenames = (srcTagMetaName != null && srcTagMetaName.length() > 0);
   }
 
   /**
@@ -428,6 +438,15 @@ public class DOMContentUtils {
                 URL url = URLUtil.resolveURL(base, target);
                 outlinks.add(new Outlink(url.toString(), linkText.toString()
                     .trim()));
+										
+                // NUTCH-2433 - Keep the node name where the URL was found into 
+                // the outlink metadata
+                if (keepNodenames) {
+                  MapWritable metadata = new MapWritable();
+                  metadata.put(new Text(srcTagMetaName), new Text(nodeName));
+                  outlinks.get(outlinks.size() - 1).setMetadata(metadata);
+                }
+
               } catch (MalformedURLException e) {
                 // don't care
               }


### PR DESCRIPTION
New configuration for HTML parser to keep the HTML nodes where outlinks are found, into their metadata.
