### PR TITLE
NUTCH-2621 Generate report of third-party licenses

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -562,7 +562,13 @@
 
   <!-- target: report  ================================================== -->
   <target name="report" depends="resolve-test" description="--> generates a report of dependencies">
-    <ivy:report todir="${build.dir}"/>
+    <ivy:report todir="${build.dir}" xml="true"/>
+  </target>
+
+  <!-- target: 3rd-party licenses report  =============================== -->
+  <target name="report-licenses" depends="resolve-default" description="--> generates a report of licenses of dependencies">
+    <ivy:report todir="${build.dir}" xml="false" graph="false" xslfile="ivy/ivy-report-license.xsl"
+                outputpattern="[organisation]-[module]-[conf]-3rd-party-licenses.tsv"/>
   </target>
 
   <!-- target: ivy-init  ================================================ -->

--- a/ivy/ivy-report-license.xsl
+++ b/ivy/ivy-report-license.xsl
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+-->
+<!-- XSLT to extract third-party licenses in a tabular view, see ant target `ant report-license` -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="text"/>
+<xsl:template match="/ivy-report">
+  <xsl:text>Name&#x09;Organization&#x09;Revision&#x09;PubDate&#x09;Licenses...&#x0a;</xsl:text>
+  <xsl:for-each select="dependencies/module">
+    <xsl:value-of select="@name"/>
+    <xsl:text>&#x09;</xsl:text>
+    <xsl:value-of select="@organisation"/>
+    <xsl:for-each select="revision[not(@evicted)]/license">
+      <xsl:text>&#x09;</xsl:text>
+      <xsl:value-of select="../@name"/>
+      <xsl:text>&#x09;</xsl:text>
+      <xsl:value-of select="../@pubdate"/>
+      <xsl:text>&#x09;</xsl:text>
+      <xsl:value-of select="@name"/>
+      <xsl:text>&#x09;</xsl:text>
+      <xsl:value-of select="@url"/>
+    </xsl:for-each>
+    <xsl:text>&#x0a;</xsl:text>
+  </xsl:for-each>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/src/plugin/build-plugin.xml
+++ b/src/plugin/build-plugin.xml
@@ -236,7 +236,13 @@
   </target>
 
   <target name="report" depends="resolve-test" description="--> generates a report of dependencies">
-    <ivy:report todir="${build.dir}"/>
+    <ivy:report todir="${build.dir}" xml="true"/>
+  </target>
+
+  <!-- target: 3rd-party licenses report  =============================== -->
+  <target name="report-licenses" depends="resolve-default" description="--> generates a report of licenses of dependencies">
+    <ivy:report todir="${build.dir}" xml="false" graph="false" xslfile="${nutch.root}/ivy/ivy-report-license.xsl"
+                outputpattern="[organisation]-[module]-[conf]-3rd-party-licenses.tsv"/>
   </target>
 
   <!-- ================================================================== -->


### PR DESCRIPTION
- add ant target `ant report-licenses` (for core and plugins) which generates tabular reports of dependency licenses

The created table is comparable to those created by the [Maven license plugin](https://www.mojohaus.org/license-maven-plugin/index.html)
- it also shows dual licenses (important if one of the alternatives is compatible with the Apache license)
- must be called separately for core and each plugin, e.g.
```
# Nutch core
ant report-licenses
more build/org.apache.nutch-nutch-default-3rd-party-licenses.tsv

# plugin any23
cd src/plugin/any23
ant report-licenses
more ../../../build/any23/org.apache.nutch-any23-default-3rd-party-licenses.tsv
```