### PR TITLE
NUTCH-2486: Fix unchecked / unsafe compiler warning

### DIFF
--- a/src/plugin/mimetype-filter/src/java/org/apache/nutch/indexer/filter/MimeTypeIndexingFilter.java
+++ b/src/plugin/mimetype-filter/src/java/org/apache/nutch/indexer/filter/MimeTypeIndexingFilter.java
@@ -171,7 +171,7 @@ public class MimeTypeIndexingFilter implements IndexingFilter {
   private void readConfiguration(Reader reader) throws IOException {
     BufferedReader in = new BufferedReader(reader);
     String line;
-    List rules = new ArrayList();
+    List<String> rules = new ArrayList<String>();
 
     while (null != (line = in.readLine())) {
       if (line.length() == 0) {


### PR DESCRIPTION
Fixes `Note: src/plugin/mimetype-filter/src/java/org/apache/nutch/indexer/filter/MimeTypeIndexingFilter.java uses unchecked or unsafe operations.`