### PR TITLE
fix for NUTCH-2454 REST API fix for usage of hostdb in generator

### DIFF
--- a/src/java/org/apache/nutch/crawl/Generator.java
+++ b/src/java/org/apache/nutch/crawl/Generator.java
@@ -929,8 +929,9 @@ public class Generator extends NutchTool implements Tool {
     boolean force = false;
     int maxNumSegments = 1;
     String expr = null;
-
+    String hostdb = null;
     Path crawlDb;
+    
     if(args.containsKey(Nutch.ARG_CRAWLDB)) {
       Object crawldbPath = args.get(Nutch.ARG_CRAWLDB);
       if(crawldbPath instanceof Path) {
@@ -956,6 +957,9 @@ public class Generator extends NutchTool implements Tool {
     }
     else {
       segmentsDir = new Path(crawlId+"/segments");
+    }
+    if (args.containsKey(Nutch.ARG_HOSTDB)) {
+      	hostdb = (String)args.get(Nutch.ARG_HOSTDB);
     }
     
     if (args.containsKey("expr")) {
@@ -986,7 +990,7 @@ public class Generator extends NutchTool implements Tool {
 
     try {
       Path[] segs = generate(crawlDb, segmentsDir, numFetchers, topN, curTime,
-          filter, norm, force, maxNumSegments, expr);
+          filter, norm, force, maxNumSegments, expr, hostdb);
       if (segs == null){
         results.put(Nutch.VAL_RESULT, Integer.toString(1));
         return results;

--- a/src/java/org/apache/nutch/metadata/Nutch.java
+++ b/src/java/org/apache/nutch/metadata/Nutch.java
@@ -97,6 +97,9 @@ public interface Nutch {
 	public static final String ARG_SEGMENTDIR = "segment_dir";
 	/** Argument key to specify the location of individual segment for the REST endpoints **/
 	public static final String ARG_SEGMENT = "segment";
+	/** Argument key to specify the location of hostdb for the REST endpoints **/
+	public static final String ARG_HOSTDB = "hostdb";
+
 	
 	/** Title key in the Pub/Sub event metadata for the title of the parsed page*/
 	public static final String FETCH_EVENT_TITLE = "title";


### PR DESCRIPTION
The recently introduced functionality allows usage of hostdb in generator. However the functionality didn't work when Generator is called from REST API server. This fix introduces hostdb for REST API.