### PR TITLE
NUTCH-2362 Upgrade MaxMind GeoIP version in index-geoip

### DIFF
--- a/src/plugin/index-geoip/ivy.xml
+++ b/src/plugin/index-geoip/ivy.xml
@@ -36,10 +36,12 @@
   </publications>
 
   <dependencies>
-    <dependency org="com.maxmind.geoip2" name="geoip2" rev="2.3.1" >
+    <dependency org="com.maxmind.geoip2" name="geoip2" rev="2.10.0" >
       <!-- Exlude due to classpath issues -->
       <exclude org="org.apache.httpcomponents" name="httpclient" />
       <exclude org="org.apache.httpcomponents" name="httpcore" />
+      <exclude org="commons-codec" name="commons-codec" />
+      <exclude org="commons-logging" name="commons-logging" />
     </dependency>
   </dependencies>
   

--- a/src/plugin/index-geoip/plugin.xml
+++ b/src/plugin/index-geoip/plugin.xml
@@ -25,15 +25,11 @@
       <library name="index-geoip.jar">
          <export name="*"/>
       </library>
-      <library name="commons-codec-1.6.jar"/>
-      <library name="commons-logging-1.1.1.jar"/>
-      <library name="geoip2-2.3.1.jar"/>
-      <library name="google-http-client-1.20.0.jar"/>
-      <library name="jackson-annotations-2.5.0.jar"/>
-      <library name="jackson-core-2.5.3.jar"/>
-      <library name="jackson-databind-2.5.3.jar"/>
-      <library name="jsr305-1.3.9.jar"/>
-      <library name="maxmind-db-1.0.0.jar"/>
+      <library name="geoip2-2.10.0.jar"/>
+      <library name="jackson-annotations-2.9.0.jar"/>
+      <library name="jackson-core-2.9.2.jar"/>
+      <library name="jackson-databind-2.9.2.jar"/>
+      <library name="maxmind-db-1.2.2.jar"/>
    </runtime>
 
    <requires>


### PR DESCRIPTION
- upgrade to recent version 2.10.0
- as there are no unit tests, tested with indexchecker:
```
$ bin/nutch indexchecker -Dstore.ip.address=true -Dindex.geoip.usage=cityDatabase \
     -Dplugin.includes="protocol-http|parse-html|index-(basic|geoip)" http://www.example.com/
fetching: http://www.example.com/
robots.txt whitelist not configured.
parsing: http://www.example.com/
contentType: text/html
countryIsoCode :        US
postalCode :    02061
title : Example Domain
accRadius :     50
content :       Example Domain
Example Domain
This domain is established to be used for illustrative examples in doc
cityName :      Norwell
digest :        09b9c392dc1f6e914cea287cb6be34b0
host :  www.example.com
id :    http://www.example.com/
continentCode : NA
cityGeoNameId : 4945936
ip :    93.184.216.34
countryGeoName :        6252001
timeZone :      America/New_York
subDivName :    Massachusetts
url :   http://www.example.com/
subDivIdoCode : MA
subDivGeoNameId :       6254926
tstamp :        Fri Dec 15 16:16:19 CET 2017
latLon :        42.1508,-70.8228
metroCode :     506
continentGeoNameId :    6255149
countryName :   United States
continentName : North America
```
(requires to work around [NUTCH-2482](https://issues.apache.org/jira/browse/NUTCH-2482))