### PR TITLE
NUTCH-2443 add source tag to the parse-html/tika outlink extractor

### DIFF
--- a/src/plugin/parse-html/src/java/org/apache/nutch/parse/html/DOMContentUtils.java
+++ b/src/plugin/parse-html/src/java/org/apache/nutch/parse/html/DOMContentUtils.java
@@ -86,6 +86,7 @@ public class DOMContentUtils {
     linkParams.put("script", new LinkParams("script", "src", 0));
     linkParams.put("link", new LinkParams("link", "href", 0));
     linkParams.put("img", new LinkParams("img", "src", 0));
+    linkParams.put("source", new LinkParams("source", "src", 0));
 
     // remove unwanted link tags from the linkParams map
     String[] ignoreTags = conf.getStrings("parser.html.outlinks.ignore_tags");

--- a/src/plugin/parse-html/src/test/org/apache/nutch/parse/html/TestDOMContentUtils.java
+++ b/src/plugin/parse-html/src/test/org/apache/nutch/parse/html/TestDOMContentUtils.java
@@ -127,7 +127,11 @@ public class TestDOMContentUtils {
           + "<a href=\"g\"><!--no anchor--></a>"
           + "<a href=\"g1\"> <!--whitespace-->  </a>"
           + "<a href=\"g2\">  <img src=test.gif alt='bla bla'> </a>"
-          + "</body></html>"), };
+          + "</body></html>"),
+      new String("<html><head><title> </title>" + "</head><body> "
+          + "<video width=\"320\" height=\"240\" controls> "
+          + "<source src=\"movie.mp4\" type=\"video/mp4\">"
+          + "</video>" + "</body></html>"), };
 
   private static int SKIP = 9;
 
@@ -137,7 +141,8 @@ public class TestDOMContentUtils {
       "http://www.nutch.org/maps/", "http://www.nutch.org/whitespace/",
       "http://www.nutch.org//", "http://www.nutch.org/",
       "http://www.nutch.org/", "http://www.nutch.org/",
-      "http://www.nutch.org/;something", "http://www.nutch.org/" };
+      "http://www.nutch.org/;something", "http://www.nutch.org/",
+      "http://www.nutch.org/" };
 
   private static final DocumentFragment testDOMs[] = new DocumentFragment[testPages.length];
 
@@ -157,11 +162,11 @@ public class TestDOMContentUtils {
           + "one two two three three four put some text here and there. "
           + "End this madness ! . . . .", "ignore ignore", "test1 test2",
       "test1 test2", "title anchor1 anchor2 anchor3",
-      "title anchor1 anchor2 anchor3 anchor4 anchor5", "title" };
+      "title anchor1 anchor2 anchor3 anchor4 anchor5", "title", "" };
 
   private static final String[] answerTitle = { "title", "title", "",
       "my title", "my title", "my title", "my title", "", "", "", "title",
-      "title", "title" };
+      "title", "title", "" };
 
   // note: should be in page-order
   private static Outlink[][] answerOutlinks;
@@ -231,7 +236,8 @@ public class TestDOMContentUtils {
           { new Outlink("http://www.nutch.org/g", ""),
               new Outlink("http://www.nutch.org/g1", ""),
               new Outlink("http://www.nutch.org/g2", "bla bla"),
-              new Outlink("http://www.nutch.org/test.gif", "bla bla"), } };
+              new Outlink("http://www.nutch.org/test.gif", "bla bla"), },
+          { new Outlink("http://www.nutch.org/movie.mp4", "") } };
 
     } catch (MalformedURLException e) {
 

--- a/src/plugin/parse-tika/src/java/org/apache/nutch/parse/tika/DOMContentUtils.java
+++ b/src/plugin/parse-tika/src/java/org/apache/nutch/parse/tika/DOMContentUtils.java
@@ -90,6 +90,7 @@ public class DOMContentUtils {
     linkParams.put("script", new LinkParams("script", "src", 0));
     linkParams.put("link", new LinkParams("link", "href", 0));
     linkParams.put("img", new LinkParams("img", "src", 0));
+    linkParams.put("source", new LinkParams("source", "src", 0));
 
     // remove unwanted link tags from the linkParams map
     String[] ignoreTags = conf.getStrings("parser.html.outlinks.ignore_tags");

--- a/src/plugin/parse-tika/src/test/org/apache/nutch/tika/TestDOMContentUtils.java
+++ b/src/plugin/parse-tika/src/test/org/apache/nutch/tika/TestDOMContentUtils.java
@@ -130,7 +130,11 @@ public class TestDOMContentUtils {
       new String("<html><head><title> title </title>" + "</head><body>"
           + "<a href=\"g\">anchor1</a>" + "<a href=\"g?y#s\">anchor2</a>"
           + "<a href=\"?y=1\">anchor3</a>" + "<a href=\"?y=1#s\">anchor4</a>"
-          + "<a href=\"?y=1;somethingelse\">anchor5</a>" + "</body></html>"), };
+          + "<a href=\"?y=1;somethingelse\">anchor5</a>" + "</body></html>"),
+      new String("<html><head><title> </title>" + "</head><body> "
+          + "<video width=\"320\" height=\"240\" controls> "
+          + "<source src=\"movie.mp4\" type=\"video/mp4\">"
+          + "</video>" + "</body></html>"), };
 
   private static int SKIP = 9;
 
@@ -140,7 +144,7 @@ public class TestDOMContentUtils {
       "http://www.nutch.org/maps/", "http://www.nutch.org/whitespace/",
       "http://www.nutch.org//", "http://www.nutch.org/",
       "http://www.nutch.org/", "http://www.nutch.org/",
-      "http://www.nutch.org/;something" };
+      "http://www.nutch.org/;something", "http://www.nutch.org/" };
 
   private static final DocumentFragment testDOMs[] = new DocumentFragment[testPages.length];
 
@@ -160,11 +164,11 @@ public class TestDOMContentUtils {
           + "one two two three three four put some text here and there. "
           + "End this madness ! . . . .", "ignore ignore", "test1 test2",
       "test1 test2", "title anchor1 anchor2 anchor3",
-      "title anchor1 anchor2 anchor3 anchor4 anchor5" };
+      "title anchor1 anchor2 anchor3 anchor4 anchor5", "" };
 
   private static final String[] answerTitle = { "title", "title", "",
       "my title", "my title", "my title", "my title", "", "", "", "title",
-      "title" };
+      "title", "" };
 
   // note: should be in page-order
   private static Outlink[][] answerOutlinks;
@@ -225,7 +229,8 @@ public class TestDOMContentUtils {
             new Outlink("http://www.nutch.org/;something?y=1", "anchor3"),
             new Outlink("http://www.nutch.org/;something?y=1#s", "anchor4"),
             new Outlink("http://www.nutch.org/;something?y=1;somethingelse",
-                "anchor5") } };
+                "anchor5") },
+        { new Outlink("http://www.nutch.org/movie.mp4", "") } };
 
   }
 


### PR DESCRIPTION
Add support for the `video`/`source` tag in the outlink extractor of the `parse-html` and `parse-tika` plugin. 