### PR TITLE
NUTCH-2619 protocol-okhttp: allow to keep partially fetched docs as truncated

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -224,6 +224,20 @@
 </property>
 
 <property>
+  <name>http.time.limit</name>
+  <value>-1</value>
+  <description>The time limit in seconds to fetch a single document.
+  If this value is nonnegative (>=0), the HTTP protocol implementation
+  will stop reading from a socket after http.time.limit seconds have
+  been spent for fetching this document.  The HTTP response is then
+  marked as truncated.  The http.time.limit should be set to a longer
+  time period than http.timeout, as it applies to the entire duration
+  to fetch a document, not only the network timeout of a single I/O
+  operation.  Note: supported only by protocol-okhttp.
+  </description>
+</property>
+
+<property>
   <name>http.proxy.host</name>
   <value></value>
   <description>The proxy hostname.  If empty, no proxy is used.</description>

--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -238,6 +238,18 @@
 </property>
 
 <property>
+  <name>http.partial.truncated</name>
+  <value>false</value>
+  <description>
+    If true the HTTP protocol implementation may store the content of
+    partial fetches and mark the response as truncated instead of
+    throwing an exception which will cause the fetch to fail.  This
+    allows to use the data which has already been fetched, instead of
+    retrying the fetch later.  Note: supported only by protocol-okhttp.
+  </description>
+</property>
+
+<property>
   <name>http.proxy.host</name>
   <value></value>
   <description>The proxy hostname.  If empty, no proxy is used.</description>

--- a/src/java/org/apache/nutch/net/protocols/Response.java
+++ b/src/java/org/apache/nutch/net/protocols/Response.java
@@ -64,7 +64,7 @@ public interface Response extends HttpHeaders {
     LENGTH,
     /** fetch exceeded configured http.fetch.duration */
     TIME,
-    /** network disconnect during fetch */
+    /** network disconnect or timeout during fetch */
     DISCONNECT,
     /** implementation internal reason */
     INTERNAL,

--- a/src/java/org/apache/nutch/net/protocols/Response.java
+++ b/src/java/org/apache/nutch/net/protocols/Response.java
@@ -47,10 +47,30 @@ public interface Response extends HttpHeaders {
   public static final String FETCH_TIME = "nutch.fetch.time";
 
   /**
-   * Key to hold boolean whether content has been trimmed because it exceeds
-   * <code>http.content.limit</code>
+   * Key to hold boolean whether content has been truncated, e.g., because it
+   * exceeds <code>http.content.limit</code>
    */
-  public static final String TRIMMED_CONTENT = "http.content.trimmed";
+  public static final String TRUNCATED_CONTENT = "http.content.truncated";
+
+  /**
+   * Key to hold reason why content has been truncated, see
+   * {@link TruncatedContentReason}
+   */
+  public static final String TRUNCATED_CONTENT_REASON = "http.content.truncated.reason";
+
+  public static enum TruncatedContentReason {
+    NOT_TRUNCATED,
+    /** fetch exceeded configured http.content.limit */
+    LENGTH,
+    /** fetch exceeded configured http.fetch.duration */
+    TIME,
+    /** network disconnect during fetch */
+    DISCONNECT,
+    /** implementation internal reason */
+    INTERNAL,
+    /** unknown reason */
+    UNSPECIFIED
+  };
 
   /** Returns the URL used to retrieve this response. */
   public URL getUrl();

--- a/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpBase.java
+++ b/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpBase.java
@@ -88,6 +88,9 @@ public abstract class HttpBase implements Protocol {
   /** The length limit for downloaded content, in bytes. */
   protected int maxContent = 64 * 1024;
 
+  /** The time limit to download the entire content, in seconds. */
+  protected int maxDuration = 300;
+
   /** The Nutch 'User-Agent' request header */
   protected String userAgent = getAgentString("NutchCVS", null, "Nutch",
       "http://nutch.apache.org/bot.html", "agent@nutch.apache.org");
@@ -186,6 +189,7 @@ public abstract class HttpBase implements Protocol {
     this.useProxy = (proxyHost != null && proxyHost.length() > 0);
     this.timeout = conf.getInt("http.timeout", 10000);
     this.maxContent = conf.getInt("http.content.limit", 64 * 1024);
+    this.maxDuration = conf.getInt("http.time.limit", -1);
     this.userAgent = getAgentString(conf.get("http.agent.name"),
         conf.get("http.agent.version"), conf.get("http.agent.description"),
         conf.get("http.agent.url"), conf.get("http.agent.email"));
@@ -440,6 +444,14 @@ public abstract class HttpBase implements Protocol {
 
   public int getMaxContent() {
     return maxContent;
+  }
+
+  /**
+   * The time limit to download the entire content, in seconds. See the property
+   * <code>http.time.limit</code>.
+   */
+  public int getMaxDuration() {
+    return maxDuration;
   }
 
   public String getUserAgent() {

--- a/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpBase.java
+++ b/src/plugin/lib-http/src/java/org/apache/nutch/protocol/http/api/HttpBase.java
@@ -91,6 +91,9 @@ public abstract class HttpBase implements Protocol {
   /** The time limit to download the entire content, in seconds. */
   protected int maxDuration = 300;
 
+  /** Whether to save partial fetches as truncated content. */
+  protected boolean partialAsTruncated = false;
+
   /** The Nutch 'User-Agent' request header */
   protected String userAgent = getAgentString("NutchCVS", null, "Nutch",
       "http://nutch.apache.org/bot.html", "agent@nutch.apache.org");
@@ -190,6 +193,8 @@ public abstract class HttpBase implements Protocol {
     this.timeout = conf.getInt("http.timeout", 10000);
     this.maxContent = conf.getInt("http.content.limit", 64 * 1024);
     this.maxDuration = conf.getInt("http.time.limit", -1);
+    this.partialAsTruncated = conf
+        .getBoolean("http.partial.truncated", false);
     this.userAgent = getAgentString(conf.get("http.agent.name"),
         conf.get("http.agent.version"), conf.get("http.agent.description"),
         conf.get("http.agent.url"), conf.get("http.agent.email"));
@@ -199,7 +204,7 @@ public abstract class HttpBase implements Protocol {
     this.accept = conf.get("http.accept", accept).trim();
     this.mimeTypes = new MimeUtil(conf);
     // backward-compatible default setting
-    this.useHttp11 = conf.getBoolean("http.useHttp11", false);
+    this.useHttp11 = conf.getBoolean("http.useHttp11", true);
     this.useHttp2 = conf.getBoolean("http.useHttp2", false);
     this.responseTime = conf.getBoolean("http.store.responsetime", true);
     this.storeIPAddress = conf.getBoolean("store.ip.address", false);
@@ -452,6 +457,14 @@ public abstract class HttpBase implements Protocol {
    */
   public int getMaxDuration() {
     return maxDuration;
+  }
+
+  /**
+   * Whether to save partial fetches as truncated content, cf. the property
+   * <code>http.partial.truncated</code>.
+   */
+  public boolean isStorePartialAsTruncated() {
+    return partialAsTruncated;
   }
 
   public String getUserAgent() {

--- a/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttpResponse.java
+++ b/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttpResponse.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.util.Base64;
+import java.util.Locale;
 
-import org.apache.commons.lang.mutable.MutableBoolean;
 import org.apache.hadoop.io.Text;
 import org.apache.nutch.crawl.CrawlDatum;
 import org.apache.nutch.metadata.Metadata;
@@ -45,6 +45,27 @@ public class OkHttpResponse implements Response {
   private byte[] content;
   private int code;
   private Metadata headers = new Metadata();
+
+  /** Container to store whether and why content has been truncated */
+  public static class TruncatedContent {
+
+    private TruncatedContentReason value = TruncatedContentReason.NOT_TRUNCATED;
+
+    public TruncatedContent() {
+    }
+
+    public void setReason(TruncatedContentReason val) {
+      value = val;
+   }
+
+    public TruncatedContentReason getReason() {
+       return value;
+    }
+
+    public boolean booleanValue() {
+      return value != TruncatedContentReason.NOT_TRUNCATED;
+    }
+  }
 
   public OkHttpResponse(OkHttp okhttp, URL url, CrawlDatum datum)
       throws ProtocolException, IOException {
@@ -91,16 +112,19 @@ public class OkHttpResponse implements Response {
     LOG.debug("{} - {} {} {}", url, response.protocol(), response.code(),
         response.message());
 
-    MutableBoolean trimmed = new MutableBoolean();
-    content = toByteArray(response.body(), trimmed, okhttp.getMaxContent(),
-        okhttp.getTimeout());
+    TruncatedContent truncated = new TruncatedContent();
+    content = toByteArray(response.body(), truncated, okhttp.getMaxContent(),
+        okhttp.getMaxDuration());
     responsemetadata.add(FETCH_TIME, Long.toString(System.currentTimeMillis()));
-    if (trimmed.booleanValue()) {
+    if (truncated.booleanValue()) {
       if (!call.isCanceled()) {
         call.cancel();
       }
-      responsemetadata.set(TRIMMED_CONTENT, "true");
-      LOG.debug("HTTP content trimmed to {} bytes", content.length);
+      responsemetadata.set(TRUNCATED_CONTENT, "true");
+      responsemetadata.set(TRUNCATED_CONTENT_REASON,
+          truncated.getReason().toString().toLowerCase(Locale.ROOT));
+      LOG.debug("HTTP content truncated to {} bytes (reason: {})",
+          content.length, truncated.getReason());
     }
 
     code = response.code();
@@ -109,15 +133,15 @@ public class OkHttpResponse implements Response {
   }
 
   private final byte[] toByteArray(final ResponseBody responseBody,
-      MutableBoolean trimmed, int maxContent, int timeout) throws IOException {
+      TruncatedContent truncated, int maxContent, int maxDuration) throws IOException {
 
     if (responseBody == null) {
       return new byte[] {};
     }
 
     long endDueFor = -1;
-    if (timeout != -1) {
-      endDueFor = System.currentTimeMillis() + timeout;
+    if (maxDuration != -1) {
+      endDueFor = System.currentTimeMillis() + (maxDuration * 1000);
     }
 
     int maxContentBytes = Integer.MAX_VALUE;
@@ -143,19 +167,19 @@ public class OkHttpResponse implements Response {
         break;
       }
       if (endDueFor != -1 && endDueFor <= System.currentTimeMillis()) {
-        LOG.debug("timeout reached");
-        trimmed.setValue(true);
+        LOG.debug("max. fetch duration reached");
+        truncated.setReason(TruncatedContentReason.TIME);
         break;
       }
       if (contentBytesBuffered > maxContentBytes) {
         LOG.debug("content limit reached");
-        trimmed.setValue(true);
+        truncated.setReason(TruncatedContentReason.LENGTH);
       }
     }
     int bytesToCopy = contentBytesBuffered;
     if (maxContent != -1 && contentBytesBuffered > maxContent) {
       // okhttp's internal buffer is larger than maxContent
-      trimmed.setValue(true);
+      truncated.setReason(TruncatedContentReason.LENGTH);
       bytesToCopy = maxContentBytes;
     }
     byte[] arr = new byte[bytesToCopy];


### PR DESCRIPTION
If http.partial.truncated is true and there is already content fetched, the content is returned as successful response but marked as truncated. Tested by disconnecting network while fetching an overlong documents (10 MB).

PR includes and is based on fix for NUTCH-2618.