### PR TITLE
NUTCH-2544 Nutch 1.15 no longer compatible with AWS EMR and S3

### DIFF
--- a/src/java/org/apache/nutch/fetcher/FetcherOutputFormat.java
+++ b/src/java/org/apache/nutch/fetcher/FetcherOutputFormat.java
@@ -47,15 +47,11 @@ public class FetcherOutputFormat extends FileOutputFormat<Text, NutchWritable> {
   @Override
   public void checkOutputSpecs(JobContext job) throws IOException {
     Configuration conf = job.getConfiguration();
-    FileSystem fs = FileSystem.get(conf);
     Path out = FileOutputFormat.getOutputPath(job);
     if ((out == null) && (job.getNumReduceTasks() != 0)) {
       throw new InvalidJobConfException("Output directory not set in conf.");
     }
-
-    if (fs == null) {
-      fs = out.getFileSystem(conf);
-    }
+    FileSystem fs = out.getFileSystem(conf);
     if (fs.exists(new Path(out, CrawlDatum.FETCH_DIR_NAME))) {
       throw new IOException("Segment already fetched!");
     }

--- a/src/java/org/apache/nutch/util/SitemapProcessor.java
+++ b/src/java/org/apache/nutch/util/SitemapProcessor.java
@@ -336,7 +336,7 @@ public class SitemapProcessor extends Configured implements Tool {
       LOG.info("SitemapProcessor: Starting at {}", sdf.format(start));
     }
 
-    FileSystem fs = FileSystem.get(getConf());
+    FileSystem fs = crawldb.getFileSystem(getConf());
     Path old = new Path(crawldb, "old");
     Path current = new Path(crawldb, "current");
     Path tempCrawlDb = new Path(crawldb, "crawldb-" + Integer.toString(new Random().nextInt(Integer.MAX_VALUE)));


### PR DESCRIPTION
- use CrawlDb path to get filesystem
- fix Fetcher and SitemapProcessor