### PR TITLE
Nutch-2511 Support large sitemaps

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -2671,4 +2671,12 @@ If true (default) the Sitemap parser rejects URLs not sharing the same
     Maximum number of redirects to follow.
    </description>
 </property>
+
+<property>
+  <name>sitemap.size.max</name>
+  <value>52428800</value>
+  <description>
+    Maximum sitemap size in bytes.
+   </description>
+</property>
 </configuration>

--- a/src/java/org/apache/nutch/util/SitemapProcessor.java
+++ b/src/java/org/apache/nutch/util/SitemapProcessor.java
@@ -108,7 +108,9 @@ public class SitemapProcessor extends Configured implements Tool {
 
     public void setup(Context context) {
       Configuration conf = context.getConfiguration();
-      conf.setInt("http.content.limit", conf.getInt(SITEMAP_SIZE_MAX, SiteMapParser.MAX_BYTES_ALLOWED));
+      int maxSize = conf.getInt(SITEMAP_SIZE_MAX, SiteMapParser.MAX_BYTES_ALLOWED);
+      conf.setInt("http.content.limit", maxSize);
+      conf.setInt("file.content.limit", maxSize);
       this.protocolFactory = new ProtocolFactory(conf);
       this.filter = conf.getBoolean(SITEMAP_URL_FILTERING, true);
       this.normalize = conf.getBoolean(SITEMAP_URL_NORMALIZING, true);

--- a/src/java/org/apache/nutch/util/SitemapProcessor.java
+++ b/src/java/org/apache/nutch/util/SitemapProcessor.java
@@ -92,7 +92,8 @@ public class SitemapProcessor extends Configured implements Tool {
   public static final String SITEMAP_ALWAYS_TRY_SITEMAPXML_ON_ROOT = "sitemap.url.default.sitemap.xml";
   public static final String SITEMAP_OVERWRITE_EXISTING = "sitemap.url.overwrite.existing";
   public static final String SITEMAP_REDIR_MAX = "sitemap.redir.max";
-  
+  public static final String SITEMAP_SIZE_MAX = "sitemap.size.max";
+
   private static class SitemapMapper extends Mapper<Text, Writable, Text, CrawlDatum> {
     private ProtocolFactory protocolFactory = null;
     private boolean strict = true;
@@ -107,6 +108,7 @@ public class SitemapProcessor extends Configured implements Tool {
 
     public void setup(Context context) {
       Configuration conf = context.getConfiguration();
+      conf.setInt("http.content.limit", conf.getInt(SITEMAP_SIZE_MAX, SiteMapParser.MAX_BYTES_ALLOWED));
       this.protocolFactory = new ProtocolFactory(conf);
       this.filter = conf.getBoolean(SITEMAP_URL_FILTERING, true);
       this.normalize = conf.getBoolean(SITEMAP_URL_NORMALIZING, true);


### PR DESCRIPTION
Override http.content.limit with sitemap.size.max when fetching sitemaps. Defaults to 50MB.
