### PR TITLE
NUTCH-2574 Generator: hostCount >= maxCount comparison wrong

### DIFF
--- a/src/java/org/apache/nutch/crawl/Generator.java
+++ b/src/java/org/apache/nutch/crawl/Generator.java
@@ -283,7 +283,7 @@ public class Generator extends NutchTool implements Tool {
       private HashMap<String, int[]> hostCounts = new HashMap<>();
       private long count;
       private int currentsegmentnum = 1;
-      private MultipleOutputs mos;
+      private MultipleOutputs<FloatWritable, SelectorEntry> mos;
       private String outputFile;
       private long limit;
       private int segCounts[];
@@ -361,7 +361,7 @@ public class Generator extends NutchTool implements Tool {
       @Override
       public void setup(Context context) throws IOException {
         conf = context.getConfiguration();
-        mos = new MultipleOutputs(context);
+        mos = new MultipleOutputs<FloatWritable, SelectorEntry>(context);
         Job job = Job.getInstance(conf);
         limit = conf.getLong(GENERATOR_TOP_N, Long.MAX_VALUE) 
                      / job.getNumReduceTasks();
@@ -398,7 +398,8 @@ public class Generator extends NutchTool implements Tool {
         HostDatum host = null;
         LongWritable variableFetchDelayWritable = null; // in millis
         Text variableFetchDelayKey = new Text("_variableFetchDelay_");
-        int temp_maxCount = maxCount;
+          // local variable maxCount may hold host-specific count set in HostDb
+        int maxCount = this.maxCount;
         for (SelectorEntry entry : values) {
           Text url = entry.url;
           String urlString = url.toString();
@@ -486,12 +487,12 @@ public class Generator extends NutchTool implements Tool {
 
             // reached the limit of allowed URLs per host / domain
             // see if we can put it in the next segment?
-            if (hostCount[1] >= maxCount) {
+            if (hostCount[1] > maxCount) {
               if (hostCount[0] < maxNumSegments) {
                 hostCount[0]++;
-                hostCount[1] = 0;
+                hostCount[1] = 1;
               } else {
-                if (hostCount[1] == maxCount + 1 && LOG.isInfoEnabled()) {
+                if (hostCount[1] == maxCount && LOG.isInfoEnabled()) {
                   LOG.info("Host or domain "
                       + hostordomain
                       + " has more than "
@@ -519,7 +520,6 @@ public class Generator extends NutchTool implements Tool {
           // maxCount may cause us to skip it.
           count++;
         }
-        maxCount = temp_maxCount;
       }
       
       private String generateFileName(SelectorEntry entry) {

--- a/src/test/org/apache/nutch/crawl/TestGenerator.java
+++ b/src/test/org/apache/nutch/crawl/TestGenerator.java
@@ -145,8 +145,9 @@ public class TestGenerator {
 
     createCrawlDB(list);
 
+    int maxPerHost = 1;
     Configuration myConfiguration = new Configuration(conf);
-    myConfiguration.setInt(Generator.GENERATOR_MAX_COUNT, 2);
+    myConfiguration.setInt(Generator.GENERATOR_MAX_COUNT, maxPerHost);
     Path generatedSegment = generateFetchlist(Integer.MAX_VALUE,
         myConfiguration, false);
 
@@ -156,10 +157,13 @@ public class TestGenerator {
     ArrayList<URLCrawlDatum> fetchList = readContents(fetchlistPath);
 
     // verify we got right amount of records
-    Assert.assertEquals(1, fetchList.size());
+    int expectedFetchListSize = Math.min(maxPerHost, list.size());
+    Assert.assertEquals("Failed to apply generate.max.count by host",
+        expectedFetchListSize, fetchList.size());
 
+    maxPerHost = 2;
     myConfiguration = new Configuration(conf);
-    myConfiguration.setInt(Generator.GENERATOR_MAX_COUNT, 3);
+    myConfiguration.setInt(Generator.GENERATOR_MAX_COUNT, maxPerHost);
     generatedSegment = generateFetchlist(Integer.MAX_VALUE, myConfiguration,
         false);
 
@@ -169,10 +173,13 @@ public class TestGenerator {
     fetchList = readContents(fetchlistPath);
 
     // verify we got right amount of records
-    Assert.assertEquals(2, fetchList.size());
+    expectedFetchListSize = Math.min(maxPerHost, list.size());
+    Assert.assertEquals("Failed to apply generate.max.count by host",
+        expectedFetchListSize, fetchList.size());
 
+    maxPerHost = 3;
     myConfiguration = new Configuration(conf);
-    myConfiguration.setInt(Generator.GENERATOR_MAX_COUNT, 4);
+    myConfiguration.setInt(Generator.GENERATOR_MAX_COUNT, maxPerHost);
     generatedSegment = generateFetchlist(Integer.MAX_VALUE, myConfiguration,
         false);
 
@@ -182,7 +189,9 @@ public class TestGenerator {
     fetchList = readContents(fetchlistPath);
 
     // verify we got right amount of records
-    Assert.assertEquals(3, fetchList.size());
+    expectedFetchListSize = Math.min(maxPerHost, list.size());
+    Assert.assertEquals("Failed to apply generate.max.count by host",
+        expectedFetchListSize, fetchList.size());
   }
 
   /**
@@ -201,8 +210,9 @@ public class TestGenerator {
 
     createCrawlDB(list);
 
+    int maxPerDomain = 1;
     Configuration myConfiguration = new Configuration(conf);
-    myConfiguration.setInt(Generator.GENERATOR_MAX_COUNT, 2);
+    myConfiguration.setInt(Generator.GENERATOR_MAX_COUNT, maxPerDomain);
     myConfiguration.set(Generator.GENERATOR_COUNT_MODE,
         Generator.GENERATOR_COUNT_VALUE_DOMAIN);
 
@@ -215,10 +225,13 @@ public class TestGenerator {
     ArrayList<URLCrawlDatum> fetchList = readContents(fetchlistPath);
 
     // verify we got right amount of records
-    Assert.assertEquals(1, fetchList.size());
+    int expectedFetchListSize = Math.min(maxPerDomain, list.size());
+    Assert.assertEquals("Failed to apply generate.max.count by domain",
+        expectedFetchListSize, fetchList.size());
 
+    maxPerDomain = 2;
     myConfiguration = new Configuration(myConfiguration);
-    myConfiguration.setInt(Generator.GENERATOR_MAX_COUNT, 3);
+    myConfiguration.setInt(Generator.GENERATOR_MAX_COUNT, maxPerDomain);
     generatedSegment = generateFetchlist(Integer.MAX_VALUE, myConfiguration,
         false);
 
@@ -228,10 +241,13 @@ public class TestGenerator {
     fetchList = readContents(fetchlistPath);
 
     // verify we got right amount of records
-    Assert.assertEquals(2, fetchList.size());
+    expectedFetchListSize = Math.min(maxPerDomain, list.size());
+    Assert.assertEquals("Failed to apply generate.max.count by domain",
+        expectedFetchListSize, fetchList.size());
 
+    maxPerDomain = 3;
     myConfiguration = new Configuration(myConfiguration);
-    myConfiguration.setInt(Generator.GENERATOR_MAX_COUNT, 4);
+    myConfiguration.setInt(Generator.GENERATOR_MAX_COUNT, maxPerDomain);
     generatedSegment = generateFetchlist(Integer.MAX_VALUE, myConfiguration,
         false);
 
@@ -241,7 +257,9 @@ public class TestGenerator {
     fetchList = readContents(fetchlistPath);
 
     // verify we got right amount of records
-    Assert.assertEquals(3, fetchList.size());
+    expectedFetchListSize = Math.min(maxPerDomain, list.size());
+    Assert.assertEquals("Failed to apply generate.max.count by domain",
+        expectedFetchListSize, fetchList.size());
   }
 
   /**


### PR DESCRIPTION
- ensure that also last created segment contains maxCount URLs per host
- use local variable to hold host-specific maxCount set in HostDb  (do not modify instance variable temporarily)
- fix Java compile warnings: add missing generic type parameters
