### PR TITLE
NUTCH-2668 Integrate OWASP dependency checks as ant target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -599,6 +599,35 @@
   </fail>
  </target>
 	
+  <!-- Check dependencies for security vulnerabilities                                    -->
+  <!-- requires installation of OWASP dependency check tool, see                          -->
+  <!--   https://jeremylong.github.io/DependencyCheck/dependency-check-ant/index.html     -->
+  <!-- get http://dl.bintray.com/jeremy-long/owasp/dependency-check-ant-3.3.2-release.zip -->
+  <!-- and unzip in directory ./ivy/                                                      -->
+  <property name="dependency-check.home" value="${ivy.dir}/dependency-check-ant/"/>
+  <path id="dependency-check.path">
+    <pathelement location="${dependency-check.home}/dependency-check-ant.jar"/>
+    <fileset dir="${dependency-check.home}/lib">
+      <include name="*.jar"/>
+    </fileset>
+  </path>
+  <taskdef resource="dependency-check-taskdefs.properties">
+    <classpath refid="dependency-check.path" />
+  </taskdef>
+  <target name="report-vulnerabilities" description="--> check dependencies for security vulnerabilities">
+    <dependency-check projectname="${name}"
+                      reportoutputdirectory="${build.dir}"
+                      reportformat="ALL">
+        <suppressionfile path="${dependency-check.home}/dependency-check-suppressions.xml" />
+        <retirejsFilter regex="copyright.*jeremy long" />
+        <fileset dir="${build.dir}">
+          <include name="lib/*.jar"/>
+          <include name="plugins/*/*.jar"/>
+        </fileset>
+    </dependency-check>
+  </target>
+
+
   <target name="compile-avro-schema" depends="resolve-default" description="--> compile the avro schema(s) in src/gora/*.avsc">
     <typedef name="schema" 
   	         classname="org.apache.avro.specific.SchemaTask"

--- a/ivy/dependency-check-ant/dependency-check-suppressions.xml
+++ b/ivy/dependency-check-ant/dependency-check-suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+   <suppress>
+      <notes>only applies to tika-server &lt; 1.18</notes>
+      <gav regex="true">^org\.(apache\.tika:tika-(core|parsers)|gagravarr:vorbis-java-tika):.*$</gav>
+      <cve>CVE-2018-1335</cve>
+   </suppress>
+</suppressions>


### PR DESCRIPTION
- add ant target "report-vulnerabilities" to generate report
- initial suppression list to exclude false positives

To install the tool (eventually the installation can be automatized as ant target):
```
wget http://dl.bintray.com/jeremy-long/owasp/dependency-check-ant-3.3.2-release.zip
unzip -d ivy/ dependency-check-ant-3.3.2-release.zip
```

Run it
```
ant report-vulnerabilities
```
and open the reports `build/dependency-check-report.html` or `build/dependency-check-vulnerability.html`. There are false positives, the tool allows to maintain an suppression list which needs to be completed.