### PR TITLE
NUTCH-2495: Use -deleteGone instead of clean job in crawler script while indexing

### DIFF
--- a/src/bin/crawl
+++ b/src/bin/crawl
@@ -319,8 +319,8 @@ do
   echo "CrawlDB update"
   __bin_nutch updatedb $commonOptions "$CRAWL_PATH"/crawldb  "$CRAWL_PATH"/segments/$SEGMENT
 
-# note that the link inversion - indexing routine can be done within the main loop
-# on a per segment basis
+  # note that the link inversion - indexing routine can be done within the main loop
+  # on a per segment basis
   echo "Link inversion"
   __bin_nutch invertlinks "$CRAWL_PATH"/linkdb "$CRAWL_PATH"/segments/$SEGMENT
 
@@ -329,10 +329,7 @@ do
 
   if $INDEXFLAG; then
       echo "Indexing $SEGMENT to index"
-      __bin_nutch index $JAVA_PROPERTIES "$CRAWL_PATH"/crawldb -linkdb "$CRAWL_PATH"/linkdb "$CRAWL_PATH"/segments/$SEGMENT
-
-      echo "Cleaning up index if possible"
-      __bin_nutch clean $JAVA_PROPERTIES "$CRAWL_PATH"/crawldb
+      __bin_nutch index $JAVA_PROPERTIES "$CRAWL_PATH"/crawldb -linkdb "$CRAWL_PATH"/linkdb "$CRAWL_PATH"/segments/$SEGMENT -deleteGone
   else
       echo "Skipping indexing ..."
   fi

--- a/src/java/org/apache/nutch/indexer/IndexerMapReduce.java
+++ b/src/java/org/apache/nutch/indexer/IndexerMapReduce.java
@@ -238,18 +238,22 @@ public class IndexerMapReduce extends Configured implements
     }
 
     // Whether to delete GONE or REDIRECTS
-    if (delete && fetchDatum != null) {
-      if (fetchDatum.getStatus() == CrawlDatum.STATUS_FETCH_GONE
+    if (delete) {
+      if (fetchDatum != null && fetchDatum.getStatus() == CrawlDatum.STATUS_FETCH_GONE
           || dbDatum != null && dbDatum.getStatus() == CrawlDatum.STATUS_DB_GONE) {
         reporter.incrCounter("IndexerStatus", "deleted (gone)", 1);
         output.collect(key, DELETE_ACTION);
         return;
       }
 
-      if (fetchDatum.getStatus() == CrawlDatum.STATUS_FETCH_REDIR_PERM
-          || fetchDatum.getStatus() == CrawlDatum.STATUS_FETCH_REDIR_TEMP
-          || dbDatum != null && dbDatum.getStatus() == CrawlDatum.STATUS_DB_REDIR_PERM
-          || dbDatum != null && dbDatum.getStatus() == CrawlDatum.STATUS_DB_REDIR_TEMP) {
+      if (fetchDatum != null
+          && (fetchDatum.getStatus() == CrawlDatum.STATUS_FETCH_REDIR_PERM
+              || fetchDatum.getStatus() == CrawlDatum.STATUS_FETCH_REDIR_TEMP
+          )
+          || dbDatum != null
+          && (dbDatum.getStatus() == CrawlDatum.STATUS_DB_REDIR_PERM
+              || dbDatum.getStatus() == CrawlDatum.STATUS_DB_REDIR_TEMP
+          )) {
         reporter.incrCounter("IndexerStatus", "deleted (redirects)", 1);
         output.collect(key, DELETE_ACTION);
         return;

--- a/src/java/org/apache/nutch/indexer/IndexingJob.java
+++ b/src/java/org/apache/nutch/indexer/IndexingJob.java
@@ -167,7 +167,6 @@ public class IndexingJob extends NutchTool implements Tool {
   public int run(String[] args) throws Exception {
     if (args.length < 2) {
       System.err
-      //.println("Usage: Indexer <crawldb> [-linkdb <linkdb>] [-params k1=v1&k2=v2...] (<segment> ... | -dir <segments>) [-noCommit] [-deleteGone] [-filter] [-normalize]");
       .println("Usage: Indexer <crawldb> [-linkdb <linkdb>] [-params k1=v1&k2=v2...] (<segment> ... | -dir <segments>) [-noCommit] [-deleteGone] [-filter] [-normalize] [-addBinaryContent] [-base64]");
       IndexWriters writers = new IndexWriters(getConf());
       System.err.println(writers.describe());


### PR DESCRIPTION
Instead of running `bin/nutch` clean after indexing the documents run `bin/nutch index` with the `-deleteGone` flag which instead of just deleting gone and duplicated documents also deletes redirects from the index.