### PR TITLE
NUTCH-2763 protocol-okhttp (store.http.headers): add whitespace in status line after status code also when message is empty

### DIFF
--- a/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttp.java
+++ b/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttp.java
@@ -280,11 +280,8 @@ public class OkHttp extends HttpBase {
         responseverbatim = new StringBuilder();
 
         responseverbatim.append(getNormalizedProtocolName(response.protocol()))
-            .append(' ').append(response.code());
-        if (!response.message().isEmpty()) {
-          responseverbatim.append(' ').append(response.message());
-        }
-        responseverbatim.append("\r\n");
+            .append(' ').append(response.code()).append(' ')
+            .append(response.message()).append("\r\n");
 
         Headers headers = response.headers();
 

--- a/src/plugin/protocol-okhttp/src/test/org/apache/nutch/protocol/okhttp/TestBadServerResponses.java
+++ b/src/plugin/protocol-okhttp/src/test/org/apache/nutch/protocol/okhttp/TestBadServerResponses.java
@@ -477,4 +477,19 @@ public class TestBadServerResponses {
         (kB * 1024), fetched.getContent().getContent().length);
   }
 
+  /**
+   * NUTCH-2763 store.http.headers: add whitespace in status line after status
+   * code also when message is empty
+   */
+  @Test
+  public void testHttpStatusNoMessage() throws Exception {
+    setUp();
+    String statusLineNoMessage = "HTTP/1.1 200 \r\n";
+    launchServer(statusLineNoMessage + simpleContent);
+    ProtocolOutput fetched = fetchPage("/", 200);
+    assertTrue(
+        "Invalid HTTP status line (see NUTCH-2763, missing whitespace between status code and message)",
+        getHeaders(fetched).startsWith(statusLineNoMessage));
+  }
+
 }


### PR DESCRIPTION
(see [NUTCH-2763](https://issues.apache.org/jira/browse/NUTCH-2763))