### PR TITLE
NUTCH-2722 Fetch dependencies via https

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -352,6 +352,17 @@
     <artifact:mvn>
       <arg value="test"/>
       <arg value="-e"/>
+      <arg value="-o"/>
+      <!-- run offline (-o): must not download dependencies as this is
+           done from http://repo1.maven.org/ hardwired in
+           maven-ant-tasks-2.1.3.jar, see NUTCH-2722.
+
+           Dependencies and plugins need to be resolved and cached locally beforehand
+           by running
+             `mvn dependency:resolve`
+           resp.
+             `mvn dependency:resolve-plugins`
+           after the pom.xml has been generated. -->
     </artifact:mvn>
   </target>
 

--- a/ivy/ivysettings.xml
+++ b/ivy/ivysettings.xml
@@ -16,20 +16,11 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-  <!-- you can override this property to use mirrors
-          http://repo1.maven.org/maven2/
-          http://mirrors.dotsrc.org/maven2
-          http://ftp.ggi-project.org/pub/packages/maven2
-          http://mirrors.sunsite.dk/maven2
-          http://public.planetmirror.com/pub/maven2
-          http://ibiblio.lsu.edu/main/pub/packages/maven2
-          http://www.ibiblio.net/pub/packages/maven2
-  -->
   <property name="oss.sonatype.org" 
-    value="http://oss.sonatype.org/content/repositories/releases/" 
+    value="https://oss.sonatype.org/content/repositories/releases/" 
     override="false"/>
   <property name="repo.maven.org"
-    value="http://repo1.maven.org/maven2/"
+    value="https://repo1.maven.org/maven2/"
     override="false"/>
   <property name="repository.apache.org"
     value="https://repository.apache.org/content/repositories/snapshots/"

--- a/ivy/mvn.template
+++ b/ivy/mvn.template
@@ -36,7 +36,7 @@
 
   <scm>
     <developerConnection>scm:git:https://github.com/apache/nutch.git</developerConnection>
-    <connection>scm:git:http://github.com/apache/nutch.git</connection>
+    <connection>scm:git:https://github.com/apache/nutch.git</connection>
     <url>https://github.com/apache/nutch.git</url>
   </scm>
 


### PR DESCRIPTION
PR for 1.x (needs similarly applied to 2.x and 2.4)
- change the Maven repository URL to https
- remove mirrors (mostly outdated anyway)
- work-around to avoid that the `ant restdoc` task fetches from `http://repo1.maven.org/` (the URL seems to be hardwired in the [Maven ant task project/library](https://maven.apache.org/ant-tasks/) (not maintained anymore)