### PR TITLE
fix for NUTCH-2505 contributed by lianyuzhe

### DIFF
--- a/src/java/org/apache/nutch/crawl/Generator.java
+++ b/src/java/org/apache/nutch/crawl/Generator.java
@@ -752,6 +752,7 @@ public class Generator extends NutchTool implements Tool {
       }
     } catch (Exception e) {
       LOG.warn("Generator: exception while partitioning segments, exiting ...");
+      LockUtil.removeLockFile(getConf(),lock);
       fs.delete(tempDir, true);
       return null;
     }


### PR DESCRIPTION
fix the problem of nutch does not delete the .locked file when the generator partition got an exception. 