### PR TITLE
NUTCH-2767 Fetcher to stop filling queues skipped due to repeated exception

### DIFF
--- a/src/java/org/apache/nutch/fetcher/FetchItemQueue.java
+++ b/src/java/org/apache/nutch/fetcher/FetchItemQueue.java
@@ -82,6 +82,10 @@ public class FetchItemQueue {
     return inProgress.get();
   }
 
+  public int getExceptionCounter() {
+    return exceptionCounter.get();
+  }
+
   public int incrementExceptionCounter() {
     return exceptionCounter.incrementAndGet();
   }

--- a/src/java/org/apache/nutch/fetcher/FetchItemQueue.java
+++ b/src/java/org/apache/nutch/fetcher/FetchItemQueue.java
@@ -49,7 +49,6 @@ public class FetchItemQueue {
   long crawlDelay;
   long minCrawlDelay;
   int maxThreads;
-  Configuration conf;
   Text cookie;
   Text variableFetchDelayKey = new Text("_variableFetchDelay_");
   boolean variableFetchDelaySet = false;
@@ -60,7 +59,6 @@ public class FetchItemQueue {
   
   public FetchItemQueue(Configuration conf, int maxThreads, long crawlDelay,
       long minCrawlDelay) {
-    this.conf = conf;
     this.maxThreads = maxThreads;
     this.crawlDelay = crawlDelay;
     this.minCrawlDelay = minCrawlDelay;
@@ -80,10 +78,6 @@ public class FetchItemQueue {
 
   public int getInProgressSize() {
     return inProgress.get();
-  }
-
-  public int getExceptionCounter() {
-    return exceptionCounter.get();
   }
 
   public int incrementExceptionCounter() {

--- a/src/java/org/apache/nutch/fetcher/Fetcher.java
+++ b/src/java/org/apache/nutch/fetcher/Fetcher.java
@@ -163,9 +163,14 @@ public class Fetcher extends NutchTool implements Tool {
       float avgPagesSec = (float) pages.get() / elapsed.floatValue();
       long avgBytesSec = (bytes.get() / 128l) / elapsed.longValue();
 
-      status.append(activeThreads).append(" threads (").append(spinWaiting.get())
-      .append(" waiting), ");
+      status.append(activeThreads).append(" threads (")
+          .append(spinWaiting.get()).append(" waiting), ");
       status.append(fetchQueues.getQueueCount()).append(" queues, ");
+      if (fetchQueues.maxExceptionsPerQueue != -1
+          && fetchQueues.getQueueCountMaxExceptions() > 0) {
+        status.append(fetchQueues.getQueueCountMaxExceptions())
+            .append(" queues.max.except., ");
+      }
       status.append(fetchQueues.getTotalSize()).append(" URLs queued, ");
       status.append(pages).append(" pages, ").append(errors).append(" errors, ");
       status.append(String.format("%.2f", avgPagesSec)).append(" pages/s (");

--- a/src/java/org/apache/nutch/fetcher/QueueFeeder.java
+++ b/src/java/org/apache/nutch/fetcher/QueueFeeder.java
@@ -19,8 +19,6 @@ package org.apache.nutch.fetcher;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
-import java.util.Map;
-import java.util.TreeMap;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;


### PR DESCRIPTION
- each queue checks whether max. exceptions are reached when adding a new fetch item - if yes, the item is not added to the queue
- for proper counting and logging the queuing status is reported to QueueFeeder