### PR TITLE
NUTCH-2699 Protocol-okhttp: needless loops to increment requested bytes counter when more content is already buffered

### DIFF
--- a/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttpResponse.java
+++ b/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttpResponse.java
@@ -148,7 +148,7 @@ public class OkHttpResponse implements Response {
     }
 
     int maxContentBytes = Integer.MAX_VALUE;
-    if (maxContent != -1) {
+    if (maxContent >= 0) {
       maxContentBytes = Math.min(maxContentBytes, maxContent);
     }
 
@@ -190,7 +190,7 @@ public class OkHttpResponse implements Response {
     }
     int bytesBuffered = (int) source.buffer().size();
     int bytesToCopy = bytesBuffered;
-    if (maxContent != -1 && bytesToCopy > maxContent) {
+    if (maxContent >= 0 && bytesToCopy > maxContent) {
       // okhttp's internal buffer is larger than maxContent
       truncated.setReason(TruncatedContentReason.LENGTH);
       bytesToCopy = maxContentBytes;

--- a/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttpResponse.java
+++ b/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttpResponse.java
@@ -153,27 +153,25 @@ public class OkHttpResponse implements Response {
     }
 
     BufferedSource source = responseBody.source();
-    int contentBytesBuffered = 0;
-    int contentBytesRequested = 0;
+    int bytesRequested = 0;
     int bufferGrowStepBytes = 8192;
-    while (contentBytesBuffered < maxContentBytes) {
-      contentBytesRequested += Math.min(bufferGrowStepBytes,
-          (maxContentBytes - contentBytesBuffered));
+    while (source.buffer().size() < maxContentBytes) {
+      bytesRequested += Math.min(bufferGrowStepBytes,
+          (maxContentBytes - bytesRequested));
       boolean success = false;
       try {
-        success = source.request(contentBytesRequested);
+        success = source.request(bytesRequested);
       } catch (IOException e) {
-        if (partialAsTruncated && contentBytesBuffered > 0) {
+        if (partialAsTruncated && source.buffer().size() > 0) {
           // treat already fetched content as truncated
           truncated.setReason(TruncatedContentReason.DISCONNECT);
         } else {
           throw e;
         }
       }
-      contentBytesBuffered = (int) source.buffer().size();
       if (LOG.isDebugEnabled()) {
-        LOG.debug("total bytes requested = {}, buffered = {}",
-            contentBytesRequested, contentBytesBuffered);
+        LOG.debug("total bytes requested = {}, buffered = {}", bytesRequested,
+            source.buffer().size());
       }
       if (!success) {
         LOG.debug("source exhausted, no more data to read");
@@ -184,13 +182,15 @@ public class OkHttpResponse implements Response {
         truncated.setReason(TruncatedContentReason.TIME);
         break;
       }
-      if (contentBytesBuffered > maxContentBytes) {
+      if (source.buffer().size() > maxContentBytes) {
         LOG.debug("content limit reached");
-        truncated.setReason(TruncatedContentReason.LENGTH);
       }
+      // okhttp may fetch more content than requested, forward requested bytes
+      bytesRequested = (int) source.buffer().size();
     }
-    int bytesToCopy = contentBytesBuffered;
-    if (maxContent != -1 && contentBytesBuffered > maxContent) {
+    int bytesBuffered = (int) source.buffer().size();
+    int bytesToCopy = bytesBuffered;
+    if (maxContent != -1 && bytesToCopy > maxContent) {
       // okhttp's internal buffer is larger than maxContent
       truncated.setReason(TruncatedContentReason.LENGTH);
       bytesToCopy = maxContentBytes;
@@ -199,8 +199,8 @@ public class OkHttpResponse implements Response {
     source.buffer().readFully(arr);
     if (LOG.isDebugEnabled()) {
       LOG.debug(
-          "copied {} bytes out of {} buffered, remaining buffer contains {} bytes",
-          bytesToCopy, contentBytesBuffered, source.buffer().size());
+          "copied {} bytes out of {} buffered, remaining {} bytes in buffer",
+          bytesToCopy, bytesBuffered, source.buffer().size());
     }
     return arr;
   }


### PR DESCRIPTION
Significantly less loops are now executed:
```
2019-03-13 17:46:25,232 DEBUG okhttp.OkHttpResponse - http://localhost/large.pdf - http/1.1 200 OK
2019-03-13 17:46:25,233 DEBUG okhttp.OkHttpResponse - total bytes requested = 8192, buffered = 16088
2019-03-13 17:46:25,233 DEBUG okhttp.OkHttpResponse - total bytes requested = 24280, buffered = 24280
2019-03-13 17:46:25,233 DEBUG okhttp.OkHttpResponse - total bytes requested = 32472, buffered = 32472
2019-03-13 17:46:25,233 DEBUG okhttp.OkHttpResponse - total bytes requested = 40664, buffered = 40664
2019-03-13 17:46:25,233 DEBUG okhttp.OkHttpResponse - total bytes requested = 48856, buffered = 48856
2019-03-13 17:46:25,233 DEBUG okhttp.OkHttpResponse - total bytes requested = 57048, buffered = 57048
2019-03-13 17:46:25,233 DEBUG okhttp.OkHttpResponse - total bytes requested = 65240, buffered = 65240
2019-03-13 17:46:25,233 DEBUG okhttp.OkHttpResponse - total bytes requested = 65534, buffered = 73432
2019-03-13 17:46:25,233 DEBUG okhttp.OkHttpResponse - content limit reached
2019-03-13 17:46:25,233 DEBUG okhttp.OkHttpResponse - copied 65534 bytes out of 73432 buffered, remaining 7898 bytes in buffer
2019-03-13 17:46:25,234 DEBUG okhttp.OkHttpResponse - HTTP content truncated to 65534 bytes (reason: LENGTH)
2019-03-13 17:46:25,249 INFO  parse.ParseSegment - http://localhost/large.pdf skipped. Content of size 366578 was truncated to 65534
2019-03-13 17:46:25,249 WARN  parse.ParserChecker - Content is truncated, parse may fail!
```