### PR TITLE
[NUTCH-2801] RobotsRulesParser command-line checker to use http.robots.agents as fall-back

### DIFF
--- a/src/java/org/apache/nutch/protocol/RobotRulesParser.java
+++ b/src/java/org/apache/nutch/protocol/RobotRulesParser.java
@@ -380,8 +380,14 @@ public abstract class RobotRulesParser implements Tool {
   private static class TestRobotRulesParser extends RobotRulesParser {
 
     public void setConf(Configuration conf) {
-      // make sure that agent name is set so that setConf() does not complain,
-      // the agent name is later overwritten by command-line argument
+      /*
+       * Make sure that agent name is not empty so that
+       * RobotRulesParser.setConf() does not complain.
+       * 
+       * If provided the agent names passed as command-line argument are
+       * checked, see RobotRulesParser.run(...). Also http.agent.name is then
+       * filled taking the first agent name from command-line.
+       */
       if (conf.get("http.agent.name", "").isEmpty()) {
         String firstRobotsAgent = conf.get("http.robots.agents", "").split(",")[0].trim();
         if (firstRobotsAgent.isEmpty()) {


### PR DESCRIPTION
- if no agent names are given as command-line arguments use values ofhttp.agent.name and http.robots.agents as agent names to be checked
- update command-line help

```
$> nutch org.apache.nutch.protocol.RobotRulesParser \
      -Dhttp.agent.name='mybot' \
      -Dhttp.robots.agents='nutch,goodbot' \
      robots.txt urls.txt 
Testing robots.txt for agent names: mybot,nutch,goodbot
allowed:        https://www.example.com/

# command-line overwrite:
$> nutch org.apache.nutch.protocol.RobotRulesParser \
      -Dhttp.agent.name='mybot' \
      -Dhttp.robots.agents='nutch,goodbot' \
      robots.txt urls.txt \
      badbot,anybot
Testing robots.txt for agent names: badbot,anybot
not allowed:    https://www.example.com/
```