### PR TITLE
NUTCH-2790 indexer-csv: escape field leading quote character

### DIFF
--- a/src/plugin/indexer-csv/src/java/org/apache/nutch/indexwriter/csv/CSVIndexWriter.java
+++ b/src/plugin/indexer-csv/src/java/org/apache/nutch/indexwriter/csv/CSVIndexWriter.java
@@ -405,13 +405,12 @@ public class CSVIndexWriter implements IndexWriter {
     if (max > maxFieldLength) {
       max = maxFieldLength;
     }
-    while (nextQuoteChar > 0 && nextQuoteChar < max) {
+    while (nextQuoteChar >= 0 && nextQuoteChar < max) {
       csvout.write(value.substring(start, nextQuoteChar).getBytes(encoding));
       csvout.write(escapeCharacter.bytes);
       csvout.write(quoteCharacter.bytes);
       start = nextQuoteChar + 1;
       nextQuoteChar = quoteCharacter.find(value, start);
-      if (nextQuoteChar > max) break;
     }
     csvout.write(value.substring(start, max).getBytes(encoding));
   }

--- a/src/plugin/indexer-csv/src/test/org/apache/nutch/indexwriter/csv/TestCSVIndexWriter.java
+++ b/src/plugin/indexer-csv/src/test/org/apache/nutch/indexwriter/csv/TestCSVIndexWriter.java
@@ -159,6 +159,15 @@ public class TestCSVIndexWriter {
   }
 
   @Test
+  public void testCSVescapeLeadingQuotes() throws IOException {
+    String[] params = { CSVConstants.CSV_FIELDS, "test" };
+    String[] fields = { "test", "\"quote\"" };
+    String csv = getCSV(params, fields);
+    assertEquals("Leading quotes inside a quoted field must be escaped",
+        "\"\"\"quote\"\"\"", csv.trim());
+  }
+
+  @Test
   public void testCSVclipMaxLength() throws IOException {
     String[] params = { CSVConstants.CSV_FIELDS, "test",
         CSVConstants.CSV_MAXFIELDLENGTH, "8" };


### PR DESCRIPTION
Before the change, the leading quote of a field value like '"value'
would be left unescaped.

NOTE: the tests fail locally with and without the PR. The only output I have is:
```
test:
     [echo] Testing plugin: urlnormalizer-slash
    [junit] Running org.apache.nutch.net.urlnormalizer.regex.TestRegexURLNormalizer
    [junit] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.276 sec
    [junit] Running org.apache.nutch.net.urlnormalizer.slash.TestSlashURLNormalizer
    [junit] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.306 sec
```
Is there any way to have detailed test information when running them from command line? I am not very excited about working with Eclipse.