### PR TITLE
NUTCH-2552 CrawlDbReader -topN fails

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -985,7 +985,7 @@
   <name>fetcher.threads.timeout.divisor</name>
   <value>2</value>
   <description>(EXPERT)The thread time-out divisor to use. By default threads have a time-out
-  value of mapred.task.timeout / 2. Increase this setting if the fetcher waits too
+  value of mapreduce.task.timeout / 2. Increase this setting if the fetcher waits too
   long before killing hanged threads. Be careful, a too high setting (+8) will most likely kill the
   fetcher threads prematurely.
   </description>

--- a/src/java/org/apache/nutch/crawl/CrawlDbReader.java
+++ b/src/java/org/apache/nutch/crawl/CrawlDbReader.java
@@ -367,7 +367,7 @@ public class CrawlDbReader extends AbstractChecker implements Closeable {
 
     public void setup(Reducer<FloatWritable, Text, FloatWritable, Text>.Context context) {
       Configuration conf = context.getConfiguration();
-      topN = conf.getLong("db.reader.topn", 100) / Integer.parseInt(conf.get("mapred.job.reduces"));
+      topN = conf.getLong("db.reader.topn", 100) / Integer.parseInt(conf.get("mapreduce.job.reduces"));
     }
 
     public void close() {

--- a/src/java/org/apache/nutch/crawl/LinkDb.java
+++ b/src/java/org/apache/nutch/crawl/LinkDb.java
@@ -307,7 +307,7 @@ public class LinkDb extends NutchTool implements Tool {
 
     FileOutputFormat.setOutputPath(job, newLinkDb);
     job.setOutputFormatClass(MapFileOutputFormat.class);
-    conf.setBoolean("mapred.output.compress", true);
+    conf.setBoolean("mapreduce.output.fileoutputformat.compress", true);
     job.setOutputKeyClass(Text.class);
     job.setOutputValueClass(Inlinks.class);
 

--- a/src/java/org/apache/nutch/crawl/LinkDbMerger.java
+++ b/src/java/org/apache/nutch/crawl/LinkDbMerger.java
@@ -164,7 +164,7 @@ public class LinkDbMerger extends Configured implements Tool {
 
     FileOutputFormat.setOutputPath(job, newLinkDb);
     job.setOutputFormatClass(MapFileOutputFormat.class);
-    conf.setBoolean("mapred.output.compress", true);
+    conf.setBoolean("mapreduce.output.fileoutputformat.compress", true);
     job.setOutputKeyClass(Text.class);
     job.setOutputValueClass(Inlinks.class);
 

--- a/src/java/org/apache/nutch/fetcher/Fetcher.java
+++ b/src/java/org/apache/nutch/fetcher/Fetcher.java
@@ -228,7 +228,7 @@ public class Fetcher extends NutchTool implements Tool {
       }
 
       // select a timeout that avoids a task timeout
-      long timeout = conf.getInt("mapred.task.timeout", 10 * 60 * 1000)
+      long timeout = conf.getInt("mapreduce.task.timeout", 10 * 60 * 1000)
           / timeoutDivisor;
 
       // Used for threshold check, holds pages and bytes processed in the last

--- a/src/java/org/apache/nutch/hostdb/ReadHostDb.java
+++ b/src/java/org/apache/nutch/hostdb/ReadHostDb.java
@@ -177,7 +177,7 @@ public class ReadHostDb extends Configured implements Tool {
       conf.set(HOSTDB_FILTER_EXPRESSION, expr);
     }
     conf.setBoolean("mapreduce.fileoutputcommitter.marksuccessfuljobs", false);
-    conf.set("mapred.textoutputformat.separator", "\t");
+    conf.set("mapreduce.output.textoutputformat.separator", "\t");
     
     Job job = Job.getInstance(conf);
     job.setJobName("ReadHostDb");

--- a/src/java/org/apache/nutch/scoring/webgraph/NodeDumper.java
+++ b/src/java/org/apache/nutch/scoring/webgraph/NodeDumper.java
@@ -330,7 +330,7 @@ public class NodeDumper extends Configured implements Tool {
 
     // Set equals-sign as separator for Solr's ExternalFileField
     if (asEff) {
-      conf.set("mapred.textoutputformat.separator", "=");
+      conf.set("mapreduce.output.textoutputformat.separator", "=");
     }
 
     try {

--- a/src/java/org/apache/nutch/util/SitemapProcessor.java
+++ b/src/java/org/apache/nutch/util/SitemapProcessor.java
@@ -433,7 +433,7 @@ public class SitemapProcessor extends Configured implements Tool {
     System.err.println("\t<crawldb>\t\tpath to crawldb where the sitemap urls would be injected");
     System.err.println("\t-hostdb <hostdb>\tpath of a hostdb. Sitemap(s) from these hosts would be downloaded");
     System.err.println("\t-sitemapUrls <url_dir>\tpath to sitemap urls directory");
-    System.err.println("\t-threads <threads>\tNumber of threads created per mapper to fetch sitemap urls");
+    System.err.println("\t-threads <threads>\tNumber of threads created per mapper to fetch sitemap urls (default: 8)");
     System.err.println("\t-force\t\t\tforce update even if CrawlDb appears to be locked (CAUTION advised)");
     System.err.println("\t-noStrict\t\tBy default Sitemap parser rejects invalid urls. '-noStrict' disables that.");
     System.err.println("\t-noFilter\t\tturn off URLFilters on urls (optional)");
@@ -452,7 +452,7 @@ public class SitemapProcessor extends Configured implements Tool {
     boolean strict = true;
     boolean filter = true;
     boolean normalize = true;
-    int threads = getConf().getInt("mapred.map.multithreadedrunner.threads", 8);
+    int threads = 8;
 
     for (int i = 1; i < args.length; i++) {
       if (args[i].equals("-hostdb")) {

--- a/src/plugin/protocol-httpclient/src/java/org/apache/nutch/protocol/httpclient/Http.java
+++ b/src/plugin/protocol-httpclient/src/java/org/apache/nutch/protocol/httpclient/Http.java
@@ -200,7 +200,7 @@ public class Http extends HttpBase {
     // for multi-threaded crawls.
     // --------------------------------------------------------------------------------
     params.setMaxTotalConnections(
-        conf.getInt("mapred.tasktracker.map.tasks.maximum", 5)
+        conf.getInt("mapreduce.tasktracker.map.tasks.maximum", 5)
             * conf.getInt("fetcher.threads.fetch", maxThreadsTotal));
 
     // Also set max connections per host to maxThreadsTotal since all threads


### PR DESCRIPTION
- update Hadoop properties (deprecated / old MapReduce API)
- includes fix for
   NUTCH-1228 Change mapred.task.timeout to mapreduce.task.timeout in fetcher