### PR TITLE
NUTCH-2899 Remove needless warning about missing o/a/rat/anttasks/antlib.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1063,16 +1063,15 @@
     <delete file="${ivy.dir}/apache-rat-${apache-rat.version}-bin.tar.gz" />
   </target>
 
-  <taskdef
-      uri="antlib:org.apache.rat.anttasks"
-      resource="org/apache/rat/anttasks/antlib.xml">
-    <classpath>
-      <pathelement location="${apache-rat.jar}" />
-    </classpath>
-  </taskdef>
-
   <target name="rat-sources" depends="init, apache-rat-download"
     description="--> runs RAT tasks over src/java">
+    <taskdef
+        uri="antlib:org.apache.rat.anttasks"
+        resource="org/apache/rat/anttasks/antlib.xml">
+      <classpath>
+        <pathelement location="${apache-rat.jar}" />
+      </classpath>
+    </taskdef>
     <rat:report
         reportFile="${build.dir}/apache-rat-report.txt">
       <fileset dir="src">


### PR DESCRIPTION
- avoid needless warning by moving taskdef into task element