### PR TITLE
fix for NUTCH-2461 generate with maxcount equals 0

### DIFF
--- a/src/java/org/apache/nutch/crawl/Generator.java
+++ b/src/java/org/apache/nutch/crawl/Generator.java
@@ -377,13 +377,16 @@ public class Generator extends NutchTool implements Tool {
               LOG.info("Generator: variable maxCount: {} for {}", variableMaxCount, hostname);
               maxCount = (int)variableMaxCount;
             }
-            
             if (fetchDelayExpr != null) {
               long variableFetchDelay = Math.round((double)fetchDelayExpr.evaluate(createContext(host)));
               LOG.info("Generator: variable fetchDelay: {} ms for {}", variableFetchDelay, hostname);
               variableFetchDelayWritable = new LongWritable(variableFetchDelay);              
             }
           }
+        }
+        
+        if(maxCount == 0){ 
+        	continue; 
         }
         
         // Got a non-zero variable fetch delay? Add it to the datum's metadata


### PR DESCRIPTION
When max count == 0 the reducer ignores hostdb condition because of  if (maxCount > 0). The fix adds the condition, but add it as explicit statement to save the ruining time.