### PR TITLE
NUTCH-2686 New property: "moreIndexingFilter.mapMimeTypes.field"

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1207,6 +1207,15 @@
   </description>
 </property>
 
+<property>
+  <name>moreIndexingFilter.mapMimeTypes.field</name>
+  <value></value>
+  <description>It's used if moreIndexingFilter.mapMimeTypes is true. Indicates the field
+  where the mapped MIME-type must be written. If it's null, the field "type"
+  will be replaced by the mapped MIME-type.
+  </description>
+</property>
+
 <!-- AnchorIndexing filter plugin properties -->
 
 <property>

--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1211,7 +1211,7 @@
   <name>moreIndexingFilter.mapMimeTypes.field</name>
   <value></value>
   <description>It's used if moreIndexingFilter.mapMimeTypes is true. Indicates the field
-  where the mapped MIME-type must be written. If it's null, the field "type"
+  where the mapped MIME-type must be written. If it's empty or unset, the content of the field "type"
   will be replaced by the mapped MIME-type.
   </description>
 </property>

--- a/src/plugin/index-more/src/java/org/apache/nutch/indexer/more/MoreIndexingFilter.java
+++ b/src/plugin/index-more/src/java/org/apache/nutch/indexer/more/MoreIndexingFilter.java
@@ -81,6 +81,7 @@ public class MoreIndexingFilter implements IndexingFilter {
   /** Map for mime-type substitution */
   private HashMap<String, String> mimeMap = null;
   private boolean mapMimes = false;
+  private String mapFieldName;
 
   public NutchDocument filter(NutchDocument doc, Parse parse, Text url,
       CrawlDatum datum, Inlinks inlinks) throws IndexingException {
@@ -226,8 +227,11 @@ public class MoreIndexingFilter implements IndexingFilter {
     if (mapMimes) {
       // Check if the current mime is mapped
       if (mimeMap.containsKey(mimeType)) {
-        // It's mapped, let's replace it
-        mimeType = mimeMap.get(mimeType);
+        if (mapFieldName != null) {
+          doc.add(mapFieldName, mimeMap.get(mimeType));
+        } else {
+          mimeType = mimeMap.get(mimeType);
+        }
       }
     }
 
@@ -300,8 +304,10 @@ public class MoreIndexingFilter implements IndexingFilter {
     this.conf = conf;
     MIME = new MimeUtil(conf);
 
-    if (conf.getBoolean("moreIndexingFilter.mapMimeTypes", false) == true) {
+    if (conf.getBoolean("moreIndexingFilter.mapMimeTypes", false)) {
       mapMimes = true;
+
+      mapFieldName = conf.get("moreIndexingFilter.mapMimeTypes.field");
 
       // Load the mapping
       try {


### PR DESCRIPTION
Includes a new property: "moreIndexingFilter.mapMimeTypes.field", which indicates the field's name where the mapped mime type must be written. If this property is NULL (default value) the field "type" will be replaced by the mapped mime type (current behavior).