### PR TITLE
fix for NUTCH-2600: indexer-solr refactoring

### DIFF
--- a/conf/index-writers.xml.template
+++ b/conf/index-writers.xml.template
@@ -22,10 +22,10 @@
   <writer id="indexer_solr_1" class="org.apache.nutch.indexwriter.solr.SolrIndexWriter">
     <parameters>
       <param name="type" value="http"/>
-      <!-- Solr URL (default core name is "nutch" but you may change it): -->
       <param name="url" value="http://localhost:8983/solr/nutch"/>
-      <param name="commitSize" value="250"/>
-      <param name="commitIndex" value="true"/>
+      <param name="collection" value=""/>
+      <param name="weight.field" value=""/>
+      <param name="commitSize" value="1000"/>
       <param name="auth" value="false"/>
       <param name="username" value="username"/>
       <param name="password" value="password"/>

--- a/src/java/org/apache/nutch/indexer/IndexingJob.java
+++ b/src/java/org/apache/nutch/indexer/IndexingJob.java
@@ -125,9 +125,6 @@ public class IndexingJob extends NutchTool implements Tool {
 
     IndexerMapReduce.initMRJob(crawlDb, linkDb, segments, job, addBinaryContent);
 
-    // NOW PASSED ON THE COMMAND LINE AS A HADOOP PARAM
-    // job.set(SolrConstants.SERVER_URL, solrUrl);
-
     conf.setBoolean(IndexerMapReduce.INDEXER_DELETE, deleteGone);
     conf.setBoolean(IndexerMapReduce.URL_FILTERING, filter);
     conf.setBoolean(IndexerMapReduce.URL_NORMALIZING, normalize);

--- a/src/plugin/indexer-solr/ivy.xml
+++ b/src/plugin/indexer-solr/ivy.xml
@@ -36,9 +36,9 @@
   </publications>
 
   <dependencies>
-    <dependency org="org.apache.solr" name="solr-solrj" rev="5.5.0"/>
-    <dependency org="org.apache.httpcomponents" name="httpcore" rev="4.4.1" conf="*->default"/>
-    <dependency org="org.apache.httpcomponents" name="httpmime" rev="4.4.1" conf="*->default"/>
+    <dependency org="org.apache.solr" name="solr-solrj" rev="7.3.1"/>
+    <dependency org="org.apache.httpcomponents" name="httpcore" rev="4.4.6" conf="*->default"/>
+    <dependency org="org.apache.httpcomponents" name="httpmime" rev="4.5.3" conf="*->default"/>
   </dependencies>
   
 </ivy-module>

--- a/src/plugin/indexer-solr/plugin.xml
+++ b/src/plugin/indexer-solr/plugin.xml
@@ -22,15 +22,15 @@
     <library name="indexer-solr.jar">
       <export name="*" />
     </library>
-      <library name="commons-io-2.4.jar"/>
-      <library name="httpclient-4.4.1.jar"/>
-      <library name="httpcore-4.4.1.jar"/>
-      <library name="httpmime-4.4.1.jar"/>
-      <library name="noggit-0.6.jar"/>
-      <library name="solr-solrj-5.5.0.jar"/>
+      <library name="commons-io-2.5.jar"/>
+      <library name="httpclient-4.5.3.jar"/>
+      <library name="httpcore-4.4.6.jar"/>
+      <library name="httpmime-4.5.3.jar"/>
+      <library name="noggit-0.8.jar"/>
+      <library name="solr-solrj-7.3.1.jar"/>
       <library name="stax2-api-3.1.4.jar"/>
       <library name="woodstox-core-asl-4.4.1.jar"/>
-      <library name="zookeeper-3.4.6.jar"/> 
+      <library name="zookeeper-3.4.11.jar"/>
   </runtime>
 
   <requires>

--- a/src/plugin/indexer-solr/src/java/org/apache/nutch/indexwriter/solr/SolrConstants.java
+++ b/src/plugin/indexer-solr/src/java/org/apache/nutch/indexwriter/solr/SolrConstants.java
@@ -17,43 +17,21 @@
 package org.apache.nutch.indexwriter.solr;
 
 public interface SolrConstants {
-  public static final String SOLR_PREFIX = "solr.";
 
-  public static final String SERVER_TYPE = "type";
+  String SERVER_TYPE = "type";
 
-  public static final String SERVER_URL = "url";
+  String SERVER_URLS = "url";
 
-  public static final String COMMIT_SIZE = "commitSize";
+  String COLLECTION = "collection";
 
-  public static final String MAPPING_FILE = SOLR_PREFIX + "mapping.file";
+  String COMMIT_SIZE = "commitSize";
 
-  public static final String USE_AUTH = "auth";
+  String WEIGHT_FIELD = "weight.field";
 
-  public static final String USERNAME = "username";
+  String USE_AUTH = "auth";
 
-  public static final String PASSWORD = "password";
+  String USERNAME = "username";
 
-  public static final String LOAD_BALANCE_URL = "loadbalanceURL";
+  String PASSWORD = "password";
 
-  public static final String COLLECTION = "collection";
-
-  public static final String ZOOKEEPER_HOSTS = SOLR_PREFIX + "zookeeper.hosts";
-
-  public static final String ID_FIELD = "id";
-
-  public static final String URL_FIELD = "url";
-
-  public static final String BOOST_FIELD = "boost";
-
-  public static final String TIMESTAMP_FIELD = "tstamp";
-
-  public static final String DIGEST_FIELD = "digest";
-
-
-
-  @Deprecated
-  public static final String COMMIT_INDEX = "commitIndex";
-
-  @Deprecated
-  public static final String PARAMS = SOLR_PREFIX + "params";
 }


### PR DESCRIPTION
This patch includes an update for solrj library from version 5.5.0 to 7.3.1. According to [SOLR-8903](https://issues.apache.org/jira/browse/SOLR-8903), the lastest available version of this library doesn't include `DateUtil` class, so for formatting the dates I used `DateTimeFormatter.ISO_INSTANT.format(d.toInstant())` instead. In addition, the weight of a document is no longer supported by this library as an attribute of `SolrInputDocument` class and for that reason I include a new paramater: "weight.field", indicating the field's name where the document weight should be written. Also, Basic Authentication is now supported.

On the other side, I refactored the code, deleting some unused constants, unsed parameters and including others in index-writers.xml.

This PR was tested in Solr 6.3.0 and 7.3.1 in standalone and cloud mode. Basic Authentication was tested in these versions too.