### PR TITLE
NUTCH-2829 Fix ant target "clean-cache"

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1000,7 +1000,7 @@
   </target>
 
   <!-- target: clean-cache  ============================================= -->
-  <target name="clean-cache" depends=""
+  <target name="clean-cache" depends="ivy-init"
                         description="--> delete ivy cache">
     <ivy:cleancache />
   </target>


### PR DESCRIPTION
- make target "clean-cache" depend on "ivy-init" so that ivy-related resources are defined