### PR TITLE
NUTCH-2606 MIME detection is wrong for plain-text documents send as Content-Type "application/msword"

### DIFF
--- a/src/java/org/apache/nutch/util/MimeUtil.java
+++ b/src/java/org/apache/nutch/util/MimeUtil.java
@@ -200,8 +200,7 @@ public final class MimeUtil {
       }
 
       if (magicType != null && !magicType.equals(MimeTypes.OCTET_STREAM)
-          && !magicType.equals(MimeTypes.PLAIN_TEXT) && retType != null
-          && !retType.equals(magicType)) {
+          && retType != null && !retType.equals(magicType)) {
 
         // If magic enabled and the current mime type differs from that of the
         // one returned from the magic, take the magic mimeType

--- a/src/test/org/apache/nutch/util/TestMimeUtil.java
+++ b/src/test/org/apache/nutch/util/TestMimeUtil.java
@@ -68,7 +68,16 @@ public class TestMimeUtil extends TestCase {
           "<?xml version=\"1.0\"?>\n<html xmlns=\"http://www.w3.org/1999/xhtml\">"
               + "<html>\n<head>\n"
               + "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />"
-              + "</head>\n<body>Hello, World!</body></html>" } };
+              + "</head>\n<body>Hello, World!</body></html>" },
+      { /*
+         * test detection of plain-text documents with erroneous Content-Type
+         * sent in HTTP header (NUTCH-2606)
+         */
+          "text/plain", // correct MIME type
+          "test.doc", // erroneously indicates MS-Word document
+          "application/msword", // erroneous Content-Type
+          "This is a plain text document",
+          "requires-mime-magic" } };
 
   public static String[][] binaryFiles = { {
       "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -99,6 +108,9 @@ public class TestMimeUtil extends TestCase {
   /** use only HTTP Content-Type (if given) and URL pattern */
   public void testWithoutMimeMagic() {
     for (String[] testPage : textBasedFormats) {
+      if (testPage.length > 4 && "requires-mime-magic".equals(testPage[4])) {
+        continue;
+      }
       String mimeType = getMimeType(urlPrefix + testPage[1],
           testPage[3].getBytes(defaultCharset), testPage[2], false);
       assertEquals("", testPage[0], mimeType);


### PR DESCRIPTION
- allow text/plain (from MIME magic) to overwrite type derived from HTTP Content-Type or file extension