### PR TITLE
NUTCH-2727 Upgrade Hadoop dependencies to 2.9.2

### DIFF
--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -52,7 +52,7 @@
 		<dependency org="com.tdunning" name="t-digest" rev="3.2" />
 
 		<!-- Hadoop Dependencies -->
-		<dependency org="org.apache.hadoop" name="hadoop-common" rev="2.7.4" conf="*->default">
+		<dependency org="org.apache.hadoop" name="hadoop-common" rev="2.9.2" conf="*->default">
 			<exclude org="hsqldb" name="hsqldb" />
 			<exclude org="net.sf.kosmosfs" name="kfs" />
 			<exclude org="net.java.dev.jets3t" name="jets3t" />
@@ -60,9 +60,9 @@
 			<exclude org="org.mortbay.jetty" name="jsp-*" />
 			<exclude org="ant" name="ant" />
 		</dependency>
-		<dependency org="org.apache.hadoop" name="hadoop-hdfs" rev="2.7.4" conf="*->default"/>
-		<dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-core" rev="2.7.4" conf="*->default"/>
-		<dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-jobclient" rev="2.7.4" conf="*->default"/>
+		<dependency org="org.apache.hadoop" name="hadoop-hdfs" rev="2.9.2" conf="*->default"/>
+		<dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-core" rev="2.9.2" conf="*->default"/>
+		<dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-jobclient" rev="2.9.2" conf="*->default"/>
 		<!-- End of Hadoop Dependencies -->
 
 		<dependency org="org.apache.tika" name="tika-core" rev="1.22" />
@@ -76,7 +76,9 @@
 
 		<dependency org="com.github.crawler-commons" name="crawler-commons" rev="1.0" />
 
-		<dependency org="com.martinkl.warc" name="warc-hadoop" rev="0.1.0" />
+		<dependency org="com.martinkl.warc" name="warc-hadoop" rev="0.1.0">
+			<exclude module="hadoop-client" />
+		</dependency>
 
 		<!--dependency org="org.apache.cxf" name="cxf" rev="3.0.4" conf="*->default"/-->
 		<dependency org="org.apache.cxf" name="cxf-rt-frontend-jaxws" rev="3.2.7" conf="*->default"/>

--- a/src/java/org/apache/nutch/protocol/ProtocolFactory.java
+++ b/src/java/org/apache/nutch/protocol/ProtocolFactory.java
@@ -215,4 +215,20 @@ public class ProtocolFactory {
     return false;
   }
 
+  /** Get a {@link Protocol} instance of the specified extension ID. */
+  /**
+   * @param id
+   *          protocol plugin ID, e.g.,
+   *          <code>org.apache.nutch.protocol.http</code>
+   * @return protocol instance for the given ID
+   * @throws PluginRuntimeException
+   *           if plugin not found or failed to instantiate
+   */
+  public Protocol getProtocolById(String id) throws PluginRuntimeException {
+    Extension ext = getExtensionById(id);
+    if (ext == null) {
+      throw new PluginRuntimeException("ID " + id + " not found");
+    }
+    return getProtocolInstanceByExtension(ext);
+  }
 }

--- a/src/plugin/protocol-okhttp/src/test/conf/nutch-site-test.xml
+++ b/src/plugin/protocol-okhttp/src/test/conf/nutch-site-test.xml
@@ -20,6 +20,11 @@
 <configuration>
 
 <property>
+  <name>plugin.includes</name>
+  <value>protocol-okhttp</value>
+</property>
+
+<property>
   <name>http.agent.name</name>
   <value>Nutch-Test</value>
 </property>


### PR DESCRIPTION
- fix unit tests of protocol-okhttp to use plugin class loader
  and methods defined by Protocol interface to avoid dependency
  conflicts (Hadoop depends on okhttp as well)
