### PR TITLE
NUTCH-2836 Upgrade various commons dependencies

### DIFF
--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -41,11 +41,11 @@
 			<exclude org="com.sun.jmx" name="jmxri" />
 		</dependency-->
 
-		<dependency org="org.apache.commons" name="commons-lang3" rev="3.8.1" conf="*->default" />
-		<dependency org="org.apache.commons" name="commons-collections4" rev="4.2" conf="*->master" />
-		<dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.6" conf="*->master" />
-		<dependency org="commons-codec" name="commons-codec" rev="1.11" conf="*->default" />
-		<dependency org="org.apache.commons" name="commons-compress" rev="1.18" conf="*->default" />
+		<dependency org="org.apache.commons" name="commons-lang3" rev="3.11" conf="*->default" />
+		<dependency org="org.apache.commons" name="commons-collections4" rev="4.4" conf="*->master" />
+		<dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.13" conf="*->master" />
+		<dependency org="commons-codec" name="commons-codec" rev="1.15" conf="*->default" />
+		<dependency org="org.apache.commons" name="commons-compress" rev="1.20" conf="*->default" />
 		<dependency org="org.apache.commons" name="commons-jexl3" rev="3.1" conf="*->default"/>
 		<dependency org="com.tdunning" name="t-digest" rev="3.2" />
 


### PR DESCRIPTION
PR addresses https://issues.apache.org/jira/browse/NUTCH-2836
I looked for deprecation and none exists.
All tests pass locally. 
3 rounds of crawling executed with >15k seed list. No issues were observed. 