### PR TITLE
NUTCH-2578 Avoid lock by MimeUtil in constructor of protocol.Content

### DIFF
--- a/src/java/org/apache/nutch/protocol/Content.java
+++ b/src/java/org/apache/nutch/protocol/Content.java
@@ -81,6 +81,29 @@ public final class Content implements Writable {
     this.metadata = metadata;
 
     this.mimeTypes = new MimeUtil(conf);
+
+    this.contentType = getContentType(contentType, url, content);
+  }
+
+  public Content(String url, String base, byte[] content, String contentType,
+      Metadata metadata, MimeUtil mimeTypes) {
+
+    if (url == null)
+      throw new IllegalArgumentException("null url");
+    if (base == null)
+      throw new IllegalArgumentException("null base");
+    if (content == null)
+      throw new IllegalArgumentException("null content");
+    if (metadata == null)
+      throw new IllegalArgumentException("null metadata");
+
+    this.url = url;
+    this.base = base;
+    this.content = content;
+    this.metadata = metadata;
+
+    this.mimeTypes = mimeTypes;
+
     this.contentType = getContentType(contentType, url, content);
   }
 

--- a/src/java/org/apache/nutch/util/MimeUtil.java
+++ b/src/java/org/apache/nutch/util/MimeUtil.java
@@ -66,8 +66,12 @@ public final class MimeUtil {
       .getLogger(MethodHandles.lookup().lookupClass());
 
   public MimeUtil(Configuration conf) {
-    tika = new Tika();
     ObjectCache objectCache = ObjectCache.get(conf);
+    tika = (Tika) objectCache.getObject(Tika.class.getName());
+    if (tika == null) {
+      tika = new Tika();
+      objectCache.setObject(Tika.class.getName(), tika);
+    }
     MimeTypes mimeTypez = (MimeTypes) objectCache.getObject(MimeTypes.class
         .getName());
     if (mimeTypez == null) {

--- a/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpBase.java
+++ b/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpBase.java
@@ -41,6 +41,7 @@ import org.apache.nutch.protocol.ProtocolException;
 import org.apache.nutch.protocol.ProtocolOutput;
 import org.apache.nutch.protocol.ProtocolStatus;
 import org.apache.nutch.util.GZIPUtils;
+import org.apache.nutch.util.MimeUtil;
 import org.apache.nutch.util.DeflateUtils;
 import org.apache.hadoop.util.StringUtils;
 
@@ -105,6 +106,13 @@ public abstract class HttpBase implements Protocol {
   /** The nutch configuration */
   private Configuration conf = null;
 
+  /**
+   * MimeUtil for MIME type detection. Note (see NUTCH-2578): MimeUtil object is
+   * used concurrently by parallel fetcher threads, methods to detect MIME type
+   * must be thread-safe.
+   */
+  private MimeUtil mimeTypes = null;
+
   /** Do we use HTTP/1.1? */
   protected boolean useHttp11 = false;
 
@@ -158,6 +166,7 @@ public abstract class HttpBase implements Protocol {
         .trim();
     this.acceptCharset = conf.get("http.accept.charset", acceptCharset).trim();
     this.accept = conf.get("http.accept", accept).trim();
+    this.mimeTypes = new MimeUtil(conf);
     // backward-compatible default setting
     this.useHttp11 = conf.getBoolean("http.useHttp11", false);
     this.responseTime = conf.getBoolean("http.store.responsetime", true);
@@ -282,7 +291,7 @@ public abstract class HttpBase implements Protocol {
       byte[] content = response.getContent();
       Content c = new Content(u.toString(), u.toString(),
           (content == null ? EMPTY_CONTENT : content),
-          response.getHeader("Content-Type"), response.getHeaders(), this.conf);
+          response.getHeader("Content-Type"), response.getHeaders(), mimeTypes);
 
       if (code == 200) { // got a good response
         return new ProtocolOutput(c); // return it


### PR DESCRIPTION
- avoid creation of new Tika object in constructor of MimeUtil (cache in ObjectCache) - suggested by @YossiTamari. Thanks!
- also hold MimeUtil object in protocol implementation (protocol plugin) and pass it to constructor of Content. This avoids any locks (also those by ObjectCache) in a highly concurrent fetcher. Note that the current MimeUtil implementation and the Tika detector are thread-safe.
