### PR TITLE
NUTCH-2916 Fix log file rotation / rename default log file

### DIFF
--- a/conf/log4j2.xml
+++ b/conf/log4j2.xml
@@ -21,13 +21,12 @@
                      NUTCH_LOG_DIR and NUTCH_LOGFILE -->
     <Property name="hadoop.log.dir">${sys:hadoop.log.dir:-./logs}</Property>
     <Property name="hadoop.log.file">${sys:hadoop.log.file:-hadoop.log}</Property>
-    <Property name="hadoop.log.file">hadoop.log</Property>
   </Properties>
   <Appenders>
     <RollingFile name="RollingFile" fileName="${hadoop.log.dir}/${hadoop.log.file}"
       filePattern="${hadoop.log.dir}/$${date:yyyy-MM}/nutch-%d{yyyy-MM-dd}.log.gz">
       <PatternLayout pattern="%d %p %c{1.} [%t] %m%n" />
-      <CronTriggeringPolicy schedule="0 0 0 * * ?"/>
+      <CronTriggeringPolicy schedule="0 0 0 * * ?" evaluateOnStartup="true" />
       <DefaultRolloverStrategy>
         <Delete basePath="${hadoop.log.dir}" maxDepth="2">
           <IfFileName glob="*/nutch-*.log.gz" />

--- a/src/bin/nutch
+++ b/src/bin/nutch
@@ -29,7 +29,8 @@
 #
 #   NUTCH_LOG_DIR   Log directory (default: $NUTCH_HOME/logs)
 #
-#   NUTCH_LOGFILE   Log file (default: hadoop.log)
+#   NUTCH_LOGFILE   Log file (default: nutch.log - if overridden, do not forget
+#                   to change the log file rotation patterns in conf/log4j2.xml)
 #
 #   NUTCH_CONF_DIR  Path(s) to configuration files (default: $NUTCH_HOME/conf).
 #                   Multiple paths must be separated by a colon ':'.


### PR DESCRIPTION
- `nutch.log` replaces `hadoop.log` as default log file name
- file rotation patterns only match `nutch.log` as log file name
- checking on start-up whether the log file(s) need to be rotated