### PR TITLE
fix for NUTCH-2508 contributed by mfeltscher

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -280,7 +280,7 @@
 <property>
   <name>http.proxy.exception.list</name>
   <value></value>
-  <description>A comma separated list of URL's and hosts that don't use the proxy 
+  <description>A comma separated list of hosts that don't use the proxy 
   (e.g. intranets). Example: www.apache.org</description>
 </property>
 


### PR DESCRIPTION
This is a small documentation fix since the description of `http.proxy.exception.list` is misleading. Only hosts can be defined as you can see here: https://github.com/apache/nutch/blob/master/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpBase.java#L370