### PR TITLE
NUTCH-2693 Misspelled configuration property names in documentation

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -849,14 +849,14 @@
   <value>-1</value>
   <description>The maximum number of urls in a single
   fetchlist.  -1 if unlimited. The urls are counted according
-  to the value of the parameter generator.count.mode.
+  to the value of the parameter generate.count.mode.
   </description>
 </property>
 
 <property>
   <name>generate.count.mode</name>
   <value>host</value>
-  <description>Determines how the URLs are counted for generator.max.count.
+  <description>Determines how the URLs are counted for generate.max.count.
   Default value is 'host' but can be 'domain'. Note that we do not count 
   per IP in the new version of the Generator.
   </description>
@@ -1062,7 +1062,7 @@
 <property>
   <name>fetcher.throughput.threshold.retries</name>
   <value>5</value>
-  <description>The number of times the fetcher.throughput.threshold is allowed to be exceeded.
+  <description>The number of times the fetcher.throughput.threshold.pages is allowed to be exceeded.
   This settings prevents accidental slow downs from immediately killing the fetcher thread.
   </description>
 </property>

--- a/src/java/org/apache/nutch/crawl/Generator.java
+++ b/src/java/org/apache/nutch/crawl/Generator.java
@@ -702,9 +702,9 @@ public class Generator extends NutchTool implements Tool {
 
   /**
    * Generate fetchlists in one or more segments. Whether to filter URLs or not
-   * is read from the crawl.generate.filter property in the configuration files.
-   * If the property is not found, the URLs are filtered. Same for the
-   * normalisation.
+   * is read from the &quot;generate.filter&quot; property set for the job from
+   * command-line. If the property is not found, the URLs are filtered. Same for
+   * the normalisation.
    * 
    * @param dbDir
    *          Crawl database directory

--- a/src/java/org/apache/nutch/net/protocols/Response.java
+++ b/src/java/org/apache/nutch/net/protocols/Response.java
@@ -62,7 +62,7 @@ public interface Response extends HttpHeaders {
     NOT_TRUNCATED,
     /** fetch exceeded configured http.content.limit */
     LENGTH,
-    /** fetch exceeded configured http.fetch.duration */
+    /** fetch exceeded configured http.time.limit */
     TIME,
     /** network disconnect or timeout during fetch */
     DISCONNECT,

--- a/src/plugin/indexer-csv/src/java/org/apache/nutch/indexwriter/csv/CSVIndexWriter.java
+++ b/src/plugin/indexer-csv/src/java/org/apache/nutch/indexwriter/csv/CSVIndexWriter.java
@@ -393,7 +393,7 @@ public class CSVIndexWriter implements IndexWriter {
 
   /**
    * Write a value to output stream. Escape quote characters.
-   * Clip value after <code>indexer.csv.maxfieldlength</code> characters.
+   * Clip value after <code>maxfieldlength</code> characters.
    *
    * @param value
    *          String to write
@@ -419,7 +419,7 @@ public class CSVIndexWriter implements IndexWriter {
 
   /**
    * Write a value to output stream. Escape quote characters. Clip value after
-   * <code>indexer.csv.maxfieldlength</code> characters.
+   * <code>maxfieldlength</code> characters.
    */
   private void writeEscaped (String value) throws IOException {
     int nextQuoteChar = quoteCharacter.find(value, 0);

--- a/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttp.java
+++ b/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttp.java
@@ -236,34 +236,34 @@ public class OkHttp extends HttpBase {
       String httpProtocol = response.protocol().toString()
           .toUpperCase(Locale.ROOT);
       if (useHttp2 && "H2".equals(httpProtocol)) {
-        // back-warc compatible protocol name
+        // back-ward compatible protocol name
         httpProtocol = "HTTP/2";
       }
 
-      StringBuilder resquestverbatim = null;
+      StringBuilder requestverbatim = null;
       StringBuilder responseverbatim = null;
 
       if (storeHttpRequest) {
-        resquestverbatim = new StringBuilder();
+        requestverbatim = new StringBuilder();
 
-        resquestverbatim.append(request.method()).append(' ');
-        resquestverbatim.append(request.url().encodedPath());
+        requestverbatim.append(request.method()).append(' ');
+        requestverbatim.append(request.url().encodedPath());
         String query = request.url().encodedQuery();
         if (query != null) {
-          resquestverbatim.append('?').append(query);
+          requestverbatim.append('?').append(query);
         }
-        resquestverbatim.append(' ').append(httpProtocol).append("\r\n");
+        requestverbatim.append(' ').append(httpProtocol).append("\r\n");
 
         Headers headers = request.headers();
 
         for (int i = 0, size = headers.size(); i < size; i++) {
           String key = headers.name(i);
           String value = headers.value(i);
-          resquestverbatim.append(key).append(": ").append(value)
+          requestverbatim.append(key).append(": ").append(value)
               .append("\r\n");
         }
 
-        resquestverbatim.append("\r\n");
+        requestverbatim.append("\r\n");
       }
 
       if (storeHttpHeaders) {
@@ -294,9 +294,9 @@ public class OkHttp extends HttpBase {
         builder = builder.header(Response.IP_ADDRESS, ipAddress);
       }
 
-      if (resquestverbatim != null) {
+      if (requestverbatim != null) {
         byte[] encodedBytesRequest = Base64.getEncoder()
-            .encode(resquestverbatim.toString().getBytes());
+            .encode(requestverbatim.toString().getBytes());
         builder = builder.header(Response.REQUEST,
             new String(encodedBytesRequest));
       }

--- a/src/plugin/scoring-orphan/src/test/org/apache/nutch/scoring/orphan/TestOrphanScoringFilter.java
+++ b/src/plugin/scoring-orphan/src/test/org/apache/nutch/scoring/orphan/TestOrphanScoringFilter.java
@@ -91,7 +91,7 @@ public class TestOrphanScoringFilter {
             + CrawlDatum.getStatusName(datum.getStatus()),
         CrawlDatum.STATUS_DB_NOTMODIFIED, datum.getStatus());
 
-    // Wait until mark.gone.after
+    // Wait until scoring.orphan.mark.gone.after
     try {
       Thread.sleep(5000);
     } catch (Exception e) {
@@ -106,7 +106,7 @@ public class TestOrphanScoringFilter {
             + CrawlDatum.getStatusName(datum.getStatus()),
         CrawlDatum.STATUS_DB_GONE, datum.getStatus());
 
-    // Wait until mark.orphan.after
+    // Wait until scoring.orphan.mark.orphan.after
     try {
       Thread.sleep(5000);
     } catch (Exception e) {

--- a/src/test/org/apache/nutch/crawl/TestGenerator.java
+++ b/src/test/org/apache/nutch/crawl/TestGenerator.java
@@ -131,7 +131,7 @@ public class TestGenerator {
   }
 
   /**
-   * Test that generator obeys the property "generate.max.per.host".
+   * Test that generator obeys the property "generate.max.count".
    * 
    * @throws Exception
    */
@@ -195,8 +195,8 @@ public class TestGenerator {
   }
 
   /**
-   * Test that generator obeys the property "generator.max.count" and
-   * "generator.count.per.domain".
+   * Test that generator obeys the property "generate.max.count" and
+   * "generate.count.mode".
    * 
    * @throws Exception
    */


### PR DESCRIPTION
- fix wrong names of Nutch configuration properties in documentation (nutch-default.xml and Java comments)
- also fix further typos