### PR TITLE
NUTCH-2483 Remove/replace indirect dependencies to org.json

### DIFF
--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -95,6 +95,7 @@
 			<exclude module="hadoop-core"/>
 			<exclude org="com.google.guava"/>
 			<exclude org="junit"/>
+			<exclude org="org.json"/>
 		</dependency>
 
 		<!--artifacts needed for testing -->
@@ -128,7 +129,9 @@
     	<dependency org="org.apache.wicket" name="wicket-core" rev="6.16.0" conf="*->default" />
     	<dependency org="org.apache.wicket" name="wicket-spring" rev="6.16.0" conf="*->default" />
     	<dependency org="de.agilecoders.wicket" name="wicket-bootstrap-core" rev="0.9.2" conf="*->default" />
-    	<dependency org="de.agilecoders.wicket" name="wicket-bootstrap-extensions" rev="0.9.2" conf="*->default" />
+		<dependency org="de.agilecoders.wicket" name="wicket-bootstrap-extensions" rev="0.9.2" conf="*->default">
+			<exclude org="org.json"/>
+		</dependency>
 		
 		<!-- RabbitMQ dependencies -->
 		<dependency org="com.rabbitmq" name="amqp-client" rev="3.6.5" conf="*->default" />


### PR DESCRIPTION
- exclude dependency for webarchive-commons: no classes requiring JSON are used
- exclude dependency for wicket-bootstrap-extensions (transitive dep via closure-compiler):
  only one class is used from wicket-bootstrap-extensions which isn't related to JavaScript or JSON