### PR TITLE
NUTCH-2784 Add tool to list Nutch and Hadoop properties

### DIFF
--- a/src/bin/nutch
+++ b/src/bin/nutch
@@ -96,6 +96,7 @@ if [ $# = 0 ]; then
   echo "  updatehostdb      update the host db with records from the crawl db"
   echo "  readhostdb        read / dump host db"
   echo "  sitemap           perform Sitemap processing"
+  echo "  showproperties    print Nutch/Hadoop configuration properties to stdout"
   echo " or"
   echo "  CLASSNAME         run the class named CLASSNAME"
   echo "Most commands print help when invoked w/o parameters."
@@ -304,6 +305,8 @@ elif [ "$COMMAND" = "readhostdb" ] ; then
   CLASS=org.apache.nutch.hostdb.ReadHostDb
 elif [ "$COMMAND" = "sitemap" ] ; then
   CLASS=org.apache.nutch.util.SitemapProcessor
+elif [ "$COMMAND" = "showproperties" ] ; then
+  CLASS=org.apache.nutch.tools.ShowProperties
 else
   CLASS=$COMMAND
 fi

--- a/src/java/org/apache/nutch/tools/ShowProperties.java
+++ b/src/java/org/apache/nutch/tools/ShowProperties.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nutch.tools;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+
+import org.apache.nutch.util.NutchConfiguration;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.util.Tool;
+import org.apache.hadoop.util.ToolRunner;
+
+/**
+ * Tool to list properties and their values set by the current Nutch
+ * configuration
+ */
+public class ShowProperties extends Configured implements Tool {
+
+  private String format3cols = "%-32s  %24s  %20s";
+
+  @Override
+  public int run(String[] arg0) {
+    Configuration conf = getConf();
+    List<Entry<String, String>> list = new ArrayList<>();
+    conf.iterator().forEachRemaining(list::add);
+    Collections.sort(list, (a, b) -> a.getKey().compareTo(b.getKey()));
+    System.out.println(
+        String.format(format3cols, "conf.name", "conf.value", "substituted.value"));
+    System.out.println(
+        "================================================================================");
+    for (Entry<String, String> e : list) {
+      String key = e.getKey();
+      String val = e.getValue();
+      String substitutedVal = conf.get(key);
+      if (val.equals(substitutedVal)) {
+        String format = String.format("%%-%ds  %%%ds", key.length(),
+            (80 - 2 - key.length()));
+        System.out.println(String.format(format, key, val));
+      } else {
+        String format = String.format("%%-%ds  %%%ds  %%18s", key.length(),
+            (60 - 2 - key.length()));
+        System.out
+            .println(String.format(format, key, val, substitutedVal));
+      }
+    }
+    return 0;
+  }
+
+  public static void main(String[] args) throws Exception {
+    System.exit(ToolRunner.run(NutchConfiguration.create(),
+        new ShowProperties(), args));
+  }
+
+}


### PR DESCRIPTION
Because it's a Nutch/Hadoop tool it really uses the same configuration mechanism as all other tools, including command-line overrides:

```bash
$> bin/nutch showproperties | (head -2 && grep delay)
conf.name                                       conf.value     substituted.value
================================================================================
crawl.gen.delay                                                        604800000
fetcher.max.crawl.delay                                                       30
fetcher.min.crawl.delay              ${fetcher.server.delay}                 5.0
fetcher.server.delay                                                         5.0
fetcher.server.min.delay                                                     0.0
ipc.client.tcpnodelay                                                       true
page.load.delay                                                                3

# command-line override of fetcher.server.delay:
$> bin/nutch showproperties -Dfetcher.server.delay=10.0 | (head -2 && grep delay)
conf.name                                       conf.value     substituted.value
================================================================================
crawl.gen.delay                                                        604800000
fetcher.max.crawl.delay                                                       30
fetcher.min.crawl.delay              ${fetcher.server.delay}                10.0
fetcher.server.delay                                                        10.0
fetcher.server.min.delay                                                     0.0
ipc.client.tcpnodelay                                                       true
page.load.delay                                                                3
```

If configured and substituted value are identical only one is shown.