### PR TITLE
NUTCH-1993 Nutch does not use backup parsers

### DIFF
--- a/src/java/org/apache/nutch/parse/ParseResult.java
+++ b/src/java/org/apache/nutch/parse/ParseResult.java
@@ -59,7 +59,7 @@ public class ParseResult implements Iterable<Map.Entry<Text, Parse>> {
 
   /**
    * Convenience method for obtaining {@link ParseResult} from a single
-   * <code>Parse</code> output.
+   * {@link Parse} output.
    * 
    * @param url
    *          canonical url.
@@ -150,7 +150,7 @@ public class ParseResult implements Iterable<Map.Entry<Text, Parse>> {
 
   /**
    * Remove all results where status is not successful (as determined by
-   * <code>ParseStatus#isSuccess()</code>). Note that effects of this operation
+   * {@link ParseStatus#isSuccess()}). Note that effects of this operation
    * cannot be reversed.
    */
   public void filter() {
@@ -166,7 +166,7 @@ public class ParseResult implements Iterable<Map.Entry<Text, Parse>> {
 
   /**
    * A convenience method which returns true only if all parses are successful.
-   * Parse success is determined by <code>ParseStatus#isSuccess()</code>.
+   * Parse success is determined by {@link ParseStatus#isSuccess()}.
    */
   public boolean isSuccess() {
     for (Iterator<Entry<Text, Parse>> i = iterator(); i.hasNext();) {
@@ -176,5 +176,19 @@ public class ParseResult implements Iterable<Map.Entry<Text, Parse>> {
       }
     }
     return true;
+  }
+
+  /**
+   * A convenience method which returns true if at least one of the parses is
+   * successful. Parse success is determined by {@link ParseStatus#isSuccess()}.
+   */
+  public boolean isAnySuccess() {
+    for (Iterator<Entry<Text, Parse>> i = iterator(); i.hasNext();) {
+      Entry<Text, Parse> entry = i.next();
+      if (entry.getValue().getData().getStatus().isSuccess()) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/java/org/apache/nutch/parse/ParseUtil.java
+++ b/src/java/org/apache/nutch/parse/ParseUtil.java
@@ -34,9 +34,6 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
  * as iterating through a preferred list of {@link Parser}s to obtain
  * {@link Parse} objects.
  * 
- * @author mattmann
- * @author J&eacute;r&ocirc;me Charron
- * @author S&eacute;bastien Le Callonnec
  */
 public class ParseUtil {
 
@@ -102,8 +99,16 @@ public class ParseUtil {
         }
       }
 
-      if (parseResult != null && !parseResult.isEmpty())
+      if (parseResult != null && parseResult.isAnySuccess()) {
         return parseResult;
+      }
+
+      // continue and try further parsers if parse failed
+    }
+
+    // if there is a failed parse result return it (contains reason for failure)
+    if (parseResult != null && !parseResult.isEmpty()) {
+      return parseResult;
     }
 
     if (LOG.isWarnEnabled()) {


### PR DESCRIPTION
- apply patch contributed by Arkadi Kosmynin
- return last failed parse result (the empty result returned otherwise does not contain the failure reason)
- improve javadoc
