### PR TITLE
NUTCH-2628 Fetcher: optionally generate signature of unparsed content

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1017,6 +1017,20 @@
 </property>
 
 <property>
+  <name>fetcher.signature</name>
+  <value>false</value>
+  <description>If true, fetcher will generate the signature for
+  successfully fetched documents even if the content is not parsed by
+  fetcher (see property fetcher.parse).  Default is false, which means
+  that the signature is calculated when parsing either by the fetcher
+  or during the parsing step.  Note that a non-parsing fetcher can
+  only generate signatures based on the binary content and not on the
+  textual content. An appropriate signature class should be chosen
+  (see property db.signature.class).
+  </description>
+</property>
+
+<property>
   <name>fetcher.timelimit.mins</name>
   <value>-1</value>
   <description>This is the number of minutes allocated to the fetching.

--- a/src/java/org/apache/nutch/fetcher/FetcherThread.java
+++ b/src/java/org/apache/nutch/fetcher/FetcherThread.java
@@ -129,6 +129,8 @@ public class FetcherThread extends Thread {
 
   private boolean storingContent;
 
+  private boolean signatureWithoutParsing;
+
   private AtomicInteger pages;
 
   private AtomicLong bytes;
@@ -155,6 +157,7 @@ public class FetcherThread extends Thread {
     this.scfilters = new ScoringFilters(conf);
     this.parseUtil = new ParseUtil(conf);
     this.skipTruncated = conf.getBoolean(ParseSegment.SKIP_TRUNCATED, true);
+    this.signatureWithoutParsing = conf.getBoolean("fetcher.signature", false);
     this.protocolFactory = new ProtocolFactory(conf);
     this.normalizers = new URLNormalizers(conf, URLNormalizers.SCOPE_FETCHER);
     this.maxCrawlDelay = conf.getInt("fetcher.max.crawl.delay", 30) * 1000;
@@ -617,13 +620,9 @@ public class FetcherThread extends Thread {
               Thread.currentThread().getId(), key, e);
         }
       }
-      /*
-       * Note: Fetcher will only follow meta-redirects coming from the
-       * original URL.
-       */
-      if (parsing && status == CrawlDatum.STATUS_FETCH_SUCCESS) {
-        if (!skipTruncated
-            || (skipTruncated && !ParseSegment.isTruncated(content))) {
+
+      if (status == CrawlDatum.STATUS_FETCH_SUCCESS) {
+        if (parsing && !(skipTruncated && ParseSegment.isTruncated(content))) {
           try {
             parseResult = this.parseUtil.parse(content);
           } catch (Exception e) {
@@ -633,7 +632,7 @@ public class FetcherThread extends Thread {
           }
         }
 
-        if (parseResult == null) {
+        if (parseResult == null && (parsing || signatureWithoutParsing)) {
           byte[] signature = SignatureFactory.getSignature(conf)
               .calculate(content, new ParseStatus().getEmptyParse(conf));
           datum.setSignature(signature);
@@ -808,7 +807,8 @@ public class FetcherThread extends Thread {
       }
     }
 
-    // return parse status if it exits
+    // return parse status (of the "original" URL if the ParseResult contains
+    // multiple parses) which allows Fetcher to follow meta-redirects
     if (parseResult != null && !parseResult.isEmpty()) {
       Parse p = parseResult.get(content.getUrl());
       if (p != null) {


### PR DESCRIPTION
- add property fetcher.signature to make fetcher generate a signature even if fetcher is not parsing
- move comment about following meta-redirects for multi-parse ParseResults into the right position