### PR TITLE
NUTCH-2754 fetcher.max.crawl.delay ignored if exceeding 5 min. / 300 sec.

### DIFF
--- a/src/java/org/apache/nutch/protocol/RobotRulesParser.java
+++ b/src/java/org/apache/nutch/protocol/RobotRulesParser.java
@@ -78,6 +78,10 @@ public abstract class RobotRulesParser implements Tool {
       RobotRulesMode.ALLOW_NONE);
 
   private static SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+  static {
+    robotParser.setMaxCrawlDelay(Long.MAX_VALUE);
+  }
+
   protected Configuration conf;
   protected String agentNames;
 


### PR DESCRIPTION
Initialize crawler-commons's SimpleRobotRulesParser with the longest possible internal maxDelay so that Nutch can always handle the max. delay by itself.