### PR TITLE
NUTCH-2489: Dependency collision with lucene-analyzers-common in scoring-similarity plugin

### DIFF
--- a/src/plugin/scoring-similarity/ivy.xml
+++ b/src/plugin/scoring-similarity/ivy.xml
@@ -36,7 +36,7 @@
   </publications>
 
   <dependencies>
-    <dependency org="org.apache.lucene" name="lucene-analyzers-common" rev="5.5.0" conf="*->default"/>
+    <dependency org="org.apache.lucene" name="lucene-analyzers-common" rev="6.4.1" conf="*->default"/>
   </dependencies>
   
 </ivy-module>

--- a/src/plugin/scoring-similarity/plugin.xml
+++ b/src/plugin/scoring-similarity/plugin.xml
@@ -26,8 +26,8 @@
       <library name="scoring-similarity.jar">
          <export name="*"/>
       </library>
-      <library name="lucene-analyzers-common-5.5.0.jar"/>
-      <library name="lucene-core-5.5.0.jar"/>
+      <library name="lucene-analyzers-common-6.4.1.jar"/>
+      <library name="lucene-core-6.4.1.jar"/>
    </runtime>
 
    <requires>

--- a/src/plugin/scoring-similarity/src/java/org/apache/nutch/scoring/similarity/util/LuceneAnalyzerUtil.java
+++ b/src/plugin/scoring-similarity/src/java/org/apache/nutch/scoring/similarity/util/LuceneAnalyzerUtil.java
@@ -28,7 +28,7 @@ import org.apache.lucene.analysis.en.EnglishMinimalStemFilter;
 import org.apache.lucene.analysis.en.PorterStemFilter;
 import org.apache.lucene.analysis.standard.ClassicTokenizer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.analysis.util.CharArraySet;
+import org.apache.lucene.analysis.CharArraySet;
 
 /**
  * Creates a custom analyzer based on user provided inputs

--- a/src/plugin/scoring-similarity/src/java/org/apache/nutch/scoring/similarity/util/LuceneTokenizer.java
+++ b/src/plugin/scoring-similarity/src/java/org/apache/nutch/scoring/similarity/util/LuceneTokenizer.java
@@ -29,7 +29,7 @@ import org.apache.lucene.analysis.standard.ClassicTokenizer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
 import org.apache.lucene.analysis.shingle.ShingleFilter;
-import org.apache.lucene.analysis.util.CharArraySet;
+import org.apache.lucene.analysis.CharArraySet;
 import org.apache.nutch.scoring.similarity.util.LuceneAnalyzerUtil.StemFilterType;
 
 public class LuceneTokenizer {


### PR DESCRIPTION
Upgraded lucene-analyzers-common from 5.5.0 to 6.4.1 in order to resolve conflict in Eclipse.