### PR TITLE
NUTCH-2864 Upgrade Dockerfile to use JDK 11

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,18 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:18.04
+FROM alpine:3.13
 MAINTAINER Apache Nutch Committers <dev@nutch.apache.org>
 
 WORKDIR /root/
 
 
 # Install dependencies
-RUN apt update
-RUN apt install -y ant git openjdk-8-jdk-headless
-
-# Set up JAVA_HOME
-RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64' >> $HOME/.bashrc
+RUN apk update
+RUN apk --no-cache add apache-ant git openjdk11
 
 # Checkout and build the Nutch master branch (1.x)
 RUN git clone https://github.com/apache/nutch.git nutch_source && cd nutch_source && ant runtime

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,13 +18,16 @@ MAINTAINER Apache Nutch Committers <dev@nutch.apache.org>
 
 WORKDIR /root/
 
-
 # Install dependencies
 RUN apk update
-RUN apk --no-cache add apache-ant git openjdk11
+RUN apk --no-cache add apache-ant bash git openjdk11
 
 # Checkout and build the Nutch master branch (1.x)
-RUN git clone https://github.com/apache/nutch.git nutch_source && cd nutch_source && ant runtime
+RUN git clone https://github.com/apache/nutch.git nutch_source && \
+     cd nutch_source && \
+     ant runtime && \
+     rm -rf build/ && \
+     rm -rf /root/.ivy2/
 
 # Convenience symlink to Nutch runtime local
 RUN ln -s nutch_source/runtime/local $HOME/nutch

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,8 @@ WORKDIR /root/
 RUN apk update
 RUN apk --no-cache add apache-ant bash git openjdk11
 
+RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-11-openjdk' >> $HOME/.bashrc
+
 # Checkout and build the Nutch master branch (1.x)
 RUN git clone https://github.com/apache/nutch.git nutch_source && \
      cd nutch_source && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,7 @@ Current configuration of this image consists of components:
 
 ##  Base Image
 
-* [ubuntu:18.04](https://hub.docker.com/_/ubuntu/)
+* [alpine:3.13](https://hub.docker.com/_/alpine/)
 
 ## Tips
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,12 @@
 # Nutch Dockerfile #
 
+![Docker Pulls](https://img.shields.io/docker/pulls/apache/nutch?style=for-the-badge)
+![Docker Image Size (latest by date)](https://img.shields.io/docker/image-size/apache/nutch?style=for-the-badge)
+![Docker Image Version (latest semver)](https://img.shields.io/docker/v/apache/nutch?style=for-the-badge)
+![MicroBadger Layers](https://img.shields.io/microbadger/layers/apache/nutch?style=for-the-badge)
+![Docker Stars](https://img.shields.io/docker/stars/apache/nutch?style=for-the-badge)
+![Docker Automated build](https://img.shields.io/docker/automated/apache/nutch?style=for-the-badge)
+
 Get up and running quickly with Nutch on Docker.
 
 ## What is Nutch?


### PR DESCRIPTION
This PR addresses https://issues.apache.org/jira/browse/NUTCH-2864
Using the Alpine Linux base is supposed to create a smaller overall image footprint...