### PR TITLE
NUTCH-2737 NUTCH-2738 Generator: count and log reason of rejections during selection, document property generate.restrict.status

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -862,8 +862,9 @@
   generate/fetch/update cycles may overlap, setting this to true ensures
   that generate will create different fetchlists even without intervening
   updatedb-s, at the cost of running an additional job to update CrawlDB.
-  If false, running generate twice without intervening
-  updatedb will generate identical fetchlists.</description>
+  If false, running generate twice without intervening updatedb will
+  generate identical fetchlists. See also crawl.gen.delay which defines
+  how long items already generated are blocked.</description>
 </property>
 
 <property>
@@ -927,8 +928,9 @@
   <description>
    This value, expressed in milliseconds, defines how long we should keep the lock on records 
    in CrawlDb that were just selected for fetching. If these records are not updated 
-   in the meantime, the lock is canceled, i.e. they become eligible for selecting. 
-   Default value of this is 7 days (604800000 ms).
+   in the meantime, the lock is canceled, i.e. they become eligible for selecting again.
+   Default value of this is 7 days (604800000 ms). If generate.update.crawldb is false
+   the property crawl.gen.delay has no effect.
   </description>
 </property>
 

--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -904,6 +904,13 @@
   See https://issues.apache.org/jira/browse/NUTCH-2368</description>
 </property>
 
+<property>
+  <name>generate.restrict.status</name>
+  <value></value>
+  <description>Select only entries of this status, see
+  https://issues.apache.org/jira/browse/NUTCH-1248</description>
+</property>
+
 <!-- urlpartitioner properties -->
 
 <property>

--- a/src/java/org/apache/nutch/crawl/CrawlDatum.java
+++ b/src/java/org/apache/nutch/crawl/CrawlDatum.java
@@ -185,6 +185,15 @@ public class CrawlDatum implements WritableComparable<CrawlDatum>, Cloneable {
     return res;
   }
 
+  public static byte getStatusByName(String name) {
+    for (Entry<Byte, String> status : statNames.entrySet()) {
+      if (name.equalsIgnoreCase(status.getValue())) {
+        return status.getKey();
+      }
+    }
+    return -1;
+  }
+
   public void setStatus(int status) {
     this.status = (byte) status;
   }

--- a/src/java/org/apache/nutch/crawl/Generator.java
+++ b/src/java/org/apache/nutch/crawl/Generator.java
@@ -193,8 +193,8 @@ public class Generator extends NutchTool implements Tool {
       filters = new URLFilters(conf);
       scfilters = new ScoringFilters(conf);
       filter = conf.getBoolean(GENERATOR_FILTER, true);
-      genDelay = conf.getLong(GENERATOR_DELAY, 604800000L); // 7 days as
-                                                            // default.
+      /* CrawlDb items are unblocked after 7 days as default */
+      genDelay = conf.getLong(GENERATOR_DELAY, 604800000L);
       long time = conf.getLong(Nutch.GENERATE_TIME_KEY, 0L);
       if (time > 0)
         genTime.set(time);
@@ -775,11 +775,9 @@ public class Generator extends NutchTool implements Tool {
     Job job = NutchJob.getInstance(getConf());
     job.setJobName("generate: select from " + dbDir);
     Configuration conf = job.getConfiguration();
-    if (numLists == -1) { // for politeness make
-      numLists = Integer.parseInt(conf.get("mapreduce.job.maps")); // a
-                                                                   // partition
-                                                                   // per fetch
-                                                                   // task
+    if (numLists == -1) {
+      /* for politeness create exactly one partition per fetch task */ 
+      numLists = Integer.parseInt(conf.get("mapreduce.job.maps"));
     }
     if ("local".equals(conf.get("mapreduce.framework.name")) && numLists != 1) {
       // override

--- a/src/java/org/apache/nutch/crawl/Generator.java
+++ b/src/java/org/apache/nutch/crawl/Generator.java
@@ -502,12 +502,17 @@ public class Generator extends NutchTool implements Tool {
                 hostCount[0]++;
                 hostCount[1] = 1;
               } else {
-                if (hostCount[1] == maxCount && LOG.isInfoEnabled()) {
+                if (hostCount[1] == maxCount) {
+                  context
+                    .getCounter("Generator", "HOSTS_AFFECTED_PER_HOST_OVERFLOW")
+                    .increment(1);
                   LOG.info(
                       "Host or domain {} has more than {} URLs for all {} segments. Additional URLs won't be included in the fetchlist.",
                       hostordomain, maxCount, maxNumSegments);
                 }
                 // skip this entry
+                context.getCounter("Generator", "URLS_SKIPPED_PER_HOST_OVERFLOW")
+                  .increment(1);
                 continue;
               }
             }

--- a/src/java/org/apache/nutch/crawl/Generator.java
+++ b/src/java/org/apache/nutch/crawl/Generator.java
@@ -750,7 +750,7 @@ public class Generator extends NutchTool implements Tool {
     if (expr != null) {
       LOG.info("Generator: expr: {}", expr);
     }
-    if (expr != null) {
+    if (hostdb != null) {
       LOG.info("Generator: hostdb: {}", hostdb);
     }
     

--- a/src/java/org/apache/nutch/crawl/Generator.java
+++ b/src/java/org/apache/nutch/crawl/Generator.java
@@ -181,7 +181,7 @@ public class Generator extends NutchTool implements Tool {
       private FetchSchedule schedule;
       private float scoreThreshold = 0f;
       private int intervalThreshold = -1;
-      private String restrictStatus = null;
+      private byte restrictStatus = -1;
       private Expression expr = null;
  
       @Override 
@@ -198,7 +198,10 @@ public class Generator extends NutchTool implements Tool {
         schedule = FetchScheduleFactory.getFetchSchedule(conf);
         scoreThreshold = conf.getFloat(GENERATOR_MIN_SCORE, Float.NaN);
         intervalThreshold = conf.getInt(GENERATOR_MIN_INTERVAL, -1);
-        restrictStatus = conf.get(GENERATOR_RESTRICT_STATUS, null);
+        String restrictStatusString = conf.getTrimmed(GENERATOR_RESTRICT_STATUS, "");
+        if (!restrictStatusString.isEmpty()) {
+          restrictStatus = CrawlDatum.getStatusByName(restrictStatusString);
+        }
         expr = JexlUtil.parseExpression(conf.get(GENERATOR_EXPR, null));
       }
 
@@ -252,9 +255,7 @@ public class Generator extends NutchTool implements Tool {
           }
         }
 
-        if (restrictStatus != null
-            && !restrictStatus
-                .equalsIgnoreCase(CrawlDatum.getStatusName(crawlDatum.getStatus()))) {
+        if (restrictStatus != -1 && restrictStatus != crawlDatum.getStatus()) {
           context.getCounter("Generator", "STATUS_REJECTED").increment(1);
           return;
         }

--- a/src/java/org/apache/nutch/crawl/Generator.java
+++ b/src/java/org/apache/nutch/crawl/Generator.java
@@ -513,7 +513,7 @@ public class Generator extends NutchTool implements Tool {
               hostCount[0]++;
               hostCount[1] = 1;
             } else {
-              if (hostCount[1] == maxCount) {
+              if (hostCount[1] == (maxCount+1)) {
                 context
                     .getCounter("Generator", "HOSTS_AFFECTED_PER_HOST_OVERFLOW")
                     .increment(1);


### PR DESCRIPTION
Generator improvements to address NUTCH-2737 and NUTCH-2738:
- add counters for skipped URLs in Selector mapper and reducer
- document generate.restrict.status
- parameterize log messages