### PR TITLE
NUTCH-2788 ParseData: improve presentation of Metadata in method toString()

### DIFF
--- a/src/java/org/apache/nutch/metadata/Metadata.java
+++ b/src/java/org/apache/nutch/metadata/Metadata.java
@@ -232,13 +232,28 @@ public class Metadata implements Writable, CreativeCommons, DublinCore,
     return true;
   }
 
+  @Override
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    return toString("=", " ");
+  }
+
+  /**
+   * @param separator
+   *          separator between Metadata's key-value pairs
+   * @param keyValueSeparator
+   *          separator between key and value
+   * @return list of all key-value pairs in Metadata using the provided
+   *         separators
+   */
+  public String toString(String separator, String keyValueSeparator) {
+    StringBuilder buf = new StringBuilder();
     String[] names = names();
     for (int i = 0; i < names.length; i++) {
       String[] values = _getValues(names[i]);
       for (int j = 0; j < values.length; j++) {
-        buf.append(names[i]).append("=").append(values[j]).append(" ");
+        if (buf.length() > 0)
+          buf.append(separator);
+        buf.append(names[i]).append(keyValueSeparator).append(values[j]);
       }
     }
     return buf.toString();
@@ -278,3 +293,4 @@ public class Metadata implements Writable, CreativeCommons, DublinCore,
   }
 
 }
+  

--- a/src/java/org/apache/nutch/parse/ParseData.java
+++ b/src/java/org/apache/nutch/parse/ParseData.java
@@ -188,22 +188,25 @@ public final class ParseData extends VersionedWritable {
         && this.parseMeta.equals(other.parseMeta);
   }
 
+  @Override
   public String toString() {
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
 
-    buffer.append("Version: " + version + "\n");
-    buffer.append("Status: " + status + "\n");
-    buffer.append("Title: " + title + "\n");
+    buffer.append("Version: ").append(version).append("\n");
+    buffer.append("Status: ").append(status).append("\n");
+    buffer.append("Title: ").append(title ).append("\n");
 
     if (outlinks != null) {
-      buffer.append("Outlinks: " + outlinks.length + "\n");
+      buffer.append("Outlinks: ").append(outlinks.length).append("\n");
       for (int i = 0; i < outlinks.length; i++) {
-        buffer.append("  outlink: " + outlinks[i] + "\n");
+        buffer.append("  outlink: ").append(outlinks[i]).append("\n");
       }
     }
 
-    buffer.append("Content Metadata: " + contentMeta + "\n");
-    buffer.append("Parse Metadata: " + parseMeta + "\n");
+    buffer.append("Content Metadata:\n  ")
+        .append(contentMeta.toString("\n  ", " = ")).append("\n");
+    buffer.append("Parse Metadata:\n  ")
+        .append(parseMeta.toString("\n  ", " = ")).append("\n");
 
     return buffer.toString();
   }

--- a/src/java/org/apache/nutch/parse/ParserChecker.java
+++ b/src/java/org/apache/nutch/parse/ParserChecker.java
@@ -288,8 +288,8 @@ public class ParserChecker extends AbstractChecker {
         }
       }
 
-      output.append(turl + "\n");
-      output.append(parse.getData() + "\n");
+      output.append(turl).append("\n");
+      output.append(parse.getData()).append("\n");
       if (dumpText) {
         output.append(parse.getText());
       }


### PR DESCRIPTION
- switch to multi-line presentation of Metadata in ParseData::toString
- default implementation of Metadata::toString is still single-line
- replace StringBuffer by StringBuilder in modified methods

Parsechecker will now show metadata as follows:
```
$> bin/nutch parsechecker -Dplugin.includes='parse-(tika|metatags)|protocol-okhttp' http://localhost/
fetching: http://localhost/
...
Title: Apache2 Ubuntu Default Page: It works
Outlinks: 2
  outlink: toUrl: http://localhost/icons/ubuntu-logo.png anchor: Ubuntu Logo
  outlink: toUrl: http://localhost/manual anchor: manual
Content Metadata:
  Accept-Ranges = bytes
  Keep-Alive = timeout=5, max=100
  nutch.fetch.time = 1591696071739
  Server = Apache/2.4.41 (Ubuntu)
  ETag = "2aa6-59647cb960db3-gzip"
  Connection = Keep-Alive
  Vary = Accept-Encoding
  Last-Modified = Fri, 01 Nov 2019 12:06:26 GMT
  Date = Tue, 09 Jun 2020 09:47:51 GMT
  Content-Type = text/html
Parse Metadata:
  dc:title = Apache2 Ubuntu Default Page: It works
  Content-Encoding = UTF-8
  Content-Type-Hint = text/html; charset=UTF-8
  Content-Type = application/xhtml+xml; charset=UTF-8
```