### PR TITLE
NUTCH-2449 Replace Tika LanguageIdentifier in language-identifier

### DIFF
--- a/src/plugin/language-identifier/build-ivy.xml
+++ b/src/plugin/language-identifier/build-ivy.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project name="language-identifier" default="deps-jar" xmlns:ivy="antlib:org.apache.ivy.ant">
+
+  <property name="ivy.dir" value="../../../ivy" />
+  <property file="../../../default.properties" />
+
+  <target name="download-ivy" unless="offline">
+    <!-- download Ivy from web site so that it can be used even without any special installation -->
+    <available file="${ivy.jar}" property="ivy.jar.found"/>
+    <antcall target="ivy-download-unchecked"/>
+  </target>
+
+  <target name="ivy-download-unchecked" unless="ivy.jar.found" description="--> fetch any ivy file">
+    <get src="${ivy.repo.url}" dest="${ivy.jar}" usetimestamp="true" />
+  </target>
+
+  <target name="init-ivy" depends="download-ivy">
+    <!-- try to load ivy here from ivy home, in case the user has not already dropped
+         it into ant's lib dir (note that the latter copy will always take precedence).
+         We will not fail as long as local lib dir exists (it may be empty) and
+         ivy is in at least one of ant's lib dir or the local lib dir. -->
+    <taskdef resource="org/apache/ivy/ant/antlib.xml"
+             uri="antlib:org.apache.ivy.ant" classpath="${ivy.jar}"/>
+    <ivy:settings file="${ivy.dir}/ivysettings.xml" />
+  </target>
+
+  <target name="deps-jar" depends="init-ivy">
+    <ivy:retrieve pattern="lib/[artifact]-[revision].[ext]" sync="true"/>
+  </target>
+
+</project>

--- a/src/plugin/language-identifier/build.xml
+++ b/src/plugin/language-identifier/build.xml
@@ -20,9 +20,9 @@
   <import file="../build-plugin.xml"/>
 
   <target name="init-plugin">
-    <echo>Copying language profiles</echo>
+    <echo>Copying language mappings (language codes to names)</echo>
     <copy todir="${build.classes}">
-      <fileset dir="${src.dir}" includes="**/*.ngp, **/*.properties"/>
+      <fileset dir="${src.dir}" includes="**/*.properties"/>
     </copy>
     <echo>Copying test files</echo>
     <copy todir="${build.test}">


### PR DESCRIPTION
This PR finishes off and therefore supersedes https://github.com/apache/nutch/pull/233 in a post-[NUTCH-2891](https://issues.apache.org/jira/browse/NUTCH-2891)/ b0cbea5 world :)

@sebastian-nagel I have no examples which would validate [NUTCH-1397](https://issues.apache.org/jira/browse/NUTCH-1397). Do you?