### PR TITLE
NUTCH-2701 Fetcher: log dates and times also in human-readable form

### DIFF
--- a/src/java/org/apache/nutch/fetcher/Fetcher.java
+++ b/src/java/org/apache/nutch/fetcher/Fetcher.java
@@ -19,7 +19,6 @@ package org.apache.nutch.fetcher;
 import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -427,10 +426,9 @@ public class Fetcher extends NutchTool implements Tool {
 
     checkConfiguration();
 
-    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
     long start = System.currentTimeMillis();
     if (LOG.isInfoEnabled()) {
-      LOG.info("Fetcher: starting at {}", sdf.format(start));
+      LOG.info("Fetcher: starting at {}", TimingUtil.logDateMillis(start));
       LOG.info("Fetcher: segment: {}", segment);
     }
 
@@ -440,7 +438,8 @@ public class Fetcher extends NutchTool implements Tool {
     long timelimit = getConf().getLong("fetcher.timelimit.mins", -1);
     if (timelimit != -1) {
       timelimit = System.currentTimeMillis() + (timelimit * 60 * 1000);
-      LOG.info("Fetcher Timelimit set for : {}", timelimit);
+      LOG.info("Fetcher Timelimit set for : {}  ({})", timelimit,
+          TimingUtil.logDateMillis(timelimit));
       getConf().setLong("fetcher.timelimit", timelimit);
     }
 
@@ -507,8 +506,8 @@ public class Fetcher extends NutchTool implements Tool {
     }
 
     long end = System.currentTimeMillis();
-    LOG.info("Fetcher: finished at {}, elapsed: {}", sdf.format(end),
-        TimingUtil.elapsedTime(start, end));
+    LOG.info("Fetcher: finished at {}, elapsed: {}",
+        TimingUtil.logDateMillis(end), TimingUtil.elapsedTime(start, end));
   }
 
   /** Run the fetcher. */

--- a/src/java/org/apache/nutch/util/TimingUtil.java
+++ b/src/java/org/apache/nutch/util/TimingUtil.java
@@ -16,9 +16,25 @@
  */
 package org.apache.nutch.util;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.concurrent.TimeUnit;
 
 public class TimingUtil {
+
+  /** Formats dates for logging */
+  public static DateTimeFormatter logDateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+  /**
+   * Convert epoch milliseconds ({@link System#currentTimeMillis()}) into date
+   * string (local time zone) used for logging
+   */
+  public static String logDateMillis(long millis) {
+    return logDateFormat.format(
+        LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault()));
+  }
 
   /**
    * Calculate the elapsed time between two times specified in milliseconds.


### PR DESCRIPTION
- add human-readable date to log message about time limit
- move date formatter to TimingUtil
- use new thread-safe date and time API