### PR TITLE
NUTCH-2480 Upgrade crawler-commons dependency to 0.9

### DIFF
--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -74,7 +74,9 @@
 
 		<dependency org="com.google.guava" name="guava" rev="18.0" />
 
-		<dependency org="com.github.crawler-commons" name="crawler-commons" rev="0.8" />
+		<dependency org="com.github.crawler-commons" name="crawler-commons" rev="0.9">
+			<exclude org="org.apache.tika"/>
+		</dependency>
 
 		<dependency org="com.martinkl.warc" name="warc-hadoop" rev="0.1.0" />
 		


### PR DESCRIPTION
and exclude transitive dependency to tika-core to avoid that Tika version requested as direct dependency is evicted.