### PR TITLE
NUTCH-2448: Treat white-space http.agent.version as empty.

### DIFF
--- a/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpBase.java
+++ b/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpBase.java
@@ -438,7 +438,7 @@ public abstract class HttpBase implements Protocol {
     StringBuffer buf = new StringBuffer();
 
     buf.append(agentName);
-    if (agentVersion != null) {
+    if (agentVersion != null && !agentVersion.trim().isEmpty()) {
       buf.append("/");
       buf.append(agentVersion);
     }


### PR DESCRIPTION
(And do not append a slash to http.agent.name.)