### PR TITLE
[NUTCH-2796] [NUTCH-2730] Update crawler-commons 1.1, SitemapProcessor to treat sitemap URLs as Set instead of List

### DIFF
--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -72,7 +72,7 @@
 
 		<dependency org="com.google.guava" name="guava" rev="25.0-jre" />
 
-		<dependency org="com.github.crawler-commons" name="crawler-commons" rev="1.0" />
+		<dependency org="com.github.crawler-commons" name="crawler-commons" rev="1.1" />
 
 		<dependency org="com.martinkl.warc" name="warc-hadoop" rev="0.1.0">
 			<exclude module="hadoop-client" />

--- a/src/java/org/apache/nutch/util/SitemapProcessor.java
+++ b/src/java/org/apache/nutch/util/SitemapProcessor.java
@@ -51,7 +51,6 @@ import org.apache.nutch.protocol.Protocol;
 import org.apache.nutch.protocol.ProtocolFactory;
 import org.apache.nutch.protocol.ProtocolOutput;
 import org.apache.nutch.protocol.ProtocolStatus;
-import org.apache.nutch.util.NutchJob;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -287,7 +286,7 @@ public class SitemapProcessor extends Configured implements Tool {
       }
       else if (asm instanceof SiteMapIndex) {
         SiteMapIndex index = (SiteMapIndex) asm;
-        Collection<AbstractSiteMap> sitemapUrls = index.getSitemaps();
+        Collection<AbstractSiteMap> sitemapUrls = index.getSitemaps(true);
 
         if (sitemapUrls.isEmpty()) {
           return;


### PR DESCRIPTION
[NUTCH-2796] Upgrade to crawler-commons 1.1

[NUTCH-2730] SitemapProcessor to treat sitemap URLs as Set instead of List
- sitemap links from robots.txt are treated as set by crawler-commons (since crawler-commons 1.1)
- sitemaps referenced in sitemap index are deduplicated