### PR TITLE
NUTCH-1106 Options to skip url's based on length

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -702,7 +702,7 @@
 
 <property>
   <name>db.max.outlink.length</name>
-  <value>8192</value>
+  <value>4096</value>
   <description>
     The maximum length in characters accepted for outlinks before
     applying URL normalizers and filters.  If this value is

--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -701,6 +701,21 @@
 </property>
 
 <property>
+  <name>db.max.outlink.length</name>
+  <value>8192</value>
+  <description>
+    The maximum length in characters accepted for outlinks before
+    applying URL normalizers and filters.  If this value is
+    nonnegative (>=0), only URLs with a length in characters less or
+    equal than db.max.outlink.length are accepted and then passed to
+    URL normalizers and filters. Doing the length check beforehand
+    avoids that normalizers or filters hang up on overlong URLs.
+    Note: this property is only used to check URLs found as outlinks
+    and redirects, but not for injected URLs.
+  </description>
+</property>
+
+<property>
   <name>db.parsemeta.to.crawldb</name>
   <value></value>
   <description>Comma-separated list of parse metadata keys to transfer to the crawldb (NUTCH-779).

--- a/conf/regex-urlfilter.txt.template
+++ b/conf/regex-urlfilter.txt.template
@@ -26,8 +26,8 @@
 # skip file: ftp: and mailto: urls
 -^(file|ftp|mailto):
 
-# skip URLs longer than 8192 characters, see also db.max.outlink.length
-#-^.{8193,}
+# skip URLs longer than 2048 characters, see also db.max.outlink.length
+#-^.{2049,}
 
 # skip image and other suffixes we can't yet parse
 # for a more extensive coverage use the urlfilter-suffix plugin

--- a/conf/regex-urlfilter.txt.template
+++ b/conf/regex-urlfilter.txt.template
@@ -26,6 +26,9 @@
 # skip file: ftp: and mailto: urls
 -^(file|ftp|mailto):
 
+# skip URLs longer than 8192 characters, see also db.max.outlink.length
+#-^.{8193,}
+
 # skip image and other suffixes we can't yet parse
 # for a more extensive coverage use the urlfilter-suffix plugin
 -(?i)\.(gif|jpg|png|ico|css|sit|eps|wmf|zip|ppt|mpg|xls|gz|rpm|tgz|mov|exe|jpeg|bmp|js)$

--- a/src/java/org/apache/nutch/fetcher/FetcherThread.java
+++ b/src/java/org/apache/nutch/fetcher/FetcherThread.java
@@ -200,7 +200,7 @@ public class FetcherThread extends Thread {
     int maxOutlinksPerPage = conf.getInt("db.max.outlinks.per.page", 100);
     maxOutlinks = (maxOutlinksPerPage < 0) ? Integer.MAX_VALUE
         : maxOutlinksPerPage;
-    int maxOutlinkL = conf.getInt("db.max.outlink.length", 8192);
+    int maxOutlinkL = conf.getInt("db.max.outlink.length", 4096);
     maxOutlinkLength = (maxOutlinkL < 0) ? Integer.MAX_VALUE : maxOutlinkL;
     interval = conf.getInt("db.fetch.interval.default", 2592000);
     ignoreInternalLinks = conf.getBoolean("db.ignore.internal.links", false);

--- a/src/java/org/apache/nutch/parse/ParseOutputFormat.java
+++ b/src/java/org/apache/nutch/parse/ParseOutputFormat.java
@@ -164,7 +164,7 @@ public class ParseOutputFormat extends OutputFormat<Text, Parse> {
     int maxOutlinksPerPage = conf.getInt("db.max.outlinks.per.page", 100);
     final int maxOutlinks = (maxOutlinksPerPage < 0) ? Integer.MAX_VALUE
         : maxOutlinksPerPage;
-    int maxOutlinkL = conf.getInt("db.max.outlink.length", 8192);
+    int maxOutlinkL = conf.getInt("db.max.outlink.length", 4096);
     final int maxOutlinkLength = (maxOutlinkL < 0) ? Integer.MAX_VALUE
         : maxOutlinkL;
     final boolean isParsing = conf.getBoolean("fetcher.parse", true);

--- a/src/java/org/apache/nutch/parse/ParseOutputFormat.java
+++ b/src/java/org/apache/nutch/parse/ParseOutputFormat.java
@@ -162,9 +162,12 @@ public class ParseOutputFormat extends OutputFormat<Text, Parse> {
     final boolean storeText = conf.getBoolean("parser.store.text", true);
 
     int maxOutlinksPerPage = conf.getInt("db.max.outlinks.per.page", 100);
-    final boolean isParsing = conf.getBoolean("fetcher.parse", true);
     final int maxOutlinks = (maxOutlinksPerPage < 0) ? Integer.MAX_VALUE
         : maxOutlinksPerPage;
+    int maxOutlinkL = conf.getInt("db.max.outlink.length", 8192);
+    final int maxOutlinkLength = (maxOutlinkL < 0) ? Integer.MAX_VALUE
+        : maxOutlinkL;
+    final boolean isParsing = conf.getBoolean("fetcher.parse", true);
     final CompressionType compType = SequenceFileOutputFormat
         .getOutputCompressionType(context);
     Path out = FileOutputFormat.getOutputPath(context);
@@ -301,6 +304,9 @@ public class ParseOutputFormat extends OutputFormat<Text, Parse> {
 
           // only normalize and filter if fetcher.parse = false
           if (!isParsing) {
+            if (toUrl.length() > maxOutlinkLength) {
+              continue;
+            }
             toUrl = ParseOutputFormat.filterNormalize(fromUrl, toUrl, origin,
                 ignoreInternalLinks, ignoreExternalLinks, ignoreExternalLinksMode, filters, exemptionFilters, normalizers);
             if (toUrl == null) {


### PR DESCRIPTION
- add property db.max.outlink.length to limit length of outlinks and redirects (default = 8192 characters)
- check length in ParseOutputFormat and FetcherThread for outlinks and redirects
- also add rule (not active, commented out) to regex-urlfilters.txt.template
