### PR TITLE
NUTCH-2791 Handle GCS URLs in stats commands

### DIFF
--- a/src/java/org/apache/nutch/util/CrawlCompletionStats.java
+++ b/src/java/org/apache/nutch/util/CrawlCompletionStats.java
@@ -74,7 +74,7 @@ public class CrawlCompletionStats extends Configured implements Tool {
     Option inDirs = OptionBuilder
         .withArgName("inputDirs")
         .isRequired()
-        .withDescription("Comma separated list of crawl directories (e.g., \"./crawl1,./crawl2\")")
+        .withDescription("Comma separated list of crawldb directories (e.g., \"./crawl1/crawldb,./crawl2/crawldb\")")
         .hasArgs()
         .create("inputDirs");
     @SuppressWarnings("static-access")
@@ -153,9 +153,7 @@ public class CrawlCompletionStats extends Configured implements Tool {
 
     String[] inputDirsSpecs = inputDir.split(",");
     for (int i = 0; i < inputDirsSpecs.length; i++) {
-      File completeInputPath = new File(new File(inputDirsSpecs[i]), "crawldb/current");
-      FileInputFormat.addInputPath(job, new Path(completeInputPath.toString()));
-      
+      FileInputFormat.addInputPath(job, new Path(inputDirsSpecs[i], "current"));
     }
 
     job.setInputFormatClass(SequenceFileInputFormat.class);

--- a/src/java/org/apache/nutch/util/ProtocolStatusStatistics.java
+++ b/src/java/org/apache/nutch/util/ProtocolStatusStatistics.java
@@ -82,8 +82,8 @@ public class ProtocolStatusStatistics extends Configured implements Tool {
 
     int numOfReducers = 1;
 
-    if (args.length > 3) {
-      numOfReducers = Integer.parseInt(args[3]);
+    if (args.length > 2) {
+      numOfReducers = Integer.parseInt(args[2]);
     }
 
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
@@ -100,8 +100,7 @@ public class ProtocolStatusStatistics extends Configured implements Tool {
 
     String[] inputDirsSpecs = inputDir.split(",");
     for (int i = 0; i < inputDirsSpecs.length; i++) {
-      File completeInputPath = new File(new File(inputDirsSpecs[i]), "current");
-      FileInputFormat.addInputPath(job, new Path(completeInputPath.toString()));
+      FileInputFormat.addInputPath(job, new Path(inputDirsSpecs[i], "current"));
     }
 
     job.setInputFormatClass(SequenceFileInputFormat.class);

--- a/src/java/org/apache/nutch/util/domain/DomainStatistics.java
+++ b/src/java/org/apache/nutch/util/domain/DomainStatistics.java
@@ -119,8 +119,7 @@ public class DomainStatistics extends Configured implements Tool {
 
     String[] inputDirsSpecs = inputDir.split(",");
     for (int i = 0; i < inputDirsSpecs.length; i++) {
-      File completeInputPath = new File(new File(inputDirsSpecs[i]), "current");
-      FileInputFormat.addInputPath(job, new Path(completeInputPath.toString()));
+      FileInputFormat.addInputPath(job, new Path(inputDirsSpecs[i], "current"));
     }
 
     job.setInputFormatClass(SequenceFileInputFormat.class);


### PR DESCRIPTION
- Handle Google Cloud Storage URLs as crawldb inputs in domainstats,
  protocolstats and crawlcomplete commands.
- Correctly resolve numReducers in protocolstats.
- Align crawlcomplete -inputDirs behaviour on the other commands: expect
  directories containing "current", not "crawldb/current".

Like the other PR, I cannot run all tests locally. But I am not too worried, test-core pass.
Also, these changes are not super high quality in the sense that ideally I would have added some helper to enforce path manipulations which work with URLs, for all commands. Now, I do not think these commands deserve so much work so:

- I just copy/paste "Path" manipulations used in other commands like CrawlDBReader which I know work locally and in GCS. Then run the commands in GCP and some of them again locally just to be sure I did not break everything. I do not know Java API well enough to decide if the path manipulations make sense, I just know they work.
- I spotted the numReducers issue while reading the code. I did not test it. It is obviously a copy/paste from domainstats to protocolstats.