### PR TITLE
Fix for NUTCH-2464 get textual content from nested heading nodes

### DIFF
--- a/src/plugin/headings/ivy.xml
+++ b/src/plugin/headings/ivy.xml
@@ -36,6 +36,7 @@
   </publications>
 
   <dependencies>
+    <dependency org="net.sourceforge.nekohtml" name="nekohtml" rev="1.9.19" conf="test->master"/>
   </dependencies>
   
 </ivy-module>

--- a/src/plugin/headings/src/java/org/apache/nutch/parse/headings/HeadingsParseFilter.java
+++ b/src/plugin/headings/src/java/org/apache/nutch/parse/headings/HeadingsParseFilter.java
@@ -108,12 +108,13 @@ public class HeadingsParseFilter implements HtmlParseFilter {
    */
   protected static String getNodeValue(Node node) {
     StringBuilder buffer = new StringBuilder();
+    NodeWalker walker = new NodeWalker(node);
 
-    NodeList children = node.getChildNodes();
+    while (walker.hasNext()) {
+      final Node n = walker.nextNode();
 
-    for (int i = 0; i < children.getLength(); i++) {
-      if (children.item(i).getNodeType() == Node.TEXT_NODE) {
-        buffer.append(children.item(i).getNodeValue());
+      if (n.getNodeType() == Node.TEXT_NODE) {
+        buffer.append(n.getNodeValue());
       }
     }
 

--- a/src/plugin/headings/src/test/org/apache/nutch/parse/headings/TestHeadingsParseFilter.java
+++ b/src/plugin/headings/src/test/org/apache/nutch/parse/headings/TestHeadingsParseFilter.java
@@ -1,0 +1,51 @@
+package org.apache.nutch.parse.headings;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.html.dom.HTMLDocumentImpl;
+import org.apache.nutch.metadata.Metadata;
+import org.apache.nutch.parse.*;
+import org.apache.nutch.protocol.Content;
+import org.apache.nutch.util.NutchConfiguration;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.w3c.dom.DocumentFragment;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.cyberneko.html.parsers.DOMFragmentParser;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestHeadingsParseFilter {
+  private static Configuration conf = NutchConfiguration.create();
+
+  @Test
+  public void testExtractHeadingFromNestedNodes()
+      throws IOException, SAXException {
+
+    conf.setStrings("headings", "h1", "h2");
+    HtmlParseFilter filter = new HeadingsParseFilter();
+    filter.setConf(conf);
+
+    Content content = new Content("http://www.foo.com/", "http://www.foo.com/",
+        "".getBytes("UTF8"), "text/html; charset=UTF-8", new Metadata(), conf);
+    ParseImpl parse = new ParseImpl("foo bar", new ParseData());
+    ParseResult parseResult = ParseResult
+        .createParseResult("http://www.foo.com/", parse);
+    HTMLMetaTags metaTags = new HTMLMetaTags();
+    DOMFragmentParser parser = new DOMFragmentParser();
+    DocumentFragment node = new HTMLDocumentImpl().createDocumentFragment();
+
+    parser.parse(new InputSource(new ByteArrayInputStream(
+        ("<html><head><title>test header with span element</title></head><body><h1>header with <span>span element</span></h1></body></html>")
+            .getBytes())), node);
+
+    parseResult = filter.filter(content, parseResult, metaTags, node);
+
+    Assert.assertEquals(
+        "The h1 tag must include the content of the inner span node",
+        "header with span element",
+        parseResult.get(content.getUrl()).getData().getParseMeta().get("h1"));
+  }
+}


### PR DESCRIPTION
As suggested by @sebastian-nagel refactored the `getNodeValue` method to use `NodeWalker` iterators. This allows traversing the entire DOM tree in case of nested nodes as explained on the issue. Added a test case for this issue as well.