### PR TITLE
NUTCH-2581 Caching of redirected robots.txt may overwrite correct robots.txt rules

### DIFF
--- a/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpRobotRulesParser.java
+++ b/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpRobotRulesParser.java
@@ -174,8 +174,10 @@ public class HttpRobotRulesParser extends RobotRulesParser {
 
     if (cacheRule) {
       CACHE.put(cacheKey, robotRules); // cache rules for host
-      if (redir != null && !redir.getHost().equalsIgnoreCase(url.getHost())) {
+      if (redir != null && !redir.getHost().equalsIgnoreCase(url.getHost())
+          && "/robots.txt".equals(redir.getFile())) {
         // cache also for the redirected host
+        // if the URL path is /robots.txt
         CACHE.put(getCacheKey(redir), robotRules);
       }
     }


### PR DESCRIPTION
- only cache redirected robots.txt rules if the target URL path and query equal /robots.txt