### PR TITLE
NUTCH-2470 CrawlDbReader -stats to show quantiles of score

### DIFF
--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -47,11 +47,11 @@
 		<dependency org="commons-collections" name="commons-collections" rev="3.2.1" conf="*->master" />
 		<dependency org="commons-httpclient" name="commons-httpclient" rev="3.1" conf="*->master" />
 		<dependency org="commons-codec" name="commons-codec" rev="1.10" conf="*->default" />
-        <dependency org="org.apache.commons" name="commons-compress" rev="1.9" conf="*->default" />
-        <dependency org="org.apache.commons" name="commons-jexl" rev="2.1.1" />
-        <dependency org="com.tdunning" name="t-digest" rev="3.1" />
-            
-        <!-- Hadoop Dependencies -->
+		<dependency org="org.apache.commons" name="commons-compress" rev="1.9" conf="*->default" />
+		<dependency org="org.apache.commons" name="commons-jexl" rev="2.1.1" />
+		<dependency org="com.tdunning" name="t-digest" rev="3.2" />
+
+		<!-- Hadoop Dependencies -->
 		<dependency org="org.apache.hadoop" name="hadoop-common" rev="2.7.2" conf="*->default">
 			<exclude org="hsqldb" name="hsqldb" />
 			<exclude org="net.sf.kosmosfs" name="kfs" />


### PR DESCRIPTION
- add quantiles:
```
score quantile 0.01:    -0.002406878347319667
score quantile 0.05:    0.0
score quantile 0.1:     0.0
score quantile 0.2:     0.0
score quantile 0.25:    0.0
score quantile 0.3:     0.0
score quantile 0.4:     0.0
score quantile 0.5:     0.0
score quantile 0.6:     1.3519638927815378E-7
score quantile 0.7:     1.7516442206153347E-5
score quantile 0.75:    7.380095048071454E-5
score quantile 0.8:     1.8289990560181772E-4
score quantile 0.9:     7.733948471002675E-4
score quantile 0.95:    0.00450346029134317
score quantile 0.99:    0.2702074978807236
min score:      -0.007237845566123724
avg score:      0.010340072900048684
max score:      70.0
```
- improves precision of score min/max/average
  (represent score by float instead of long * 1000)