### PR TITLE
NUTCH-2695: fix some alerts raised by LGTM

### DIFF
--- a/src/java/org/apache/nutch/crawl/CrawlDbReader.java
+++ b/src/java/org/apache/nutch/crawl/CrawlDbReader.java
@@ -522,7 +522,7 @@ public class CrawlDbReader extends AbstractChecker implements Closeable {
             qs.add(d);
           } else {
             LOG.warn(
-                "Skipping quantile {} not in range in db.stats.score.quantiles: {}",
+                "Skipping quantile {} not in range in db.stats.score.quantiles",
                 s);
           }
         } catch (NumberFormatException e) {

--- a/src/java/org/apache/nutch/crawl/Generator.java
+++ b/src/java/org/apache/nutch/crawl/Generator.java
@@ -255,7 +255,7 @@ public class Generator extends NutchTool implements Tool {
           return;
 
         // consider only entries with a score superior to the threshold
-        if (scoreThreshold != Float.NaN && sort < scoreThreshold)
+        if (!Float.isNan(scoreThreshold) && sort < scoreThreshold)
           return;
 
         // consider only entries with a retry (or fetch) interval lower than

--- a/src/java/org/apache/nutch/service/impl/NutchServerPoolExecutor.java
+++ b/src/java/org/apache/nutch/service/impl/NutchServerPoolExecutor.java
@@ -53,7 +53,7 @@ public class NutchServerPoolExecutor extends ThreadPoolExecutor{
   protected void afterExecute(Runnable runnable, Throwable throwable) {
     super.afterExecute(runnable, throwable);
     synchronized (runningWorkers) {
-      runningWorkers.remove(((JobWorker) runnable).getInfo());
+      runningWorkers.remove((JobWorker) runnable);
     }
     JobWorker worker = ((JobWorker) runnable);
     addStatusToHistory(worker);


### PR DESCRIPTION
Fix a few of the alerts raised by LGTM (https://lgtm.com/projects/g/apache/nutch/alerts/?mode=tree).

-`Wrong NaN comparison` in Generator
-`Type mismatch on container modification` in NutchServerPoolExecutor
-`Missing format argument` in CrawlDbReader