### PR TITLE
NUTCH-2733 protocol-okhttp: add support for Brotli compression (Content-Encoding)

### DIFF
--- a/src/plugin/protocol-okhttp/ivy.xml
+++ b/src/plugin/protocol-okhttp/ivy.xml
@@ -36,7 +36,7 @@
   </publications>
 
   <dependencies>
-    <dependency org="com.squareup.okhttp3" name="okhttp" rev="3.14.2"/>
+    <dependency org="com.squareup.okhttp3" name="okhttp" rev="4.3.1"/>
   </dependencies>
   
 </ivy-module>

--- a/src/plugin/protocol-okhttp/ivy.xml
+++ b/src/plugin/protocol-okhttp/ivy.xml
@@ -37,6 +37,7 @@
 
   <dependencies>
     <dependency org="com.squareup.okhttp3" name="okhttp" rev="4.3.1"/>
+    <dependency org="com.squareup.okhttp3" name="okhttp-brotli" rev="4.3.1"/>
   </dependencies>
   
 </ivy-module>

--- a/src/plugin/protocol-okhttp/plugin.xml
+++ b/src/plugin/protocol-okhttp/plugin.xml
@@ -30,6 +30,8 @@
       <library name="kotlin-stdlib-1.3.61.jar"/>
       <library name="kotlin-stdlib-common-1.3.61.jar"/>
       <library name="annotations-13.0.jar"/>
+      <library name="okhttp-brotli-4.3.1.jar"/>
+      <library name="dec-0.1.2.jar"/>
    </runtime>
 
    <requires>

--- a/src/plugin/protocol-okhttp/plugin.xml
+++ b/src/plugin/protocol-okhttp/plugin.xml
@@ -25,8 +25,11 @@
       <library name="protocol-okhttp.jar">
          <export name="*"/>
       </library>
-      <library name="okhttp-3.14.2.jar"/>
-      <library name="okio-1.17.2.jar"/>
+      <library name="okhttp-4.3.1.jar"/>
+      <library name="okio-2.4.1.jar"/>
+      <library name="kotlin-stdlib-1.3.61.jar"/>
+      <library name="kotlin-stdlib-common-1.3.61.jar"/>
+      <library name="annotations-13.0.jar"/>
    </runtime>
 
    <requires>

--- a/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttp.java
+++ b/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttp.java
@@ -56,6 +56,7 @@ import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.Request;
+import okhttp3.brotli.BrotliInterceptor;
 
 public class OkHttp extends HttpBase {
 
@@ -215,6 +216,9 @@ public class OkHttp extends HttpBase {
     if (storeIPAddress || storeHttpHeaders || storeHttpRequest) {
       builder.addNetworkInterceptor(new HTTPHeadersInterceptor());
     }
+
+    // enable support for Brotli compression (Content-Encoding)
+    builder.addInterceptor(BrotliInterceptor.INSTANCE);
 
     client = builder.build();
   }


### PR DESCRIPTION
- upgrade to okhttp 4.3.2
- add dependency to okhttp3.brotli and enable Brotli compression

```
$> bin/nutch parsechecker -Dstore.http.headers=true -Dstore.http.request=true \
       -Dplugin.includes='protocol-okhttp|parse-html'  https://www.youtube.com/
...
_request_=GET / HTTP/1.1
...
Accept-Encoding: br,gzip
...

_response.headers_=HTTP/1.1 200 OK
Content-Encoding: br
...
```

I'll run a test crawl with some additional metrics soon.