### PR TITLE
NUTCH-2858 urlnormalizer-protocol: URL port is lost during normalization

### DIFF
--- a/conf/protocols.txt.template
+++ b/conf/protocols.txt.template
@@ -4,4 +4,6 @@
 # protocol. Useful in cases where a host accepts both http and https, doubling
 # the site's size.
 #
+# Note: if the URL includes a port number, the protocol is left unchanged.
+#
 # format: <host>\t<protocol>\n

--- a/src/plugin/urlnormalizer-basic/src/test/org/apache/nutch/net/urlnormalizer/basic/TestBasicURLNormalizer.java
+++ b/src/plugin/urlnormalizer-basic/src/test/org/apache/nutch/net/urlnormalizer/basic/TestBasicURLNormalizer.java
@@ -123,6 +123,8 @@ public class TestBasicURLNormalizer {
 
     // check that port number is normalized
     normalizeTest("http://foo.com:80/index.html", "http://foo.com/index.html");
+    normalizeTest("https://foo.com:443/index.html",
+        "https://foo.com/index.html");
     normalizeTest("http://foo.com:81/", "http://foo.com:81/");
     // check that empty port is removed
     normalizeTest("http://example.com:/", "http://example.com/");

--- a/src/plugin/urlnormalizer-protocol/src/java/org/apache/nutch/net/urlnormalizer/protocol/ProtocolURLNormalizer.java
+++ b/src/plugin/urlnormalizer-protocol/src/java/org/apache/nutch/net/urlnormalizer/protocol/ProtocolURLNormalizer.java
@@ -46,9 +46,6 @@ public class ProtocolURLNormalizer implements URLNormalizer {
   private static final Logger LOG = LoggerFactory
       .getLogger(MethodHandles.lookup().lookupClass());
 
-  private static final char QUESTION_MARK = '?';
-  private static final String PROTOCOL_DELIMITER = "://";
-
   private static String attributeFile = null;
   
   // We record a map of hosts and boolean, the boolean denotes whether the host should
@@ -155,6 +152,12 @@ public class ProtocolURLNormalizer implements URLNormalizer {
     // Get the host
     String host = u.getHost();
 
+    // Is there a (non-default) port set?
+    if (u.getPort() != -1) {
+      // do not change the protocol if the port is set
+      return url;
+    }
+
     // Do we have a rule for this host?
     if (protocolsMap.containsKey(host)) {    
       String protocol = u.getProtocol();
@@ -163,18 +166,8 @@ public class ProtocolURLNormalizer implements URLNormalizer {
       // Incorrect protocol?
       if (!protocol.equals(requiredProtocol)) {
         // Rebuild URL with new protocol
-        StringBuilder buffer = new StringBuilder(requiredProtocol);
-        buffer.append(PROTOCOL_DELIMITER);
-        buffer.append(host);
-        buffer.append(u.getPath());
-        
-        String queryString = u.getQuery();
-        if (queryString != null) {
-          buffer.append(QUESTION_MARK);
-          buffer.append(queryString);
-        }
-        
-        url = buffer.toString();
+        url = new URL(requiredProtocol, host, u.getPort(), u.getFile())
+            .toString();
       }
     }
 

--- a/src/plugin/urlnormalizer-protocol/src/test/org/apache/nutch/net/urlnormalizer/protocol/TestProtocolURLNormalizer.java
+++ b/src/plugin/urlnormalizer-protocol/src/test/org/apache/nutch/net/urlnormalizer/protocol/TestProtocolURLNormalizer.java
@@ -36,19 +36,38 @@ public class TestProtocolURLNormalizer extends TestCase {
     normalizer.setConf(conf);
 
     // No change
-    assertEquals("http://example.org/", normalizer.normalize("https://example.org/", URLNormalizers.SCOPE_DEFAULT));
-    assertEquals("http://example.net/", normalizer.normalize("https://example.net/", URLNormalizers.SCOPE_DEFAULT));
-    
+    assertEquals("http://example.org/", normalizer
+        .normalize("https://example.org/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("http://example.net/", normalizer
+        .normalize("https://example.net/", URLNormalizers.SCOPE_DEFAULT));
+
     // https to http
-    assertEquals("http://example.org/", normalizer.normalize("https://example.org/", URLNormalizers.SCOPE_DEFAULT));
-    assertEquals("http://example.net/", normalizer.normalize("https://example.net/", URLNormalizers.SCOPE_DEFAULT));
-    
+    assertEquals("http://example.org/", normalizer
+        .normalize("https://example.org/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("http://example.net/", normalizer
+        .normalize("https://example.net/", URLNormalizers.SCOPE_DEFAULT));
+
     // no change
-    assertEquals("https://example.io/", normalizer.normalize("https://example.io/", URLNormalizers.SCOPE_DEFAULT));
-    assertEquals("https://example.nl/", normalizer.normalize("https://example.nl/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("https://example.io/", normalizer
+        .normalize("https://example.io/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("https://example.nl/", normalizer
+        .normalize("https://example.nl/", URLNormalizers.SCOPE_DEFAULT));
     
     // http to https
-    assertEquals("https://example.io/", normalizer.normalize("http://example.io/", URLNormalizers.SCOPE_DEFAULT));
-    assertEquals("https://example.nl/", normalizer.normalize("http://example.nl/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("https://example.io/", normalizer
+        .normalize("http://example.io/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("https://example.nl/", normalizer
+        .normalize("http://example.nl/", URLNormalizers.SCOPE_DEFAULT));
+
+    // verify proper (de)serialization of URLs
+    assertEquals("https://example.io/path?q=uery", normalizer.normalize(
+        "http://example.io/path?q=uery", URLNormalizers.SCOPE_DEFAULT));
+
+    // verify that URLs including a port are left unchanged (port and protocol
+    // are kept)
+    assertEquals("http://example.io:8080/path?q=uery", normalizer.normalize(
+        "http://example.io:8080/path?q=uery", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("https://example.org:8443/path", normalizer.normalize(
+        "https://example.org:8443/path", URLNormalizers.SCOPE_DEFAULT));
   }
 }


### PR DESCRIPTION
- if URL includes a port the protocol is not normalized

Note that
- urlnormalizer-basic removes default ports:  `https://example.com:443/` is normalized to `https://example.com/` - by chaining normalizers there is no need to handle default ports in urlnormalizer-protocol
- non-default ports can always be mapped by urlnormalizer-regex, there shouldn't be many, so the price of more complex rules and slower execution is acceptable