### PR TITLE
fix for NUTCH-2473 Remove broken slf4j dependecy from indexer-elastic-rest

### DIFF
--- a/src/plugin/indexer-elastic-rest/plugin.xml
+++ b/src/plugin/indexer-elastic-rest/plugin.xml
@@ -6,9 +6,9 @@
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-  
+
   http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,6 @@
         <library name="httpcore-nio-4.4.4.jar"/>
         <library name="jest-2.0.3.jar"/>
         <library name="jest-common-2.0.3.jar"/>
-        <library name="slf4j-api-1.7.21.jar"/>
 
     </runtime>
 


### PR DESCRIPTION
When trying to index into Elasticsearch using indexer-elastic-rest the following error is being thrown:
```
Exception in thread "main" java.lang.LinkageError: loader constraint violation: when resolving method "org.slf4j.impl.StaticLoggerBinder.getLoggerFactory()Lorg/slf4j/ILoggerFactory;" the class loader (instance of org/apache/nutch/plugin/PluginClassLoader) of the current class, org/slf4j/LoggerFactory, and the class loader (instance of sun/misc/Launcher$AppClassLoader) for the method's defining class, org/slf4j/impl/StaticLoggerBinder, have different Class objects for the type org/slf4j/ILoggerFactory used in the signature
    at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:418)
    at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:357)
    at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:383)
    at org.apache.nutch.indexwriter.elasticrest.ElasticRestIndexWriter.<clinit>(ElasticRestIndexWriter.java:71)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
    at java.lang.Class.newInstance(Class.java:442)
    at org.apache.nutch.plugin.Extension.getExtensionInstance(Extension.java:161)
    at org.apache.nutch.indexer.IndexWriters.<init>(IndexWriters.java:57)
    at org.apache.nutch.indexer.IndexingJob.index(IndexingJob.java:123)
    at org.apache.nutch.indexer.IndexingJob.run(IndexingJob.java:230)
    at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:70)
    at org.apache.nutch.indexer.IndexingJob.main(IndexingJob.java:239)
```
e66d44d removed the runtime dependency on slf4j-api-1.7.21.jar everywhere but in indexer-elastic-rest.