### PR TITLE
NUTCH-2778 indexer-elastic to properly log errors

### DIFF
--- a/src/plugin/indexer-elastic/src/java/org/apache/nutch/indexwriter/elastic/ElasticIndexWriter.java
+++ b/src/plugin/indexer-elastic/src/java/org/apache/nutch/indexwriter/elastic/ElasticIndexWriter.java
@@ -182,14 +182,15 @@ public class ElasticIndexWriter implements IndexWriter {
       @Override
       public void afterBulk(long executionId, BulkRequest request,
           Throwable failure) {
-        throw new RuntimeException(failure);
+        LOG.error("Elasticsearch indexing failed:", failure);
       }
 
       @Override
       public void afterBulk(long executionId, BulkRequest request,
           BulkResponse response) {
         if (response.hasFailures()) {
-          LOG.warn("Failures occurred during bulk request");
+          LOG.warn("Failures occurred during bulk request: {}",
+              response.buildFailureMessage());
         }
       }
     };


### PR DESCRIPTION
- add log output in BulkProcessor.Listener
- do not throw an exception in BulkProcessor.Listener which is ignored anyway (but this might need a closer look)