### PR TITLE
NUTCH-2793 indexer-csv: make it work in distributed mode

### DIFF
--- a/src/plugin/indexer-csv/README.md
+++ b/src/plugin/indexer-csv/README.md
@@ -1,7 +1,7 @@
 indexer-csv plugin for Nutch 
 ============================
 
-**indexer-csv plugin** is used for writing documents to a CSV file. It does not work in distributed mode, the output is written to the local filesystem, not to HDFS, see [NUTCH-1541](https://issues.apache.org/jira/browse/NUTCH-1541). The configuration for the index writers is on **conf/index-writers.xml** file, included in the official Nutch distribution and it's as follow:
+**indexer-csv plugin** is used for writing documents to a CSV file. The configuration for the index writers is on **conf/index-writers.xml** file, included in the official Nutch distribution and it's as follow:
 
 ```xml
 <writer id="<writer_id>" class="org.apache.nutch.indexwriter.csv.CSVIndexWriter">

--- a/src/plugin/indexer-csv/src/java/org/apache/nutch/indexwriter/csv/CSVIndexWriter.java
+++ b/src/plugin/indexer-csv/src/java/org/apache/nutch/indexwriter/csv/CSVIndexWriter.java
@@ -44,17 +44,14 @@ import org.slf4j.LoggerFactory;
  * index as CSV or tab-separated plain text table. Format (encoding, separators,
  * etc.) is configurable by a couple of options, see output of
  * {@link #describe()}.
- * 
- * <p>
- * Note: works only in local mode, to be used with index option
- * <code>-noCommit</code>.
- * </p>
+ *
  */
 public class CSVIndexWriter implements IndexWriter {
 
   public static final Logger LOG = LoggerFactory
       .getLogger(CSVIndexWriter.class);
 
+  private String filename = "nutch.csv";
   private Configuration config;
 
   /** ordered list of fields (columns) in the CSV file */
@@ -192,7 +189,7 @@ public class CSVIndexWriter implements IndexWriter {
 
   @Override
   public void open(Configuration conf, String name) throws IOException {
-
+    filename = name;
   }
 
   /**
@@ -227,7 +224,7 @@ public class CSVIndexWriter implements IndexWriter {
     LOG.info("Writing output to {}", outputPath);
     Path outputDir = new Path(outputPath);
     fs = outputDir.getFileSystem(config);
-    csvLocalOutFile = new Path(outputDir, "nutch.csv");
+    csvLocalOutFile = new Path(outputDir, filename);
     if (!fs.exists(outputDir)) {
       fs.mkdirs(outputDir);
     }


### PR DESCRIPTION
Before the change, the output file name was hard-coded to "nutch.csv".
When running in distributed mode, multiple reducers would clobber each
other output.

After the change, the filename is taken from the first open(cfg, name)
initialization call, where name is a unique file name generated by
IndexerOutputFormat, derived from hadoop FileOutputFormat. The CSV files
are now named like part-r-000xx.