### PR TITLE
NUTCH-2709 Remove unused properties and code related to HTTP protocol

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -205,15 +205,6 @@
 </property>
 
 <property>
-  <name>http.max.delays</name>
-  <value>100</value>
-  <description>The number of times a thread will delay when trying to
-  fetch a page.  Each time it finds that a host is busy, it will wait
-  fetcher.server.delay.  After http.max.delays attempts, it will give
-  up on the page for now.</description>
-</property>
-
-<property>
   <name>http.content.limit</name>
   <value>1048576</value>
   <description>The length limit for downloaded content using the http/https
@@ -329,12 +320,6 @@
   <value></value>
   <description>A comma separated list of hosts that don't use the proxy 
   (e.g. intranets). Example: www.apache.org</description>
-</property>
-
-<property>
-  <name>http.verbose</name>
-  <value>false</value>
-  <description>If true, HTTP will log more verbosely.</description>
 </property>
 
 <property>

--- a/src/java/org/apache/nutch/protocol/ProtocolStatus.java
+++ b/src/java/org/apache/nutch/protocol/ProtocolStatus.java
@@ -50,7 +50,7 @@ public class ProtocolStatus implements Writable {
   /** Temporary failure. Application may retry immediately. */
   public static final int RETRY = 15;
   /**
-   * Unspecified exception occured. Further information may be provided in args.
+   * Unspecified exception occurred. Further information may be provided in args.
    */
   public static final int EXCEPTION = 16;
   /** Access denied - authorization required, but missing/incorrect. */
@@ -68,8 +68,10 @@ public class ProtocolStatus implements Writable {
    * expected number of milliseconds to wait before retry may be provided in
    * args.
    */
+  @Deprecated
   public static final int WOULDBLOCK = 22;
   /** Thread was blocked http.max.delays times during fetching. */
+  @Deprecated
   public static final int BLOCKED = 23;
 
   // Useful static instances for status codes that don't usually require any

--- a/src/plugin/creativecommons/conf/nutch-site.xml
+++ b/src/plugin/creativecommons/conf/nutch-site.xml
@@ -26,13 +26,6 @@
 </property>
 
 <property>
-  <name>http.max.delays</name>
-  <value>3</value>
-  <description>The CC crawl visits a large number of different
-  hosts, so we should not need to delay much.</description>
-</property>
-
-<property>
   <name>creativecommons.exclude.unlicensed</name>
   <value>true</value>
   <description>Exclude HTML content which does not contain a CC license.

--- a/src/plugin/protocol-http/src/java/org/apache/nutch/protocol/http/Http.java
+++ b/src/plugin/protocol-http/src/java/org/apache/nutch/protocol/http/Http.java
@@ -50,11 +50,6 @@ public class Http extends HttpBase {
    */
   public void setConf(Configuration conf) {
     super.setConf(conf);
-    // Level logLevel = Level.WARNING;
-    // if (conf.getBoolean("http.verbose", false)) {
-    // logLevel = Level.FINE;
-    // }
-    // LOG.setLevel(logLevel);
   }
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
- remove `http.verbose` and related code (commented out)
- remove `http.max.delays` which is obsolete since handling of politeness and delays is handled in the multi-threaded Fetcher (see NUTCH-339 and NUTCH-876)