### PR TITLE
NUTCH-2736 Upgrade Dockerfile to be based on recent Ubuntu LTS version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,20 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:16.04
-MAINTAINER Michael Joyce <joyce@apache.org>
+FROM ubuntu:18.04
+MAINTAINER Apache Nutch Committers <dev@nutch.apache.org>
 
 WORKDIR /root/
 
 
 # Install dependencies
 RUN apt update
-RUN apt install -y ant openssh-server vim telnet git rsync curl openjdk-8-jdk-headless
+RUN apt install -y ant git openjdk-8-jdk-headless
 
 # Set up JAVA_HOME
 RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64' >> $HOME/.bashrc
 
-# Checkout and build the nutch trunk
+# Checkout and build the Nutch master branch (1.x)
 RUN git clone https://github.com/apache/nutch.git nutch_source && cd nutch_source && ant runtime
 
 # Convenience symlink to Nutch runtime local

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,11 +14,11 @@ Nutch can run on a single machine, but gains a lot of its strength from running 
 
 Current configuration of this image consists of components:
 
-*	Nutch 1.x
+*	Nutch 1.x (branch "master")
 
 ##  Base Image
 
-* [ubuntu:14.04](https://registry.hub.docker.com/_/ubuntu/)
+* [ubuntu:18.04](https://hub.docker.com/_/ubuntu/)
 
 ## Tips
 


### PR DESCRIPTION
- upgrade to use Ubuntu 18.04
- remove installed packages not required to build Nutch