### PR TITLE
NUTCH-2697: Upgrade Ivy to fix the issue of an unset packaging.type p…

### DIFF
--- a/default.properties
+++ b/default.properties
@@ -63,7 +63,7 @@ runtime.dir=./runtime
 runtime.deploy=${runtime.dir}/deploy
 runtime.local=${runtime.dir}/local
 
-ivy.version=2.4.0
+ivy.version=2.5.0-rc1
 ivy.dir=${basedir}/ivy
 ivy.file=${ivy.dir}/ivy.xml
 ivy.jar=${ivy.dir}/ivy-${ivy.version}.jar

--- a/ivy/ivysettings.xml
+++ b/ivy/ivysettings.xml
@@ -38,14 +38,6 @@
     value="[organisation]/[module]/[revision]/[module]-[revision](-[classifier])"/>
   <property name="maven2.pattern.ext"
     value="${maven2.pattern}.[ext]"/>
-  <!-- define packaging.type=jar to work around the failing dependency download of
-         javax.ws.rs-api.jar
-       required by Tika (1.19 and higher), cf.
-         https://github.com/eclipse-ee4j/jaxrs-api/issues/572
-         https://github.com/jax-rs/api/pull/576
-  -->
-  <property name="packaging.type"
-    value="jar"/>
   <!-- pull in the local repository -->
   <include url="${ivy.default.conf.dir}/ivyconf-local.xml"/>
   <settings defaultResolver="default"/>


### PR DESCRIPTION
Currently Nutch fails to build from a clean checkout due to `packaging.type` not being set (even with the current workaround in `ivysettings.xml`).
```
[ivy:resolve] :: problems summary ::
[ivy:resolve] :::: WARNINGS
[ivy:resolve] [FAILED ] javax.ws.rs#javax.ws.rs-api;2.1.1!javax.ws.rs-api.${packaging.type}: (0ms)
[ivy:resolve] ==== local: tried
[ivy:resolve] /opt/work/.ivy2/local/javax.ws.rs/javax.ws.rs-api/2.1.1/${packaging.type}s/javax.ws.rs-api.${packaging.type}
[ivy:resolve] ==== maven2: tried
[ivy:resolve] http://repo1.maven.org/maven2/javax/ws/rs/javax.ws.rs-api/2.1.1/javax.ws.rs-api-2.1.1.${packaging.type}
[ivy:resolve] ==== apache-snapshot: tried
[ivy:resolve] https://repository.apache.org/content/repositories/snapshots/javax/ws/rs/javax.ws.rs-api/2.1.1/javax.ws.rs-api-2.1.1.${packaging.type}
[ivy:resolve] ==== sonatype: tried
[ivy:resolve] http://oss.sonatype.org/content/repositories/releases/javax/ws/rs/javax.ws.rs-api/2.1.1/javax.ws.rs-api-2.1.1.${packaging.type}
[ivy:resolve] ::::::::::::::::::::::::::::::::::::::::::::::
[ivy:resolve] :: FAILED DOWNLOADS ::
[ivy:resolve] :: ^ see resolution messages for details ^ ::
[ivy:resolve] ::::::::::::::::::::::::::::::::::::::::::::::
[ivy:resolve] :: javax.ws.rs#javax.ws.rs-api;2.1.1!javax.ws.rs-api.${packaging.type}
[ivy:resolve] ::::::::::::::::::::::::::::::::::::::::::::::
[ivy:resolve] 
BUILD FAILED
```
This issue has been fixed in the latest version of Ivy so upgrading will cause the build to work correctly again.