### PR TITLE
NUTCH-2534 CrawlDbReader -stats: make score quantiles configurable

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -720,6 +720,16 @@
   </description>
 </property>
 
+<property>
+  <name>db.stats.score.quantiles</name>
+  <value>.01,.05,.1,.2,.25,.3,.4,.5,.6,.7,.75,.8,.9,.95,.99</value>
+  <description>
+    Quantiles of the distribution of CrawlDatum scores shown in the
+    CrawlDb statistics (command `readdb -stats').  Comma-separated
+    list of floating point numbers.
+  </description>
+</property>
+
 <!-- linkdb properties -->
 
 <property>


### PR DESCRIPTION
by property `db.stats.score.quantiles`, e.g., show only quartiles:
```
$NUTCH_HOME/bin/nutch readdb -Ddb.stats.score.quantiles=.25,.5,.75 .../crawldb -stats
...
score quantile 0.25:    0.0
score quantile 0.5:     7.949125720188022E-4
score quantile 0.75:    0.06881623715162277
...
```