### PR TITLE
NUTCH-2526 NPE in scoring-opic when indexing document without CrawlDb datum

### DIFF
--- a/src/java/org/apache/nutch/scoring/ScoringFilter.java
+++ b/src/java/org/apache/nutch/scoring/ScoringFilter.java
@@ -193,17 +193,22 @@ public interface ScoringFilter extends Configurable, Pluggable {
   }
 
   /**
-   * This method calculates a Lucene document boost.
+   * This method calculates a indexed document score/boost.
    * 
    * @param url
    *          url of the page
    * @param doc
-   *          Lucene document. NOTE: this already contains all information
+   *          indexed document. NOTE: this already contains all information
    *          collected by indexing filters. Implementations may modify this
    *          instance, in order to store/remove some information.
    * @param dbDatum
-   *          current page from CrawlDb. NOTE: changes made to this instance are
-   *          not persisted.
+   *          current page from CrawlDb. NOTE:
+   *          <ul>
+   *          <li>changes made to this instance are not persisted</li>
+   *          <li>may be null if indexing is done without CrawlDb or if the
+   *          segment is generated not from the CrawlDb (via
+   *          FreeGenerator).</li>
+   *          </ul>
    * @param fetchDatum
    *          datum from FetcherOutput (containing among others the fetching
    *          status)
@@ -214,10 +219,10 @@ public interface ScoringFilter extends Configurable, Pluggable {
    *          current inlinks from LinkDb. NOTE: changes made to this instance
    *          are not persisted.
    * @param initScore
-   *          initial boost value for the Lucene document.
-   * @return boost value for the Lucene document. This value is passed as an
+   *          initial boost value for the indexed document.
+   * @return boost value for the indexed document. This value is passed as an
    *         argument to the next scoring filter in chain. NOTE: implementations
-   *         may also express other scoring strategies by modifying Lucene
+   *         may also express other scoring strategies by modifying the indexed
    *         document directly.
    * @throws ScoringFilterException
    */

--- a/src/plugin/scoring-link/src/java/org/apache/nutch/scoring/link/LinkAnalysisScoringFilter.java
+++ b/src/plugin/scoring-link/src/java/org/apache/nutch/scoring/link/LinkAnalysisScoringFilter.java
@@ -36,6 +36,7 @@ public class LinkAnalysisScoringFilter implements ScoringFilter {
 
   private Configuration conf;
   private float normalizedScore = 1.00f;
+  private float initialScore = 0.0f;
 
   public LinkAnalysisScoringFilter() {
 
@@ -64,12 +65,15 @@ public class LinkAnalysisScoringFilter implements ScoringFilter {
   public float indexerScore(Text url, NutchDocument doc, CrawlDatum dbDatum,
       CrawlDatum fetchDatum, Parse parse, Inlinks inlinks, float initScore)
       throws ScoringFilterException {
+    if (dbDatum == null) {
+      return initScore;
+    }
     return (normalizedScore * dbDatum.getScore());
   }
 
   public void initialScore(Text url, CrawlDatum datum)
       throws ScoringFilterException {
-    datum.setScore(0.0f);
+    datum.setScore(initialScore);
   }
 
   public void injectedScore(Text url, CrawlDatum datum)

--- a/src/plugin/scoring-opic/src/java/org/apache/nutch/scoring/opic/OPICScoringFilter.java
+++ b/src/plugin/scoring-opic/src/java/org/apache/nutch/scoring/opic/OPICScoringFilter.java
@@ -167,6 +167,9 @@ public class OPICScoringFilter implements ScoringFilter {
   public float indexerScore(Text url, NutchDocument doc, CrawlDatum dbDatum,
       CrawlDatum fetchDatum, Parse parse, Inlinks inlinks, float initScore)
       throws ScoringFilterException {
+    if (dbDatum == null) {
+      return initScore;
+    }
     return (float) Math.pow(dbDatum.getScore(), scorePower) * initScore;
   }
 }


### PR DESCRIPTION
- fix scoring-opic and scoring-link
- check whether CrawlDb datum is null before reading its score
  (after NUTCH-2456 which allows to index pages/URLs not contained in CrawlDb)
- complete Java doc