### PR TITLE
NUTCH-2668 Integrate OWASP dependency checks as ant target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -612,6 +612,34 @@
     </fail>
   </target>
 
+  <!-- Check dependencies for security vulnerabilities                                    -->
+  <!-- requires installation of OWASP dependency check tool, see                          -->
+  <!--   https://jeremylong.github.io/DependencyCheck/dependency-check-ant/index.html     -->
+  <!-- get http://dl.bintray.com/jeremy-long/owasp/dependency-check-ant-3.3.2-release.zip -->
+  <!-- and unzip in directory ./ivy/                                                      -->
+  <property name="dependency-check.home" value="${ivy.dir}/dependency-check-ant/"/>
+  <path id="dependency-check.path">
+    <pathelement location="${dependency-check.home}/dependency-check-ant.jar"/>
+    <fileset dir="${dependency-check.home}/lib">
+      <include name="*.jar"/>
+    </fileset>
+  </path>
+  <taskdef resource="dependency-check-taskdefs.properties">
+    <classpath refid="dependency-check.path" />
+  </taskdef>
+  <target name="report-vulnerabilities" description="--> check dependencies for security vulnerabilities">
+    <dependency-check projectname="${name}"
+                      reportoutputdirectory="${build.dir}"
+                      reportformat="ALL">
+        <suppressionfile path="${dependency-check.home}/dependency-check-suppressions.xml" />
+        <retirejsFilter regex="copyright.*jeremy long" />
+        <fileset dir="${build.dir}">
+          <include name="lib/*.jar"/>
+          <include name="plugins/*/*.jar"/>
+        </fileset>
+    </dependency-check>
+  </target>
+
   <!-- ================================================================== -->
   <!-- Documentation                                                      -->
   <!-- ================================================================== -->

--- a/ivy/dependency-check-ant/dependency-check-suppressions.xml
+++ b/ivy/dependency-check-ant/dependency-check-suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+   <suppress>
+      <notes>only applies to tika-server &lt; 1.18</notes>
+      <gav regex="true">^org\.(apache\.tika:tika-(core|parsers)|gagravarr:vorbis-java-tika):.*$</gav>
+      <cve>CVE-2018-1335</cve>
+   </suppress>
+</suppressions>


### PR DESCRIPTION
[OWASP](http://www.owasp.org/) provides an ant tool "[dependency-check](https://jeremylong.github.io/DependencyCheck/dependency-check-ant/index.html)" which lists potential vulnerabilities of library dependencies.

To install the tool (eventually the installation can be automatized as ant target):
```
wget http://dl.bintray.com/jeremy-long/owasp/dependency-check-ant-3.3.2-release.zip
unzip -d ivy/ dependency-check-ant-3.3.2-release.zip
```

Run it
```
ant report-vulnerabilities
```
and open the reports `build/dependency-check-report.html` or `build/dependency-check-vulnerability.html`. There are false positives, the tool allows to maintain an suppression list which needs to be completed.