### PR TITLE
Add the fields required by the index-links plugin to the Solr schema

### DIFF
--- a/conf/schema.xml
+++ b/conf/schema.xml
@@ -385,6 +385,10 @@
     <field name="lastModified" type="date" stored="true" indexed="false"/>
     <field name="date" type="tdate" stored="true" indexed="true"/>
 
+    <!-- fields for index-links -->
+    <field name="inlinks" type="url" stored="true" indexed="true" multiValued="true"/>
+    <field name="outlinks" type="url" stored="true" indexed="true" multiValued="true"/>
+
     <!-- fields for languageidentifier plugin -->
     <field name="lang" type="string" stored="true" indexed="true"/>
 


### PR DESCRIPTION
As discussed in #398 it makes perfect sense to add the fields required by the index-links plugin to the `conf/schema.xml`.

