### PR TITLE
NUTCH-2859: urlnormalizer-protocol: allow to normalize domains

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1445,6 +1445,21 @@
   </description>
 </property>
 
+<property>
+  <name>urlnormalizer.protocols.file</name>
+  <value>protocols.txt</value>
+  <description>urlnormalizer-protocol configuration file</description>
+</property>
+
+<property>
+  <name>urlnormalizer.protocols.rules</name>
+  <value></value>
+  <description>urlnormalizer-protocol rule definitions: if not empty,
+  takes precedence over rules defined in the rule file (see
+  urlnormalizer.protocols.file)</description>
+</property>
+
+
 <!-- mime properties -->
 
 <!--

--- a/conf/protocols.txt.template
+++ b/conf/protocols.txt.template
@@ -4,6 +4,10 @@
 # protocol. Useful in cases where a host accepts both http and https, doubling
 # the site's size.
 #
+# Also all hosts of a domain can be addressed by adding a "host" pattern
+# starting with "*.". E.g., "*.wikipedia.org" will match all subdomains of
+# the domain "wikipedia.org"
+#
 # Note: if the URL includes a port number, the protocol is left unchanged.
 #
 # format: <host>\t<protocol>\n

--- a/conf/protocols.txt.template
+++ b/conf/protocols.txt.template
@@ -4,4 +4,6 @@
 # protocol. Useful in cases where a host accepts both http and https, doubling
 # the site's size.
 #
+# Note: if the URL includes a port number, the protocol is left unchanged.
+#
 # format: <host>\t<protocol>\n

--- a/src/plugin/urlnormalizer-basic/src/test/org/apache/nutch/net/urlnormalizer/basic/TestBasicURLNormalizer.java
+++ b/src/plugin/urlnormalizer-basic/src/test/org/apache/nutch/net/urlnormalizer/basic/TestBasicURLNormalizer.java
@@ -123,6 +123,8 @@ public class TestBasicURLNormalizer {
 
     // check that port number is normalized
     normalizeTest("http://foo.com:80/index.html", "http://foo.com/index.html");
+    normalizeTest("https://foo.com:443/index.html",
+        "https://foo.com/index.html");
     normalizeTest("http://foo.com:81/", "http://foo.com:81/");
     // check that empty port is removed
     normalizeTest("http://example.com:/", "http://example.com/");

--- a/src/plugin/urlnormalizer-protocol/data/protocols.txt
+++ b/src/plugin/urlnormalizer-protocol/data/protocols.txt
@@ -1,7 +1,21 @@
-# format: host\tprotocol\n
+# Example configuration file for urlnormalizer-protocol
+#
+# URL's of hosts listed in the configuration are normalized to the target
+# protocol. Useful in cases where a host accepts both http and https, doubling
+# the site's size.
+#
+# Also all hosts of a domain can be addressed by adding a "host" pattern
+# starting with "*.". E.g., "*.wikipedia.org" will match all subdomains of
+# the domain "wikipedia.org"
+#
+# Note: if the URL includes a port number, the protocol is left unchanged.
+#
+# format: <host>\t<protocol>\n
 
 example.org	http
 example.net	http
 
 example.io	https
 example.nl	https
+
+*.example.com	https

--- a/src/plugin/urlnormalizer-protocol/src/java/org/apache/nutch/net/urlnormalizer/protocol/ProtocolURLNormalizer.java
+++ b/src/plugin/urlnormalizer-protocol/src/java/org/apache/nutch/net/urlnormalizer/protocol/ProtocolURLNormalizer.java
@@ -46,9 +46,6 @@ public class ProtocolURLNormalizer implements URLNormalizer {
   private static final Logger LOG = LoggerFactory
       .getLogger(MethodHandles.lookup().lookupClass());
 
-  private static final char QUESTION_MARK = '?';
-  private static final String PROTOCOL_DELIMITER = "://";
-
   private static String attributeFile = null;
   
   // We record a map of hosts and boolean, the boolean denotes whether the host should
@@ -155,6 +152,12 @@ public class ProtocolURLNormalizer implements URLNormalizer {
     // Get the host
     String host = u.getHost();
 
+    // Is there a (non-default) port set?
+    if (u.getPort() != -1) {
+      // do not change the protocol if the port is set
+      return url;
+    }
+
     // Do we have a rule for this host?
     if (protocolsMap.containsKey(host)) {    
       String protocol = u.getProtocol();
@@ -163,18 +166,8 @@ public class ProtocolURLNormalizer implements URLNormalizer {
       // Incorrect protocol?
       if (!protocol.equals(requiredProtocol)) {
         // Rebuild URL with new protocol
-        StringBuilder buffer = new StringBuilder(requiredProtocol);
-        buffer.append(PROTOCOL_DELIMITER);
-        buffer.append(host);
-        buffer.append(u.getPath());
-        
-        String queryString = u.getQuery();
-        if (queryString != null) {
-          buffer.append(QUESTION_MARK);
-          buffer.append(queryString);
-        }
-        
-        url = buffer.toString();
+        url = new URL(requiredProtocol, host, u.getPort(), u.getFile())
+            .toString();
       }
     }
 

--- a/src/plugin/urlnormalizer-protocol/src/java/org/apache/nutch/net/urlnormalizer/protocol/package-info.java
+++ b/src/plugin/urlnormalizer-protocol/src/java/org/apache/nutch/net/urlnormalizer/protocol/package-info.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * URL normalizer to normalize the protocol for all URLs of a given host or
+ * domain.
+ * 
+ * E.g., normalize <code>http://nutch.apache.org/path/</code> to
+ * <code>https://www.apache.org/path/</code> if it's known that the host
+ * <code>nutch.apache.org</code> supports https and http-URLs either cause
+ * duplicate content or are redirected to https.
+ *
+ * The configuration of rules follows the schema:
+ * 
+ * <pre>
+ * &lt;host&gt; \t &lt;protcol&gt;
+ * </pre>
+ * 
+ * for example
+ * 
+ * <pre>
+ * nutch.apache.org \t https
+ * *.example.com \t http
+ * </pre>
+ * 
+ * These rules will normalize all URLs of the host <code>nutch.apache.org</code>
+ * to use https while every URL from <code>example.com</code> and its subdomains
+ * is normalized to be based on http.
+ *
+ * A "host" pattern which starts with <code>*.</code> will match all hosts
+ * (subdomains) of the given domain, or more generally matches domain suffixes
+ * separated by a dot.
+ * 
+ * Rules are usually configured via the configuration file "protocols.txt". The
+ * filename is specified by the property
+ * <code>urlnormalizer.protocols.file</code>. Alternatively, if the property
+ * <code>urlnormalizer.protocols.rules</code> defines a non-empty string, these
+ * rules take precedence of those specified in the rule file.
+ */
+package org.apache.nutch.net.urlnormalizer.protocol;
+

--- a/src/plugin/urlnormalizer-protocol/src/test/org/apache/nutch/net/urlnormalizer/protocol/TestProtocolURLNormalizer.java
+++ b/src/plugin/urlnormalizer-protocol/src/test/org/apache/nutch/net/urlnormalizer/protocol/TestProtocolURLNormalizer.java
@@ -69,5 +69,19 @@ public class TestProtocolURLNormalizer extends TestCase {
         "http://example.io:8080/path?q=uery", URLNormalizers.SCOPE_DEFAULT));
     assertEquals("https://example.org:8443/path", normalizer.normalize(
         "https://example.org:8443/path", URLNormalizers.SCOPE_DEFAULT));
+
+    // verify normalization of all subdomains (host pattern *.example.com)
+    assertEquals("https://example.com/", normalizer
+        .normalize("http://example.com/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("https://www.example.com/", normalizer
+        .normalize("http://www.example.com/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("https://www.subdomain.example.com/", normalizer.normalize(
+        "http://www.subdomain.example.com/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("http://myexample.com/", normalizer
+        .normalize("http://myexample.com/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("http://www.subdomain.example.com:8080/path?q=uery",
+        normalizer.normalize(
+            "http://www.subdomain.example.com:8080/path?q=uery",
+            URLNormalizers.SCOPE_DEFAULT));
   }
 }

--- a/src/plugin/urlnormalizer-protocol/src/test/org/apache/nutch/net/urlnormalizer/protocol/TestProtocolURLNormalizer.java
+++ b/src/plugin/urlnormalizer-protocol/src/test/org/apache/nutch/net/urlnormalizer/protocol/TestProtocolURLNormalizer.java
@@ -36,19 +36,38 @@ public class TestProtocolURLNormalizer extends TestCase {
     normalizer.setConf(conf);
 
     // No change
-    assertEquals("http://example.org/", normalizer.normalize("https://example.org/", URLNormalizers.SCOPE_DEFAULT));
-    assertEquals("http://example.net/", normalizer.normalize("https://example.net/", URLNormalizers.SCOPE_DEFAULT));
-    
+    assertEquals("http://example.org/", normalizer
+        .normalize("https://example.org/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("http://example.net/", normalizer
+        .normalize("https://example.net/", URLNormalizers.SCOPE_DEFAULT));
+
     // https to http
-    assertEquals("http://example.org/", normalizer.normalize("https://example.org/", URLNormalizers.SCOPE_DEFAULT));
-    assertEquals("http://example.net/", normalizer.normalize("https://example.net/", URLNormalizers.SCOPE_DEFAULT));
-    
+    assertEquals("http://example.org/", normalizer
+        .normalize("https://example.org/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("http://example.net/", normalizer
+        .normalize("https://example.net/", URLNormalizers.SCOPE_DEFAULT));
+
     // no change
-    assertEquals("https://example.io/", normalizer.normalize("https://example.io/", URLNormalizers.SCOPE_DEFAULT));
-    assertEquals("https://example.nl/", normalizer.normalize("https://example.nl/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("https://example.io/", normalizer
+        .normalize("https://example.io/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("https://example.nl/", normalizer
+        .normalize("https://example.nl/", URLNormalizers.SCOPE_DEFAULT));
     
     // http to https
-    assertEquals("https://example.io/", normalizer.normalize("http://example.io/", URLNormalizers.SCOPE_DEFAULT));
-    assertEquals("https://example.nl/", normalizer.normalize("http://example.nl/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("https://example.io/", normalizer
+        .normalize("http://example.io/", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("https://example.nl/", normalizer
+        .normalize("http://example.nl/", URLNormalizers.SCOPE_DEFAULT));
+
+    // verify proper (de)serialization of URLs
+    assertEquals("https://example.io/path?q=uery", normalizer.normalize(
+        "http://example.io/path?q=uery", URLNormalizers.SCOPE_DEFAULT));
+
+    // verify that URLs including a port are left unchanged (port and protocol
+    // are kept)
+    assertEquals("http://example.io:8080/path?q=uery", normalizer.normalize(
+        "http://example.io:8080/path?q=uery", URLNormalizers.SCOPE_DEFAULT));
+    assertEquals("https://example.org:8443/path", normalizer.normalize(
+        "https://example.org:8443/path", URLNormalizers.SCOPE_DEFAULT));
   }
 }


### PR DESCRIPTION
(note: to avoid merge conflicts, this PR includes #575)

In order to address NUTCH-2859 host names starting with `*.` (in the config file `protocols.txt` or in the string rules) are matched as suffixes: `*.example.org` matches `example.org`, `www.example.org`, `www.subdomain.example.org`, etc.

Additional improvements:
- allow to read config file protocols.txt from hdfs:// or any file system supported by Hadoop - useful if the list of host or domains requiring normalization is large or changes often
- add Javadoc package documentation
- document configuration properties in nutch-default.xml
- reduce the memory footprint by deduplicating protocol strings, so that same protocol values are references to same objects