### PR TITLE
NUTCH-2242 Injector to stop if job fails to avoid loss of CrawlDb

### DIFF
--- a/src/java/org/apache/nutch/hostdb/ReadHostDb.java
+++ b/src/java/org/apache/nutch/hostdb/ReadHostDb.java
@@ -202,8 +202,17 @@ public class ReadHostDb extends Configured implements Tool {
     job.setNumReduceTasks(0);
 
     try {
-      job.waitForCompletion(true);
-    } catch (Exception e) {
+      boolean success = job.waitForCompletion(true);
+      if(!success){
+        String message = "ReadHostDb job did not succeed, job status: "
+            + job.getStatus().getState() + ", reason: "
+            + job.getStatus().getFailureInfo();
+        LOG.error(message);
+        // throw exception so that calling routine can exit with error
+        throw new RuntimeException(message);
+      }
+    } catch (IOException | InterruptedException | ClassNotFoundException e) {
+      LOG.error("ReadHostDb job failed", e);
       throw e;
     }
 

--- a/src/java/org/apache/nutch/util/CrawlCompletionStats.java
+++ b/src/java/org/apache/nutch/util/CrawlCompletionStats.java
@@ -171,8 +171,17 @@ public class CrawlCompletionStats extends Configured implements Tool {
     job.setNumReduceTasks(numOfReducers);
 
     try {
-      job.waitForCompletion(true);
-    } catch (Exception e) {
+      boolean success = job.waitForCompletion(true);
+      if(!success){
+        String message = jobName + " job did not succeed, job status: "
+            + job.getStatus().getState() + ", reason: "
+            + job.getStatus().getFailureInfo();
+        LOG.error(message);
+        // throw exception so that calling routine can exit with error
+        throw new RuntimeException(message);
+      }
+    } catch (IOException | InterruptedException | ClassNotFoundException e) {
+      LOG.error(jobName + " job failed");
       throw e;
     }
 

--- a/src/java/org/apache/nutch/util/ProtocolStatusStatistics.java
+++ b/src/java/org/apache/nutch/util/ProtocolStatusStatistics.java
@@ -122,8 +122,17 @@ public class ProtocolStatusStatistics extends Configured implements Tool {
     job.setNumReduceTasks(numOfReducers);
 
     try {
-      job.waitForCompletion(true);
-    } catch (Exception e) {
+      boolean success = job.waitForCompletion(true);
+      if(!success){
+        String message = jobName + " job did not succeed, job status: "
+            + job.getStatus().getState() + ", reason: "
+            + job.getStatus().getFailureInfo();
+        LOG.error(message);
+        // throw exception so that calling routine can exit with error
+        throw new RuntimeException(message);
+      }
+    } catch (IOException | InterruptedException | ClassNotFoundException e) {
+      LOG.error(jobName + " job failed", e);
       throw e;
     }
 

--- a/src/java/org/apache/nutch/util/SitemapProcessor.java
+++ b/src/java/org/apache/nutch/util/SitemapProcessor.java
@@ -358,7 +358,16 @@ public class SitemapProcessor extends Configured implements Tool {
     job.setReducerClass(SitemapReducer.class);
 
     try {
-      job.waitForCompletion(true);
+      boolean success = job.waitForCompletion(true);
+      if(!success){
+        String message = "SitemapProcessor_" + crawldb.toString() + " job did not succeed, job status: "
+            + job.getStatus().getState() + ", reason: "
+            + job.getStatus().getFailureInfo();
+        LOG.error(message);
+        cleanupAfterFailure(tempCrawlDb, lock, fs);
+        // throw exception so that calling routine can exit with error
+        throw new RuntimeException(message); 
+      }
 
       boolean preserveBackup = conf.getBoolean("db.preserve.backup", true);
       if (!preserveBackup && fs.exists(old))
@@ -385,11 +394,21 @@ public class SitemapProcessor extends Configured implements Tool {
         long end = System.currentTimeMillis();
         LOG.info("SitemapProcessor: Finished at {}, elapsed: {}", sdf.format(end), TimingUtil.elapsedTime(start, end));
       }
-    } catch (Exception e) {
-      if (fs.exists(tempCrawlDb))
-        fs.delete(tempCrawlDb, true);
+    } catch (IOException | InterruptedException | ClassNotFoundException e) {
+      LOG.error("SitemapProcessor_" + crawldb.toString(), e);
+      cleanupAfterFailure(tempCrawlDb, lock, fs);
+      throw e;
+    }
+  }
 
+  public void cleanupAfterFailure(Path tempCrawlDb, Path lock, FileSystem fs)
+         throws IOException {
+    try{
+      if (fs.exists(tempCrawlDb)) {
+          fs.delete(tempCrawlDb, true);
+      }
       LockUtil.removeLockFile(fs, lock);
+    } catch(IOException e) {
       throw e;
     }
   }

--- a/src/java/org/apache/nutch/util/domain/DomainStatistics.java
+++ b/src/java/org/apache/nutch/util/domain/DomainStatistics.java
@@ -140,8 +140,17 @@ public class DomainStatistics extends Configured implements Tool {
     job.setNumReduceTasks(numOfReducers);
 
     try {
-      job.waitForCompletion(true);
-    } catch (Exception e) {
+      boolean success = job.waitForCompletion(true);
+      if(!success){
+        String message = "Injector job did not succeed, job status: "
+            + job.getStatus().getState() + ", reason: "
+            + job.getStatus().getFailureInfo();
+        LOG.error(message);
+        // throw exception so that calling routine can exit with error
+        throw new RuntimeException(message);
+      }
+    } catch (IOException | InterruptedException | ClassNotFoundException e) {
+      LOG.error(jobName + " job failed", e);
       throw e;
     }
 


### PR DESCRIPTION
- Added Job status checks in the classes: Injector, ReadHostDb, CrawlCompletionStats, ProtocolStatusStatistics, SitemapProcessor and DomainStatistics. 