### PR TITLE
NUTCH-2642 MoreIndexingFilter parses ISO 8601 UTC dates in local time zone

### DIFF
--- a/src/plugin/index-more/src/java/org/apache/nutch/indexer/more/MoreIndexingFilter.java
+++ b/src/plugin/index-more/src/java/org/apache/nutch/indexer/more/MoreIndexingFilter.java
@@ -104,8 +104,10 @@ public class MoreIndexingFilter implements IndexingFilter {
     String lastModified = data.getMeta(Metadata.LAST_MODIFIED);
     if (lastModified != null) { // try parse last-modified
       time = getTime(lastModified, url); // use as time
-                                         // store as string
-      doc.add("lastModified", new Date(time));
+                                         // store as Date
+      if (time > -1) {
+        doc.add("lastModified", new Date(time));
+      }
     }
 
     if (time == -1) { // if no last-modified specified in HTTP header
@@ -139,7 +141,7 @@ public class MoreIndexingFilter implements IndexingFilter {
             "MMM dd yyyy HH:mm:ss. zzz", "MMM dd yyyy HH:mm:ss zzz",
             "dd.MM.yyyy HH:mm:ss zzz", "dd MM yyyy HH:mm:ss zzz",
             "dd.MM.yyyy; HH:mm:ss", "dd.MM.yyyy HH:mm:ss", "dd.MM.yyyy zzz",
-            "yyyy-MM-dd'T'HH:mm:ss'Z'" });
+            "yyyy-MM-dd'T'HH:mm:ssXXX" });
         time = parsedDate.getTime();
         // if (LOG.isWarnEnabled()) {
         // LOG.warn(url + ": parsed date: " + date +" to:"+time);


### PR DESCRIPTION
- fix date pattern not to convert date in local time zone
  (as suggested by John Lacey)
- do not add last-modified date if there is none
- add unit test
