### PR TITLE
NUTCH-2637 fix number of reducers to run

### DIFF
--- a/src/java/org/apache/nutch/fetcher/FetcherJob.java
+++ b/src/java/org/apache/nutch/fetcher/FetcherJob.java
@@ -215,7 +215,7 @@ public class FetcherJob extends NutchTool implements Tool {
     StorageUtils.initReducerJob(currentJob, FetcherReducer.class);
     if (numTasks == null || numTasks < 1) {
       currentJob.setNumReduceTasks(currentJob.getConfiguration().getInt(
-          "mapreduce.job.maps", currentJob.getNumReduceTasks()));
+          "mapreduce.job.reduces", currentJob.getNumReduceTasks()));
     } else {
       currentJob.setNumReduceTasks(numTasks);
     }
@@ -248,7 +248,7 @@ public class FetcherJob extends NutchTool implements Tool {
    * @param shouldResume
    * @param numTasks
    *          number of fetching tasks (reducers). If set to &lt; 1 then use the
-   *          default, which is mapreduce.job.maps.
+   *          default, which is mapreduce.job.reduces.
    * @return 0 on success
    * @throws Exception
    */
@@ -268,7 +268,7 @@ public class FetcherJob extends NutchTool implements Tool {
    * @param shouldResume
    * @param numTasks
    *          number of fetching tasks (reducers). If set to &lt; 1 then use the
-   *          default, which is mapreduce.job.maps.
+   *          default, which is mapreduce.job.reduces.
    * @param stmDetect
    *          If set true, sitemap detection is run.
    * @param sitemap
@@ -327,7 +327,7 @@ public class FetcherJob extends NutchTool implements Tool {
         + "    -crawlId <id> - the id to prefix the schemas to operate on, \n \t \t    (default: storage.crawl.id)\n"
         + "    -threads N    - number of fetching threads per task\n"
         + "    -resume       - resume interrupted job\n"
-        + "    -numTasks N   - if N > 0 then use this many reduce tasks for fetching \n \t \t    (default: mapreduce.job.maps)"
+        + "    -numTasks N   - if N > 0 then use this many reduce tasks for fetching \n \t \t    (default: mapreduce.job.reduces)"
         + "    -sitemap      - only sitemap files are fetched, defaults to false"
         + "    -stmDetect    - sitemap files are detected from robot.txt file";
 


### PR DESCRIPTION
I'm kind a new to this, so sorry if i'm wrong.
The thing is the number of fetcher reducers are currently set to the value of "mapreduce.job.maps" when the arg not passed. It should be "mapreduce.job.reduces".

JIRA URL: https://issues.apache.org/jira/browse/NUTCH-2637

thanks