### PR TITLE
Revert "NUTCH-2697: Upgrade Ivy to fix the issue of an unset packaging.type p…"

### DIFF
--- a/default.properties
+++ b/default.properties
@@ -63,7 +63,7 @@ runtime.dir=./runtime
 runtime.deploy=${runtime.dir}/deploy
 runtime.local=${runtime.dir}/local
 
-ivy.version=2.5.0-rc1
+ivy.version=2.4.0
 ivy.dir=${basedir}/ivy
 ivy.file=${ivy.dir}/ivy.xml
 ivy.jar=${ivy.dir}/ivy-${ivy.version}.jar

--- a/ivy/ivysettings.xml
+++ b/ivy/ivysettings.xml
@@ -38,6 +38,14 @@
     value="[organisation]/[module]/[revision]/[module]-[revision](-[classifier])"/>
   <property name="maven2.pattern.ext"
     value="${maven2.pattern}.[ext]"/>
+  <!-- define packaging.type=jar to work around the failing dependency download of
+         javax.ws.rs-api.jar
+       required by Tika (1.19 and higher), cf.
+         https://github.com/eclipse-ee4j/jaxrs-api/issues/572
+         https://github.com/jax-rs/api/pull/576
+  -->
+  <property name="packaging.type"
+    value="jar"/>
   <!-- pull in the local repository -->
   <include url="${ivy.default.conf.dir}/ivyconf-local.xml"/>
   <settings defaultResolver="default"/>


### PR DESCRIPTION
Reverts apache/nutch#441 because using ivy-2.5.0-rc1 causes [NUTCH-2672](https://issues.apache.org/jira/browse/NUTCH-2672).