### PR TITLE
fix for NUTCH-2490 Fix sitemap index file processing

### DIFF
--- a/src/java/org/apache/nutch/util/SitemapProcessor.java
+++ b/src/java/org/apache/nutch/util/SitemapProcessor.java
@@ -213,6 +213,7 @@ public class SitemapProcessor extends Configured implements Tool {
       AbstractSiteMap asm = parser.parseSiteMap(content.getContentType(), content.getContent(), new URL(url));
 
       if(asm instanceof SiteMap) {
+        LOG.info("Parsing sitemap file: {}", asm.getUrl().toString());
         SiteMap sm = (SiteMap) asm;
         Collection<SiteMapURL> sitemapUrls = sm.getSiteMapUrls();
         for(SiteMapURL sitemapUrl: sitemapUrls) {
@@ -252,10 +253,13 @@ public class SitemapProcessor extends Configured implements Tool {
         SiteMapIndex index = (SiteMapIndex) asm;
         Collection<AbstractSiteMap> sitemapUrls = index.getSitemaps();
 
+        if (sitemapUrls.isEmpty()) {
+          return;
+        }
+
+        LOG.info("Parsing sitemap index file: {}", index.getUrl().toString());
         for(AbstractSiteMap sitemap: sitemapUrls) {
-          if(sitemap.isIndex()) {
-            generateSitemapUrlDatum(protocol, sitemap.getUrl().toString(), context);
-          }
+          generateSitemapUrlDatum(protocol, sitemap.getUrl().toString(), context);
         }
       }
     }


### PR DESCRIPTION
This fixes processing of sitemap index files by removing a unnecessary conditional.

Before:
```bash
$ echo "https://filialen.migros.ch/sitemap.xml" > sitemaps.txt && bin/nutch sitemap crawldata -sitemapUrls sitemaps.txt
SitemapProcessor: sitemap urls dir: sitemaps.txt
SitemapProcessor: Starting at 2018-01-02 22:44:58
robots.txt whitelist not configured.
SitemapProcessor: Total records rejected by filters: 0
SitemapProcessor: Total sitemaps from HostDb: 0
SitemapProcessor: Total sitemaps from seed urls: 1
SitemapProcessor: Total failed sitemap fetches: 0
SitemapProcessor: Total new sitemap entries added: 0
SitemapProcessor: Finished at 2018-01-02 22:45:02, elapsed: 00:00:03
````

After:
```bash
$ echo "https://filialen.migros.ch/sitemap.xml" > sitemaps.txt && bin/nutch sitemap crawldata -sitemapUrls sitemaps.txt
SitemapProcessor: sitemap urls dir: sitemaps.txt
SitemapProcessor: Starting at 2018-01-02 22:47:44
robots.txt whitelist not configured.
Parsing sitemap index file: https://filialen.migros.ch/sitemap.xml
Parsing sitemap file: https://filialen.migros.ch/de/sitemap.xml
Parsing sitemap file: https://filialen.migros.ch/fr/sitemap.xml
Parsing sitemap file: https://filialen.migros.ch/it/sitemap.xml
SitemapProcessor: Total records rejected by filters: 0
SitemapProcessor: Total sitemaps from HostDb: 0
SitemapProcessor: Total sitemaps from seed urls: 1
SitemapProcessor: Total failed sitemap fetches: 0
SitemapProcessor: Total new sitemap entries added: 5754
SitemapProcessor: Finished at 2018-01-02 22:47:58, elapsed: 00:00:13
```