### PR TITLE
NUTCH-2623 Fetcher to guarantee delay for same host/domain/ip independent of http/https protocol

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -979,8 +979,9 @@
 <property>
   <name>fetcher.queue.mode</name>
   <value>byHost</value>
-  <description>Determines how to put URLs into queues. Default value is 'byHost', 
-  also takes 'byDomain' or 'byIP'. 
+  <description>Determines how to put URLs into queues. Default value
+  is 'byHost', also takes 'byDomain' or 'byIP'. Crawl delays are
+  implemented on the level of fetcher queues.
   </description>
 </property>
 

--- a/src/java/org/apache/nutch/fetcher/FetchItem.java
+++ b/src/java/org/apache/nutch/fetcher/FetchItem.java
@@ -20,6 +20,7 @@ import java.lang.invoke.MethodHandles;
 import java.net.InetAddress;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.util.Locale;
 
 import org.apache.hadoop.io.Text;
 import org.apache.nutch.crawl.CrawlDatum;
@@ -65,7 +66,6 @@ public class FetchItem {
 
   public static FetchItem create(Text url, CrawlDatum datum,
       String queueMode, int outlinkDepth) {
-    String queueID;
     URL u = null;
     try {
       u = new URL(url.toString());
@@ -73,7 +73,6 @@ public class FetchItem {
       LOG.warn("Cannot parse url: " + url, e);
       return null;
     }
-    final String proto = u.getProtocol().toLowerCase();
     String key;
     if (FetchItemQueues.QUEUE_MODE_IP.equalsIgnoreCase(queueMode)) {
       try {
@@ -85,21 +84,20 @@ public class FetchItem {
         return null;
       }
     } else if (FetchItemQueues.QUEUE_MODE_DOMAIN.equalsIgnoreCase(queueMode)) {
-      key = URLUtil.getDomainName(u);
+      key = URLUtil.getDomainName(u).toLowerCase(Locale.ROOT);
       if (key == null) {
         LOG.warn("Unknown domain for url: " + url
             + ", using URL string as key");
         key = u.toExternalForm();
       }
     } else {
-      key = u.getHost();
+      key = u.getHost().toLowerCase(Locale.ROOT);
       if (key == null) {
         LOG.warn("Unknown host for url: " + url + ", using URL string as key");
         key = u.toExternalForm();
       }
     }
-    queueID = proto + "://" + key.toLowerCase();
-    return new FetchItem(url, u, datum, queueID, outlinkDepth);
+    return new FetchItem(url, u, datum, key, outlinkDepth);
   }
 
   public CrawlDatum getDatum() {

--- a/src/java/org/apache/nutch/fetcher/FetchItemQueues.java
+++ b/src/java/org/apache/nutch/fetcher/FetchItemQueues.java
@@ -57,14 +57,7 @@ public class FetchItemQueues {
     this.conf = conf;
     this.maxThreads = conf.getInt("fetcher.threads.per.queue", 1);
     queueMode = conf.get("fetcher.queue.mode", QUEUE_MODE_HOST);
-    // check that the mode is known
-    if (!queueMode.equals(QUEUE_MODE_IP)
-        && !queueMode.equals(QUEUE_MODE_DOMAIN)
-        && !queueMode.equals(QUEUE_MODE_HOST)) {
-      LOG.error("Unknown partition mode : " + queueMode
-          + " - forcing to byHost");
-      queueMode = QUEUE_MODE_HOST;
-    }
+    queueMode = checkQueueMode(queueMode);
     LOG.info("Using queue mode : " + queueMode);
 
     this.crawlDelay = (long) (conf.getFloat("fetcher.server.delay", 1.0f) * 1000);
@@ -73,6 +66,24 @@ public class FetchItemQueues {
     this.timelimit = conf.getLong("fetcher.timelimit", -1);
     this.maxExceptionsPerQueue = conf.getInt(
         "fetcher.max.exceptions.per.queue", -1);
+  }
+
+  /**
+   * Check whether queue mode is valid, fall-back to default mode if not.
+   * 
+   * @param queueMode
+   *          queue mode to check
+   * @return valid queue mode or default
+   */
+  protected static String checkQueueMode(String queueMode) {
+    // check that the mode is known
+    if (!queueMode.equals(QUEUE_MODE_IP)
+        && !queueMode.equals(QUEUE_MODE_DOMAIN)
+        && !queueMode.equals(QUEUE_MODE_HOST)) {
+      LOG.error("Unknown partition mode : {} - forcing to byHost", queueMode);
+      queueMode = QUEUE_MODE_HOST;
+    }
+    return queueMode;
   }
 
   public int getTotalSize() {

--- a/src/java/org/apache/nutch/fetcher/FetcherThread.java
+++ b/src/java/org/apache/nutch/fetcher/FetcherThread.java
@@ -186,13 +186,7 @@ public class FetcherThread extends Thread {
     
     queueMode = conf.get("fetcher.queue.mode",
         FetchItemQueues.QUEUE_MODE_HOST);
-    // check that the mode is known
-    if (!queueMode.equals(FetchItemQueues.QUEUE_MODE_IP)
-        && !queueMode.equals(FetchItemQueues.QUEUE_MODE_DOMAIN)
-        && !queueMode.equals(FetchItemQueues.QUEUE_MODE_HOST)) {
-      LOG.error("Unknown partition mode : {} - forcing to byHost", queueMode);
-      queueMode = FetchItemQueues.QUEUE_MODE_HOST;
-    }
+    queueMode = FetchItemQueues.checkQueueMode(queueMode);
     LOG.info("{} {} Using queue mode : {}", getName(),
         Thread.currentThread().getId(), queueMode);
     this.maxRedirect = conf.getInt("http.redirect.max", 3);


### PR DESCRIPTION
- the modes byHost, byDomain and byIP now do not include the protocol for assigning URLs to queues
- added fetcher.queue.mode `byHostProtocol` for legacy
- centralize check of queue mode