### PR TITLE
NUTCH-2660 Plugin tests not executed

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1061,6 +1061,7 @@
         <source path="${plugins.dir}/feed/src/java/" />
         <source path="${plugins.dir}/feed/src/test/" />
         <source path="${plugins.dir}/headings/src/java/" />
+        <source path="${plugins.dir}/headings/src/test/" />
         <source path="${plugins.dir}/exchange-jexl/src/java/" />
         <source path="${plugins.dir}/index-anchor/src/java/" />
         <source path="${plugins.dir}/index-anchor/src/test/" />
@@ -1104,6 +1105,7 @@
         <source path="${plugins.dir}/parse-html/src/java/" />
         <source path="${plugins.dir}/parse-html/src/test/" />
         <source path="${plugins.dir}/parse-js/src/java/" />
+        <source path="${plugins.dir}/parse-js/src/test/" />
         <source path="${plugins.dir}/parse-metatags/src/java/" />
         <source path="${plugins.dir}/parse-metatags/src/test/" />
         <source path="${plugins.dir}/parse-swf/src/java/" />

--- a/default.properties
+++ b/default.properties
@@ -93,6 +93,7 @@ plugins.protocol=\
    org.apache.nutch.protocol.http*:\
    org.apache.nutch.protocol.httpclient*:\
    org.apache.nutch.protocol.interactiveselenium*:\
+   org.apache.nutch.protocol.okhttp*:\
    org.apache.nutch.protocol.selenium*:\
    org.apache.nutch.protocol.htmlunit*:\
 

--- a/src/plugin/build.xml
+++ b/src/plugin/build.xml
@@ -113,9 +113,11 @@
      <ant dir="any23" target="test"/>
      <ant dir="creativecommons" target="test"/>
      <ant dir="feed" target="test"/>
+     <ant dir="headings" target="test"/>
      <ant dir="index-anchor" target="test"/>
      <ant dir="index-basic" target="test"/>
      <!--ant dir="index-geoip" target="test"/-->
+     <ant dir="index-jexl-filter" target="test"/>
      <ant dir="index-links" target="test"/>
      <ant dir="index-more" target="test"/>
      <ant dir="index-replace" target="test"/>
@@ -128,6 +130,7 @@
      <ant dir="mimetype-filter" target="test"/>
      <!--ant dir="parse-ext" target="test"/-->
      <ant dir="parse-html" target="test"/>
+     <ant dir="parse-js" target="test"/>
      <ant dir="parse-metatags" target="test"/>
      <ant dir="parse-swf" target="test"/>
      <ant dir="parse-tika" target="test"/>

--- a/src/plugin/headings/build.xml
+++ b/src/plugin/headings/build.xml
@@ -19,4 +19,22 @@
 
   <import file="../build-plugin.xml"/>
 
+  <!-- Build compilation dependencies -->
+  <target name="deps-jar">
+    <ant target="jar" inheritall="false" dir="../lib-nekohtml"/>
+  </target>
+
+  <!-- Add compilation dependencies to classpath -->
+  <path id="plugin.deps">
+    <fileset dir="${nutch.root}/build">
+      <include name="**/lib-nekohtml/*.jar" />
+    </fileset>
+  </path>
+
+  <!-- Deploy Unit test dependencies -->
+  <target name="deps-test">
+    <ant target="deploy" inheritall="false" dir="../lib-nekohtml"/>
+    <ant target="deploy" inheritall="false" dir="../nutch-extensionpoints"/>
+  </target>
+
 </project>


### PR DESCRIPTION
- add missing unit test packages to plugin build.xml
- tests of "headings" plugin depend on "lib-nekohtml"
- add "protocol-okhttp" to Javadoc API overview
- add missing test packages to ant "eclipse" target
