### PR TITLE
fix for NUTCH-2601: CloudSearch implementation class.

### DIFF
--- a/conf/index-writers.xml.template
+++ b/conf/index-writers.xml.template
@@ -129,7 +129,7 @@
       <remove />
     </mapping>
   </writer>
-  <writer id="indexer_cloud_search_1" class="org.apache.nutch.indexwriter.elasticrest.ElasticRestIndexWriter">
+  <writer id="indexer_cloud_search_1" class="org.apache.nutch.indexwriter.cloudsearch.CloudSearchIndexWriter">
     <parameters>
       <param name="endpoint" value=""/>
       <param name="region" value=""/>


### PR DESCRIPTION
CloudSearch implementation class fixed on index-writers.xml.template
