### PR TITLE
NUTCH-2429 Fix Plugin System to allow protocol plugins to bundle their URLStreamHandlers

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1272,6 +1272,7 @@
         <source path="${plugins.dir}/parsefilter-regex/src/test/" />
         <source path="${plugins.dir}/protocol-file/src/java/" />
         <source path="${plugins.dir}/protocol-file/src/test/" />
+        <source path="${plugins.dir}/protocol-foo/src/java/" />
         <source path="${plugins.dir}/protocol-ftp/src/java/" />
         <source path="${plugins.dir}/protocol-htmlunit/src/java/" />
         <source path="${plugins.dir}/protocol-http/src/java/" />

--- a/src/java/org/apache/nutch/parse/ParserChecker.java
+++ b/src/java/org/apache/nutch/parse/ParserChecker.java
@@ -28,6 +28,7 @@ import org.apache.nutch.crawl.CrawlDatum;
 import org.apache.nutch.crawl.SignatureFactory;
 import org.apache.nutch.metadata.Metadata;
 import org.apache.nutch.net.URLNormalizers;
+import org.apache.nutch.plugin.PluginRepository;
 import org.apache.nutch.protocol.Content;
 import org.apache.nutch.protocol.ProtocolOutput;
 import org.apache.nutch.scoring.ScoringFilters;
@@ -105,6 +106,10 @@ public class ParserChecker extends AbstractChecker {
       System.err.println(usage);
       System.exit(-1);
     }
+
+    // initialize plugins early to register URL stream handlers to support
+    // custom protocol implementations
+    PluginRepository.get(getConf());
 
     int numConsumed;
     for (int i = 0; i < args.length; i++) {

--- a/src/java/org/apache/nutch/plugin/PluginManifestParser.java
+++ b/src/java/org/apache/nutch/plugin/PluginManifestParser.java
@@ -29,10 +29,9 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.apache.hadoop.conf.Configuration;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -40,8 +39,9 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 /**
- * The <code>PluginManifestParser</code> parser just parse the manifest file in
- * all plugin directories.
+ * The <code>PluginManifestParser</code> provides a mechanism for
+ * parsing Nutch plugin manifest files (<code>plugin.xml</code>) contained
+ * in a {@link java.lang.String[]} of plugin directories.
  * 
  * @author joa23
  */
@@ -50,18 +50,15 @@ public class PluginManifestParser {
   private static final String ATTR_CLASS = "class";
   private static final String ATTR_ID = "id";
 
-  protected static final Logger LOG = LoggerFactory
-      .getLogger(PluginManifestParser.class);
+  protected static final Logger LOG = LoggerFactory.getLogger(PluginManifestParser.class);
 
-  private static final boolean WINDOWS = System.getProperty("os.name")
-      .startsWith("Windows");
+  private static final boolean WINDOWS = System.getProperty("os.name").startsWith("Windows");
 
   private Configuration conf;
 
   private PluginRepository pluginRepository;
 
-  public PluginManifestParser(Configuration conf,
-      PluginRepository pluginRepository) {
+  public PluginManifestParser(Configuration conf, PluginRepository pluginRepository) {
     this.conf = conf;
     this.pluginRepository = pluginRepository;
   }
@@ -73,8 +70,7 @@ public class PluginManifestParser {
    *          folders to search plugins from
    * @return A {@link Map} of all found {@link PluginDescriptor}s.
    */
-  public Map<String, PluginDescriptor> parsePluginFolder(
-      String[] pluginFolders) {
+  public Map<String, PluginDescriptor> parsePluginFolder(String[] pluginFolders) {
     Map<String, PluginDescriptor> map = new HashMap<>();
 
     if (pluginFolders == null) {
@@ -86,18 +82,17 @@ public class PluginManifestParser {
       if (directory == null) {
         continue;
       }
-      LOG.info("Plugins: looking in: " + directory.getAbsolutePath());
+      LOG.info("Plugins: looking in: {}", directory.getAbsolutePath());
       for (File oneSubFolder : directory.listFiles()) {
         if (oneSubFolder.isDirectory()) {
           String manifestPath = oneSubFolder.getAbsolutePath() + File.separator
-              + "plugin.xml";
+                  + "plugin.xml";
           try {
-            LOG.debug("parsing: " + manifestPath);
+            LOG.debug("Parsing: {}", manifestPath);
             PluginDescriptor p = parseManifestFile(manifestPath);
             map.put(p.getPluginId(), p);
           } catch (Exception e) {
-            LOG.warn("Error while loading plugin `" + manifestPath + "` "
-                + e.toString());
+            LOG.warn("Error while loading plugin {}: {}", manifestPath, e.toString());
           }
         }
       }
@@ -116,13 +111,13 @@ public class PluginManifestParser {
     if (!directory.isAbsolute()) {
       URL url = PluginManifestParser.class.getClassLoader().getResource(name);
       if (url == null && directory.exists() && directory.isDirectory()
-          && directory.listFiles().length > 0) {
+              && directory.listFiles().length > 0) {
         return directory; // relative path that is not in the classpath
       } else if (url == null) {
-        LOG.warn("Plugins: directory not found: " + name);
+        LOG.warn("Plugins: directory not found: {}", name);
         return null;
       } else if (!"file".equals(url.getProtocol())) {
-        LOG.warn("Plugins: not a file: url. Can't load plugins from: " + url);
+        LOG.warn("Plugins: not a file: url. Can't load plugins from: {}", url);
         return null;
       }
       String path = url.getPath();
@@ -134,7 +129,7 @@ public class PluginManifestParser {
       }
       directory = new File(path);
     } else if (!directory.exists()) {
-      LOG.warn("Plugins: directory not found: " + name);
+      LOG.warn("Plugins: directory not found: {}", name);
       return null;
     }
     return directory;
@@ -148,8 +143,8 @@ public class PluginManifestParser {
    * @throws MalformedURLException
    */
   private PluginDescriptor parseManifestFile(String pManifestPath)
-      throws MalformedURLException, SAXException, IOException,
-      ParserConfigurationException {
+          throws MalformedURLException, SAXException, IOException,
+          ParserConfigurationException {
     Document document = parseXML(new File(pManifestPath).toURI().toURL());
     String pPath = new File(pManifestPath).getParent();
     return parsePlugin(document, pPath);
@@ -164,7 +159,7 @@ public class PluginManifestParser {
    * @throws DocumentException
    */
   private Document parseXML(URL url)
-      throws SAXException, IOException, ParserConfigurationException {
+          throws SAXException, IOException, ParserConfigurationException {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     DocumentBuilder builder = factory.newDocumentBuilder();
     return builder.parse(url.openStream());
@@ -175,7 +170,7 @@ public class PluginManifestParser {
    * @throws MalformedURLException
    */
   private PluginDescriptor parsePlugin(Document pDocument, String pPath)
-      throws MalformedURLException {
+          throws MalformedURLException {
     Element rootElement = pDocument.getDocumentElement();
     String id = rootElement.getAttribute(ATTR_ID);
     String name = rootElement.getAttribute(ATTR_NAME);
@@ -186,9 +181,9 @@ public class PluginManifestParser {
       pluginClazz = rootElement.getAttribute(ATTR_CLASS);
     }
     PluginDescriptor pluginDescriptor = new PluginDescriptor(id, version, name,
-        providerName, pluginClazz, pPath, this.conf);
-    LOG.debug("plugin: id=" + id + " name=" + name + " version=" + version
-        + " provider=" + providerName + "class=" + pluginClazz);
+            providerName, pluginClazz, pPath, this.conf);
+    LOG.debug("plugin: id={} name={} version={} provider={} class={}", 
+            id, name, version, providerName, pluginClazz);
     parseExtension(rootElement, pluginDescriptor);
     parseExtensionPoints(rootElement, pluginDescriptor);
     parseLibraries(rootElement, pluginDescriptor);
@@ -202,7 +197,7 @@ public class PluginManifestParser {
    * @throws MalformedURLException
    */
   private void parseRequires(Element pRootElement, PluginDescriptor pDescriptor)
-      throws MalformedURLException {
+          throws MalformedURLException {
 
     NodeList nodelist = pRootElement.getElementsByTagName("requires");
     if (nodelist.getLength() > 0) {
@@ -226,7 +221,7 @@ public class PluginManifestParser {
    * @throws MalformedURLException
    */
   private void parseLibraries(Element pRootElement,
-      PluginDescriptor pDescriptor) throws MalformedURLException {
+          PluginDescriptor pDescriptor) throws MalformedURLException {
     NodeList nodelist = pRootElement.getElementsByTagName("runtime");
     if (nodelist.getLength() > 0) {
 
@@ -251,7 +246,7 @@ public class PluginManifestParser {
    * @param pluginDescriptor
    */
   private void parseExtensionPoints(Element pRootElement,
-      PluginDescriptor pPluginDescriptor) {
+          PluginDescriptor pPluginDescriptor) {
     NodeList list = pRootElement.getElementsByTagName("extension-point");
     if (list != null) {
       for (int i = 0; i < list.getLength(); i++) {
@@ -270,7 +265,7 @@ public class PluginManifestParser {
    * @param pluginDescriptor
    */
   private void parseExtension(Element pRootElement,
-      PluginDescriptor pPluginDescriptor) {
+          PluginDescriptor pPluginDescriptor) {
     NodeList extensions = pRootElement.getElementsByTagName("extension");
     if (extensions != null) {
       for (int i = 0; i < extensions.getLength(); i++) {
@@ -289,14 +284,14 @@ public class PluginManifestParser {
             String extensionClass = oneImplementation.getAttribute(ATTR_CLASS);
             LOG.debug("impl: point=" + pointId + " class=" + extensionClass);
             Extension extension = new Extension(pPluginDescriptor, pointId, id,
-                extensionClass, this.conf, this.pluginRepository);
+                    extensionClass, this.conf, this.pluginRepository);
             NodeList parameters = oneImplementation
-                .getElementsByTagName("parameter");
+                    .getElementsByTagName("parameter");
             if (parameters != null) {
               for (int k = 0; k < parameters.getLength(); k++) {
                 Element param = (Element) parameters.item(k);
                 extension.addAttribute(param.getAttribute(ATTR_NAME),
-                    param.getAttribute("value"));
+                        param.getAttribute("value"));
               }
             }
             pPluginDescriptor.addExtension(extension);

--- a/src/java/org/apache/nutch/plugin/PluginManifestParser.java
+++ b/src/java/org/apache/nutch/plugin/PluginManifestParser.java
@@ -30,6 +30,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.conf.Configuration;
 import org.w3c.dom.Document;
@@ -49,7 +50,8 @@ public class PluginManifestParser {
   private static final String ATTR_CLASS = "class";
   private static final String ATTR_ID = "id";
 
-  public static final Logger LOG = PluginRepository.LOG;
+  protected static final Logger LOG = LoggerFactory
+      .getLogger(PluginManifestParser.class);
 
   private static final boolean WINDOWS = System.getProperty("os.name")
       .startsWith("Windows");
@@ -71,7 +73,8 @@ public class PluginManifestParser {
    *          folders to search plugins from
    * @return A {@link Map} of all found {@link PluginDescriptor}s.
    */
-  public Map<String, PluginDescriptor> parsePluginFolder(String[] pluginFolders) {
+  public Map<String, PluginDescriptor> parsePluginFolder(
+      String[] pluginFolders) {
     Map<String, PluginDescriptor> map = new HashMap<>();
 
     if (pluginFolders == null) {
@@ -160,8 +163,8 @@ public class PluginManifestParser {
    * @throws ParserConfigurationException
    * @throws DocumentException
    */
-  private Document parseXML(URL url) throws SAXException, IOException,
-      ParserConfigurationException {
+  private Document parseXML(URL url)
+      throws SAXException, IOException, ParserConfigurationException {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     DocumentBuilder builder = factory.newDocumentBuilder();
     return builder.parse(url.openStream());
@@ -222,8 +225,8 @@ public class PluginManifestParser {
    * @param pDescriptor
    * @throws MalformedURLException
    */
-  private void parseLibraries(Element pRootElement, PluginDescriptor pDescriptor)
-      throws MalformedURLException {
+  private void parseLibraries(Element pRootElement,
+      PluginDescriptor pDescriptor) throws MalformedURLException {
     NodeList nodelist = pRootElement.getElementsByTagName("runtime");
     if (nodelist.getLength() > 0) {
 

--- a/src/java/org/apache/nutch/plugin/PluginRepository.java
+++ b/src/java/org/apache/nutch/plugin/PluginRepository.java
@@ -21,6 +21,9 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -43,8 +46,13 @@ import org.apache.nutch.util.ObjectCache;
  * descriptor represents all meta information about a plugin. So a plugin
  * instance will be created later when it is required, this allow lazy plugin
  * loading.
+ *
+ * As protocol-plugins need to be registered with the JVM as well, this class
+ * also acts as URLStreamHanderFactory that registers with the JVM and supports
+ * all the new protocols as if they were native. Details how the JVM creates
+ * URLs can be seen in the API documentation for the URL constructor.
  */
-public class PluginRepository {
+public class PluginRepository implements URLStreamHandlerFactory {
   private static final WeakHashMap<String, PluginRepository> CACHE = new WeakHashMap<>();
 
   private boolean auto;
@@ -90,9 +98,12 @@ public class PluginRepository {
     try {
       installExtensions(fRegisteredPlugins);
     } catch (PluginRuntimeException e) {
-      LOG.error(e.toString());
+      LOG.error("Could not install extensions.", e.toString());
       throw new RuntimeException(e.getMessage());
     }
+
+    registerURLStreamHandlerFactory();
+
     displayStatus();
   }
 
@@ -122,7 +133,7 @@ public class PluginRepository {
     for (PluginDescriptor plugin : plugins) {
       for (ExtensionPoint point : plugin.getExtenstionPoints()) {
         String xpId = point.getId();
-        LOG.debug("Adding extension point " + xpId);
+        LOG.debug("Adding extension point {}", xpId);
         fExtensionPoints.put(xpId, point);
       }
     }
@@ -139,9 +150,8 @@ public class PluginRepository {
         String xpId = extension.getTargetPoint();
         ExtensionPoint point = getExtensionPoint(xpId);
         if (point == null) {
-          throw new PluginRuntimeException("Plugin ("
-              + descriptor.getPluginId() + "), " + "extension point: " + xpId
-              + " does not exist.");
+          throw new PluginRuntimeException("Plugin (" + descriptor.getPluginId()
+              + "), " + "extension point: " + xpId + " does not exist.");
         }
         point.addExtension(extension);
       }
@@ -151,8 +161,8 @@ public class PluginRepository {
   private void getPluginCheckedDependencies(PluginDescriptor plugin,
       Map<String, PluginDescriptor> plugins,
       Map<String, PluginDescriptor> dependencies,
-      Map<String, PluginDescriptor> branch) throws MissingDependencyException,
-      CircularDependencyException {
+      Map<String, PluginDescriptor> branch)
+      throws MissingDependencyException, CircularDependencyException {
 
     if (dependencies == null) {
       dependencies = new HashMap<>();
@@ -166,8 +176,8 @@ public class PluginRepository {
     for (String id : plugin.getDependencies()) {
       PluginDescriptor dependency = plugins.get(id);
       if (dependency == null) {
-        throw new MissingDependencyException("Missing dependency " + id
-            + " for plugin " + plugin.getPluginId());
+        throw new MissingDependencyException(
+            "Missing dependency " + id + " for plugin " + plugin.getPluginId());
       }
       if (branch.containsKey(id)) {
         throw new CircularDependencyException("Circular dependency detected "
@@ -198,7 +208,8 @@ public class PluginRepository {
    * @return List
    */
   private List<PluginDescriptor> getDependencyCheckedPlugins(
-      Map<String, PluginDescriptor> filtered, Map<String, PluginDescriptor> all) {
+      Map<String, PluginDescriptor> filtered,
+      Map<String, PluginDescriptor> all) {
     if (filtered == null) {
       return null;
     }
@@ -225,8 +236,8 @@ public class PluginRepository {
    * @return PluginDescriptor[]
    */
   public PluginDescriptor[] getPluginDescriptors() {
-    return fRegisteredPlugins.toArray(new PluginDescriptor[fRegisteredPlugins
-        .size()]);
+    return fRegisteredPlugins
+        .toArray(new PluginDescriptor[fRegisteredPlugins.size()]);
   }
 
   /**
@@ -281,10 +292,10 @@ public class PluginRepository {
       synchronized (pDescriptor) {
         Class<?> pluginClass = getCachedClass(pDescriptor,
             pDescriptor.getPluginClass());
-        Constructor<?> constructor = pluginClass.getConstructor(new Class<?>[] {
-            PluginDescriptor.class, Configuration.class });
-        Plugin plugin = (Plugin) constructor.newInstance(new Object[] {
-            pDescriptor, this.conf });
+        Constructor<?> constructor = pluginClass.getConstructor(
+            new Class<?>[] { PluginDescriptor.class, Configuration.class });
+        Plugin plugin = (Plugin) constructor
+            .newInstance(new Object[] { pDescriptor, this.conf });
         plugin.startUp();
         fActivatedPlugins.put(pDescriptor.getPluginId(), plugin);
         return plugin;
@@ -339,14 +350,14 @@ public class PluginRepository {
   }
 
   private void displayStatus() {
-    LOG.info("Plugin Auto-activation mode: [" + this.auto + "]");
+    LOG.info("Plugin Auto-activation mode: [{}]", this.auto);
     LOG.info("Registered Plugins:");
 
     if ((fRegisteredPlugins == null) || (fRegisteredPlugins.size() == 0)) {
       LOG.info("\tNONE");
     } else {
       for (PluginDescriptor plugin : fRegisteredPlugins) {
-        LOG.info("\t" + plugin.getName() + " (" + plugin.getPluginId() + ")");
+        LOG.info("\t{} ({})", plugin.getName(), plugin.getPluginId());
       }
     }
 
@@ -355,7 +366,7 @@ public class PluginRepository {
       LOG.info("\tNONE");
     } else {
       for (ExtensionPoint ep : fExtensionPoints.values()) {
-        LOG.info("\t" + ep.getName() + " (" + ep.getId() + ")");
+        LOG.info("\t ({})", ep.getName(), ep.getId());
       }
     }
   }
@@ -391,11 +402,11 @@ public class PluginRepository {
       }
 
       if (!includes.matcher(id).matches()) {
-        LOG.debug("not including: " + id);
+        LOG.debug("not including: {}", id);
         continue;
       }
       if (excludes.matcher(id).matches()) {
-        LOG.debug("excluding: " + id);
+        LOG.debug("excluding: {}", id);
         continue;
       }
       map.put(plugin.getPluginId(), plugin);
@@ -434,8 +445,8 @@ public class PluginRepository {
       }
 
       try {
-        ExtensionPoint point = PluginRepository.get(conf).getExtensionPoint(
-            xPointId);
+        ExtensionPoint point = PluginRepository.get(conf)
+            .getExtensionPoint(xPointId);
         if (point == null)
           throw new RuntimeException(xPointId + " not found.");
         Extension[] extensions = point.getExtensions();
@@ -453,9 +464,8 @@ public class PluginRepository {
         for (String orderedFilter : orderOfFilters) {
           Object f = filterMap.get(orderedFilter);
           if (f == null) {
-            LOG.error(clazz.getSimpleName() + " : " + orderedFilter
-                + " declared in configuration property " + orderProperty
-                + " but not found in an active plugin - ignoring.");
+            LOG.error("{} : {} declared in configuration property {} but not found in an active plugin - ignoring.", clazz.getSimpleName(), orderedFilter
+                , orderProperty);
             continue;
           }
           sorted.add(f);
@@ -464,8 +474,8 @@ public class PluginRepository {
         for (int i = 0; i < sorted.size(); i++) {
           filter[i] = sorted.get(i);
           if (LOG.isTraceEnabled()) {
-            LOG.trace(clazz.getSimpleName() + " : filters[" + i + "] = "
-                + filter[i].getClass());
+            LOG.trace("{} : filters[{}] = {}", clazz.getSimpleName() , i,
+                filter[i].getClass());
           }
         }
         objectCache.setObject(clazz.getName(), filter);
@@ -490,8 +500,8 @@ public class PluginRepository {
    */
   public static void main(String[] args) throws Exception {
     if (args.length < 2) {
-      System.err
-          .println("Usage: PluginRepository pluginId className [arg1 arg2 ...]");
+      System.err.println(
+          "Usage: PluginRepository pluginId className [arg1 arg2 ...]");
       return;
     }
     Configuration conf = NutchConfiguration.create();
@@ -508,8 +518,8 @@ public class PluginRepository {
     try {
       clazz = Class.forName(args[1], true, cl);
     } catch (Exception e) {
-      System.err.println("Could not load the class '" + args[1] + ": "
-          + e.getMessage());
+      System.err.println(
+          "Could not load the class '" + args[1] + ": " + e.getMessage());
       return;
     }
     Method m = null;
@@ -523,5 +533,104 @@ public class PluginRepository {
     String[] subargs = new String[args.length - 2];
     System.arraycopy(args, 2, subargs, 0, subargs.length);
     m.invoke(null, new Object[] { subargs });
+  }
+
+  /**
+   * Registers this PluginRepository to be invoked whenever URLs have to be
+   * parsed. This allows to check the registered protocol plugins for uncommon
+   * protocols.
+   */
+  private void registerURLStreamHandlerFactory() {
+    org.apache.nutch.plugin.URLStreamHandlerFactory.getInstance().registerPluginRepository(this);
+  }
+
+  /**
+   * Invoked whenever a java.net.URL needs to be instantiated. Tries to find a
+   * suitable extension and allow it to provide a URLStreamHandler. This is done
+   * by several attempts:
+   * <ul>
+   * <li>Find a protocol plugin that implements the desired protocol. If found,
+   * instantiate it so eventually the plugin can install a URLStreamHandler
+   * through a static hook.</li>
+   * <li>If the plugin specifies a URLStreamHandler in its <tt>plugin.xml</tt>,
+   * return an instance of this URLStreamHandler. Example:
+   * 
+   * <pre>
+   *  ...
+   *  &lt;implementation id="org.apache.nutch.protocol.foo.Foo" class="org.apache.nutch.protocol.foo.Foo"&gt;
+   *      &lt;parameter name="protocolName" value="foo"/&gt;
+   *      &lt;parameter name="urlStreamHandler" value="org.apache.nutch.protocol.foo.Handler"/&gt;
+   *  &lt;/implementation&gt;
+   *  ...
+   * </pre>
+   * 
+   * </li>
+   * <li>if all else fails, return null. This will fallback to the JVM's method
+   * of evaluating the system property <tt>java.protocol.handler.pkgs</tt>.</li>
+   * </ul>
+   * 
+   * @return the URLStreamHandler found, or null.
+   * @see java.net.URL
+   */
+  public URLStreamHandler createURLStreamHandler(String protocol) {
+    LOG.debug("createURLStreamHandler({})", protocol);
+
+    if (fExtensionPoints != null) {
+      ExtensionPoint ep = fExtensionPoints
+          .get("org.apache.nutch.protocol.Protocol");
+      if (ep != null) {
+        Extension[] extensions = ep.getExtensions();
+        for (Extension extension : extensions) {
+          String p = extension.getAttribute("protocolName");
+          LOG.trace("Found {}", p);
+          if (p.equals(protocol)) {
+            LOG.debug("suitable {}", p);
+
+            // instantiate the plugin. This allows it to execute a static hook,
+            // if present. Extensions and PluginInstances are cached already, so we
+            // should not create too many instances
+            Object extinst = null;
+            try {
+              extinst = extension.getExtensionInstance();
+              LOG.debug("found {}", extinst.getClass().getName());
+            } catch (Exception e) {
+              LOG.warn("Could not find {}", extension.getId(), e);
+            }
+
+            // return the handler here, if possible
+            String handlerClass = extension.getAttribute("urlStreamHandler");
+            LOG.debug("urlStreamHandler={}", handlerClass);
+            if (handlerClass != null) {
+              // instantiate the handler and return it
+              ClassLoader cl = this.getClass().getClassLoader(); // the nutch
+                                                                 // classloader
+              LOG.trace("Using nutch classloader {}", cl);
+              if (extinst != null) {
+                cl = extinst.getClass().getClassLoader(); // the extension's
+                                                          // classloader
+                LOG.trace("Using extension classloader {}", cl);
+              }
+
+              try {
+                Class clazz = cl.loadClass(handlerClass);
+                return (URLStreamHandler) clazz.newInstance();
+              } catch (Exception e) {
+                LOG.error("Could not instantiate protocol {} handler class {} defined by extension {}", protocol, handlerClass, extension.getId(), e);
+                return null;
+              }
+            }
+
+            LOG.debug(
+                "suitable protocol extension found that did not declare a handler");
+            return null;
+          }
+        }
+        LOG.debug("No suitable protocol extensions registered");
+      } else {
+        LOG.debug("No protocol extensions registered?");
+      }
+    }
+
+    return null;
   }
 }

--- a/src/java/org/apache/nutch/plugin/URLStreamHandlerFactory.java
+++ b/src/java/org/apache/nutch/plugin/URLStreamHandlerFactory.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nutch.plugin;
+
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.net.URLStreamHandler;
+import java.util.ArrayList;
+
+import org.mortbay.log.Log;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This URLStreamHandlerFactory knows about all the plugins
+ * in use and thus can create the correct URLStreamHandler
+ * even if it comes from a plugin classpath.
+ * As the JVM allows only one instance of URLStreamHandlerFactory
+ * to be registered, this class implements a singleton pattern.
+ * @author Hiran Chaudhuri
+ *
+ */
+public class URLStreamHandlerFactory
+    implements java.net.URLStreamHandlerFactory {
+  
+  protected static final Logger LOG = LoggerFactory
+      .getLogger(URLStreamHandlerFactory.class);
+  
+  /** The singleton instance. */
+  private static URLStreamHandlerFactory instance;
+  
+  /** Here we register all PluginRepositories.
+   * In this class we do not know why several instances of PluginRepository
+   * are kept, nor do we know how long they will be used. To prevent
+   * a memory leak, this class must not keep references to PluginRepository
+   * but use WeakReference which allows PluginRepository to still be
+   * garbage collected. The prize is we need to clean the list for
+   * outdated references which is done in the {@link removeInvalidRefs} method.  
+   */
+  private ArrayList<WeakReference<PluginRepository>> prs;
+  
+  static {
+    instance = new URLStreamHandlerFactory();
+    URL.setURLStreamHandlerFactory(instance);
+    LOG.info("Registered URLStreamHandlerFactory with the JVM.");
+  }
+  
+  private URLStreamHandlerFactory() {
+    LOG.debug("URLStreamHandlerFactory()");
+    prs = new ArrayList<>();
+  }
+
+  /** Return the singleton instance of this class. */
+  public static URLStreamHandlerFactory getInstance() {
+    LOG.debug("getInstance()");
+    return instance;
+  }
+  
+  /** Use this method once a new PluginRepository was created to register it.
+   * 
+   * @param pr The PluginRepository to be registered.
+   */
+  public void registerPluginRepository(PluginRepository pr) {
+    LOG.debug("registerPluginRepository(...)");
+    prs.add(new WeakReference<PluginRepository>(pr));
+    
+    removeInvalidRefs();
+  }
+
+  @Override
+  public URLStreamHandler createURLStreamHandler(String protocol) {
+    LOG.debug("createURLStreamHandler({})", protocol);
+    
+    removeInvalidRefs();
+    
+    // find the 'correct' PluginRepository. For now we simply take the first.
+    // then ask it to return the URLStreamHandler
+
+    for(WeakReference<PluginRepository> ref: prs) {
+      PluginRepository pr = ref.get();
+      if(pr != null) {
+        // found PluginRepository. Let's get the URLStreamHandler...
+        return pr.createURLStreamHandler(protocol);
+      }
+    }
+    return null;
+  }
+
+  /** Maintains the list of PluginRepositories by
+   * removing the references whose referents have been
+   * garbage collected meanwhile.
+   */
+  private void removeInvalidRefs() {
+    LOG.debug("removeInvalidRefs()");
+    ArrayList<WeakReference<PluginRepository>> copy = new ArrayList<>(prs);
+    for(WeakReference<PluginRepository> ref: copy) {
+      if(ref.get() == null) {
+        prs.remove(ref);
+      }
+    }
+    LOG.debug("removed {} references, remaining {}", copy.size()-prs.size(), prs.size());
+  }
+}

--- a/src/java/org/apache/nutch/plugin/URLStreamHandlerFactory.java
+++ b/src/java/org/apache/nutch/plugin/URLStreamHandlerFactory.java
@@ -21,7 +21,6 @@ import java.net.URL;
 import java.net.URLStreamHandler;
 import java.util.ArrayList;
 
-import org.mortbay.log.Log;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,24 +48,25 @@ public class URLStreamHandlerFactory
    * a memory leak, this class must not keep references to PluginRepository
    * but use WeakReference which allows PluginRepository to still be
    * garbage collected. The prize is we need to clean the list for
-   * outdated references which is done in the {@link removeInvalidRefs} method.  
+   * outdated references which is done in the {@link #removeInvalidRefs()} method.
    */
   private ArrayList<WeakReference<PluginRepository>> prs;
   
   static {
     instance = new URLStreamHandlerFactory();
     URL.setURLStreamHandlerFactory(instance);
-    LOG.info("Registered URLStreamHandlerFactory with the JVM.");
+    LOG.debug("Registered URLStreamHandlerFactory with the JVM.");
   }
   
   private URLStreamHandlerFactory() {
-    LOG.debug("URLStreamHandlerFactory()");
     prs = new ArrayList<>();
   }
 
-  /** Return the singleton instance of this class. */
+  /** 
+   * Get the singleton instance of this class.
+   * @return a {@link org.apache.nutch.plugin.URLStreamHandlerFactory} instance 
+   */
   public static URLStreamHandlerFactory getInstance() {
-    LOG.debug("getInstance()");
     return instance;
   }
   
@@ -75,7 +75,6 @@ public class URLStreamHandlerFactory
    * @param pr The PluginRepository to be registered.
    */
   public void registerPluginRepository(PluginRepository pr) {
-    LOG.debug("registerPluginRepository(...)");
     prs.add(new WeakReference<PluginRepository>(pr));
     
     removeInvalidRefs();
@@ -83,13 +82,12 @@ public class URLStreamHandlerFactory
 
   @Override
   public URLStreamHandler createURLStreamHandler(String protocol) {
-    LOG.debug("createURLStreamHandler({})", protocol);
+    LOG.debug("Creating URLStreamHandler for protocol: {}", protocol);
     
     removeInvalidRefs();
     
     // find the 'correct' PluginRepository. For now we simply take the first.
     // then ask it to return the URLStreamHandler
-
     for(WeakReference<PluginRepository> ref: prs) {
       PluginRepository pr = ref.get();
       if(pr != null) {
@@ -112,6 +110,6 @@ public class URLStreamHandlerFactory
         prs.remove(ref);
       }
     }
-    LOG.debug("removed {} references, remaining {}", copy.size()-prs.size(), prs.size());
+    LOG.debug("Removed the following invalid references: '{}' Remaining: '{}'", copy.size()-prs.size(), prs.size());
   }
 }

--- a/src/java/org/apache/nutch/util/CrawlCompletionStats.java
+++ b/src/java/org/apache/nutch/util/CrawlCompletionStats.java
@@ -16,40 +16,37 @@
  */
 package org.apache.nutch.util;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.SimpleDateFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.MissingOptionException;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Options;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
-import org.apache.hadoop.mapreduce.Mapper;
-import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.nutch.crawl.CrawlDatum;
-import org.apache.nutch.util.NutchConfiguration;
-import org.apache.nutch.util.TimingUtil;
-import org.apache.nutch.util.URLUtil;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.GnuParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.OptionBuilder;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.MissingOptionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extracts some simple crawl completion stats from the crawldb
@@ -204,7 +201,14 @@ public class CrawlCompletionStats extends Configured implements Tool {
     public void map(Text urlText, CrawlDatum datum, Context context)
         throws IOException, InterruptedException {
 
-      URL url = new URL(urlText.toString());
+      URL url;
+      try {
+        url = new URL(urlText.toString());
+      } catch (MalformedURLException e) {
+        LOG.error("Failed to get host or domain from URL {}: {}",
+            urlText, e.getMessage());
+        return;
+      }
       String out = "";
       switch (mode) {
         case MODE_HOST:

--- a/src/java/org/apache/nutch/util/NutchJob.java
+++ b/src/java/org/apache/nutch/util/NutchJob.java
@@ -19,12 +19,13 @@ package org.apache.nutch.util;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.nutch.plugin.PluginRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** A {@link Job} for Nutch jobs. */
 public class NutchJob extends Job {
@@ -35,6 +36,11 @@ public class NutchJob extends Job {
   @SuppressWarnings("deprecation")
   public NutchJob(Configuration conf, String jobName) throws IOException {
     super(conf, jobName);
+    if (conf != null) {
+      // initialize plugins early to register URL stream handlers to support
+      // custom protocol implementations
+      PluginRepository.get(conf);
+    }
   }
 
   public static Job getInstance(Configuration conf) throws IOException {

--- a/src/java/org/apache/nutch/util/NutchTool.java
+++ b/src/java/org/apache/nutch/util/NutchTool.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.nutch.metadata.Nutch;
+import org.apache.nutch.plugin.PluginRepository;
 
 public abstract class NutchTool extends Configured {
 
@@ -52,6 +53,14 @@ public abstract class NutchTool extends Configured {
 
   public NutchTool(){
     super(null);
+  }
+  
+  @Override
+  public void setConf(Configuration conf) {
+    super.setConf(conf);
+    if(conf != null) {
+      PluginRepository.get(conf);
+    }
   }
 
   /**

--- a/src/java/org/apache/nutch/util/SitemapProcessor.java
+++ b/src/java/org/apache/nutch/util/SitemapProcessor.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.mapreduce.lib.output.MapFileOutputFormat;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
-
 import org.apache.nutch.crawl.CrawlDatum;
 import org.apache.nutch.hostdb.HostDatum;
 import org.apache.nutch.net.URLFilters;
@@ -51,7 +50,6 @@ import org.apache.nutch.protocol.Protocol;
 import org.apache.nutch.protocol.ProtocolFactory;
 import org.apache.nutch.protocol.ProtocolOutput;
 import org.apache.nutch.protocol.ProtocolStatus;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,13 +80,11 @@ import crawlercommons.sitemaps.SiteMapURL;
  * the sitemaps into the CrawlDb.</li>
  * </ol>
  *
- * <p>
- * For more details see:
- * https://cwiki.apache.org/confluence/display/NUTCH/SitemapFeature
- * </p>
+ * @see
+ * <a href="https://cwiki.apache.org/confluence/display/NUTCH/SitemapFeature">SitemapFeature</a>
  */
 public class SitemapProcessor extends Configured implements Tool {
-  public static final Logger LOG = LoggerFactory.getLogger(SitemapProcessor.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SitemapProcessor.class);
   public static final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
   public static final String CURRENT_NAME = "current";

--- a/src/java/org/apache/nutch/util/domain/DomainStatistics.java
+++ b/src/java/org/apache/nutch/util/domain/DomainStatistics.java
@@ -16,31 +16,32 @@
  */
 package org.apache.nutch.util.domain;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.SimpleDateFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
-import org.apache.hadoop.mapreduce.Mapper;
-import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.nutch.crawl.CrawlDatum;
 import org.apache.nutch.util.NutchConfiguration;
 import org.apache.nutch.util.TimingUtil;
 import org.apache.nutch.util.URLUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extracts some very basic statistics about domains from the crawldb
@@ -175,7 +176,14 @@ public class DomainStatistics extends Configured implements Tool {
           || datum.getStatus() == CrawlDatum.STATUS_DB_NOTMODIFIED) {
 
         try {
-          URL url = new URL(urlText.toString());
+          URL url;
+          try {
+            url = new URL(urlText.toString());
+          } catch (MalformedURLException e) {
+            LOG.error("Failed to get host or domain from URL {}: {}",
+                urlText, e.getMessage());
+            return;
+          }
           String out = null;
           switch (mode) {
           case MODE_HOST:

--- a/src/plugin/any23/src/java/org/apache/nutch/any23/Any23IndexingFilter.java
+++ b/src/plugin/any23/src/java/org/apache/nutch/any23/Any23IndexingFilter.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 public class Any23IndexingFilter implements IndexingFilter {
 
   /** Logging instance */
-  public static final Logger LOG = LoggerFactory.getLogger(Any23IndexingFilter.class);
+  private static final Logger LOG = LoggerFactory.getLogger(Any23IndexingFilter.class);
   
   public static final String STRUCTURED_DATA = "structured_data";
 

--- a/src/plugin/any23/src/java/org/apache/nutch/any23/Any23ParseFilter.java
+++ b/src/plugin/any23/src/java/org/apache/nutch/any23/Any23ParseFilter.java
@@ -58,7 +58,7 @@ import org.w3c.dom.DocumentFragment;
 public class Any23ParseFilter implements HtmlParseFilter {
 
   /** Logging instance */
-  public static final Logger LOG = LoggerFactory.getLogger(Any23ParseFilter.class);
+  private static final Logger LOG = LoggerFactory.getLogger(Any23ParseFilter.class);
 
   private Configuration conf = null;
 

--- a/src/plugin/build.xml
+++ b/src/plugin/build.xml
@@ -71,6 +71,7 @@
     <ant dir="parsefilter-naivebayes" target="deploy"/>
     <ant dir="parsefilter-regex" target="deploy"/>
     <ant dir="protocol-file" target="deploy"/>
+    <ant dir="protocol-foo" target="deploy" />
     <ant dir="protocol-ftp" target="deploy"/>
     <ant dir="protocol-htmlunit" target="deploy" />
     <ant dir="protocol-http" target="deploy"/>
@@ -219,6 +220,7 @@
     <ant dir="parsefilter-naivebayes" target="clean" />
     <ant dir="parsefilter-regex" target="clean"/>
     <ant dir="protocol-file" target="clean"/>
+    <ant dir="protocol-foo" target="clean" />
     <ant dir="protocol-ftp" target="clean"/>
     <ant dir="protocol-htmlunit" target="clean" />
     <ant dir="protocol-http" target="clean"/>

--- a/src/plugin/indexer-csv/src/java/org/apache/nutch/indexwriter/csv/CSVIndexWriter.java
+++ b/src/plugin/indexer-csv/src/java/org/apache/nutch/indexwriter/csv/CSVIndexWriter.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CSVIndexWriter implements IndexWriter {
 
-  public static final Logger LOG = LoggerFactory
+  private static final Logger LOG = LoggerFactory
       .getLogger(CSVIndexWriter.class);
 
   private Configuration config;

--- a/src/plugin/indexer-rabbit/src/java/org/apache/nutch/indexwriter/rabbit/RabbitIndexWriter.java
+++ b/src/plugin/indexer-rabbit/src/java/org/apache/nutch/indexwriter/rabbit/RabbitIndexWriter.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
 
 public class RabbitIndexWriter implements IndexWriter {
 
-  public static final Logger LOG = LoggerFactory
+  private static final Logger LOG = LoggerFactory
       .getLogger(RabbitIndexWriter.class);
 
   private String uri;

--- a/src/plugin/protocol-foo/build.xml
+++ b/src/plugin/protocol-foo/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project name="protocol-foo" default="jar-core">
+
+  <import file="../build-plugin.xml"/>
+
+</project>

--- a/src/plugin/protocol-foo/ivy.xml
+++ b/src/plugin/protocol-foo/ivy.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" ?>
+
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<ivy-module version="1.0">
+  <info organisation="org.apache.nutch" module="${ant.project.name}">
+    <license name="Apache 2.0"/>
+    <ivyauthor name="Apache Nutch Team" url="http://nutch.apache.org"/>
+    <description>
+        Apache Nutch
+    </description>
+  </info>
+
+  <configurations>
+    <include file="../../..//ivy/ivy-configurations.xml"/>
+  </configurations>
+
+  <publications>
+    <!--get the artifact from our module name-->
+    <artifact conf="master"/>
+  </publications>
+
+  <dependencies>
+  </dependencies>
+  
+</ivy-module>

--- a/src/plugin/protocol-foo/plugin.xml
+++ b/src/plugin/protocol-foo/plugin.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<plugin
+   id="protocol-foo"
+   name="Foo Protocol Example Plug-in"
+   version="1.0.0"
+   provider-name="Hiran Chaudhuri">
+
+   <runtime>
+      <library name="protocol-foo.jar">
+         <export name="*"/>
+      </library>
+   </runtime>
+
+   <requires>
+      <import plugin="nutch-extensionpoints"/>
+   </requires>
+
+   <extension id="org.apache.nutch.protocol.foo"
+              name="FooProtocol"
+              point="org.apache.nutch.protocol.Protocol">
+
+      <implementation id="org.apache.nutch.protocol.foo.Foo"
+                      class="org.apache.nutch.protocol.foo.Foo">
+        <parameter name="protocolName" value="foo"/>
+		<parameter name="urlStreamHandler" value="org.apache.nutch.protocol.foo.Handler"/>
+      </implementation>
+      
+   </extension>
+
+</plugin>

--- a/src/plugin/protocol-foo/src/java/org/apache/nutch/protocol/foo/Foo.java
+++ b/src/plugin/protocol-foo/src/java/org/apache/nutch/protocol/foo/Foo.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nutch.protocol.foo;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.apache.nutch.crawl.CrawlDatum;
+import org.apache.nutch.metadata.Metadata;
+import org.apache.nutch.net.protocols.HttpDateFormat;
+import org.apache.nutch.plugin.URLStreamHandlerFactory;
+import org.apache.nutch.protocol.Content;
+import org.apache.nutch.protocol.Protocol;
+import org.apache.nutch.protocol.ProtocolOutput;
+import org.apache.nutch.protocol.ProtocolStatus;
+import org.apache.nutch.protocol.RobotRulesParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import crawlercommons.robots.BaseRobotRules;
+
+public class Foo implements Protocol {
+  protected static final Logger LOG = LoggerFactory.getLogger(Foo.class);
+
+  private Configuration conf;
+
+  @Override
+  public Configuration getConf() {
+    LOG.debug("getConf()");
+    return conf;
+  }
+
+  @Override
+  public void setConf(Configuration conf) {
+    LOG.debug("setConf(...)");
+    this.conf = conf;
+  }
+
+  /**
+   * This is a dummy implementation only. So what we will do is return this
+   * structure:
+   * 
+   * <pre>
+   * foo://example.com - will contain one directory and one file
+   * foo://example.com/a - directory, will contain two files
+   * foo://example.com/a/aa.txt - text file
+   * foo://example.com/a/ab.txt - text file
+   * foo://example.com/a.txt - text file
+   * </pre>
+   */
+  @Override
+  public ProtocolOutput getProtocolOutput(Text url, CrawlDatum datum) {
+    LOG.debug("getProtocolOutput({}, {})", url, datum);
+
+    try {
+      String urlstr = String.valueOf(url);
+      URL u = new URL(urlstr);
+      URL base = new URL(u, ".");
+      byte[] bytes = new byte[0];
+      String contentType = "foo/something";
+      ProtocolStatus status = ProtocolStatus.STATUS_GONE;
+
+      switch (urlstr) {
+      case "foo://example.com":
+      case "foo://example.com/": {
+        String time = HttpDateFormat.toString(System.currentTimeMillis());
+        contentType = "text/html";
+        StringBuffer sb = new StringBuffer();
+        sb.append("<html><head>");
+        sb.append("<title>Index of /</title></head>\n");
+        sb.append("<body><h1>Index of /</h1><pre>\n");
+        sb.append("<a href='a/" + "'>a/</a>\t"+ time + "\t-\n"); // add directory
+        sb.append("<a href='a.txt'>a.txt</a>\t" + time + "\t" + 0 + "\n"); // add file
+        sb.append("</pre></html></body>");
+        bytes = sb.toString().getBytes();
+        status = ProtocolStatus.STATUS_SUCCESS;
+        break;
+      }
+      case "foo://example.com/a/": {
+        String time = HttpDateFormat.toString(System.currentTimeMillis());
+        contentType = "text/html";
+        StringBuffer sb = new StringBuffer();
+        sb.append("<html><head>");
+        sb.append("<title>Index of /a/</title></head>\n");
+        sb.append("<body><h1>Index of /a/</h1><pre>\n");
+        sb.append("<a href='aa.txt'>aa.txt</a>\t" + time + "\t" + 0 + "\n"); // add file
+        sb.append("<a href='ab.txt'>ab.txt</a>\t" + time + "\t" + 0 + "\n"); // add file
+        sb.append("</pre></html></body>");
+        bytes = sb.toString().getBytes();
+        status = ProtocolStatus.STATUS_SUCCESS;
+        break;
+      }
+      case "foo://example.com/a.txt":
+      case "foo://example.com/a/aa.txt":
+      case "foo://example.com/a/ab.txt": {
+        contentType = "text/plain";
+        bytes = "In publishing and graphic design, lorem ipsum is a filler text or greeking commonly used to demonstrate the textual elements of a graphic document or visual presentation. Replacing meaningful content with placeholder text allows designers to design the form of the content before the content itself has been produced.".getBytes();
+        status = ProtocolStatus.STATUS_SUCCESS;
+        break;
+      }
+      default:
+        LOG.warn("Unknown url '{}'. This dummy implementation only supports 'foo://example.com'", url);
+        // all our default values are set for URLs that do not exist.
+        break;
+      }
+
+      Metadata metadata = new Metadata();
+      Content content = new Content(String.valueOf(url), String.valueOf(base),
+          bytes, contentType, metadata, getConf());
+
+      return new ProtocolOutput(content, status);
+    } catch (MalformedURLException mue) {
+      LOG.error("Could not retrieve {}", url);
+      LOG.error("", mue);
+      // clain STATUS_GONE to tell nutch to never ever re-request this URL
+      return new ProtocolOutput(null, ProtocolStatus.STATUS_GONE);
+    }
+  }
+
+  @Override
+  public BaseRobotRules getRobotRules(Text url, CrawlDatum datum,
+      List<Content> robotsTxtContent) {
+    LOG.debug(
+        "getRobotRules({}, {}, {})", url, datum, robotsTxtContent);
+    return RobotRulesParser.EMPTY_RULES;
+  }
+}

--- a/src/plugin/protocol-foo/src/java/org/apache/nutch/protocol/foo/Foo.java
+++ b/src/plugin/protocol-foo/src/java/org/apache/nutch/protocol/foo/Foo.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.io.Text;
 import org.apache.nutch.crawl.CrawlDatum;
 import org.apache.nutch.metadata.Metadata;
 import org.apache.nutch.net.protocols.HttpDateFormat;
-import org.apache.nutch.plugin.URLStreamHandlerFactory;
 import org.apache.nutch.protocol.Content;
 import org.apache.nutch.protocol.Protocol;
 import org.apache.nutch.protocol.ProtocolOutput;
@@ -44,12 +43,11 @@ public class Foo implements Protocol {
   @Override
   public Configuration getConf() {
     LOG.debug("getConf()");
-    return conf;
+    return this.conf;
   }
 
   @Override
   public void setConf(Configuration conf) {
-    LOG.debug("setConf(...)");
     this.conf = conf;
   }
 
@@ -129,7 +127,7 @@ public class Foo implements Protocol {
     } catch (MalformedURLException mue) {
       LOG.error("Could not retrieve {}", url);
       LOG.error("", mue);
-      // clain STATUS_GONE to tell nutch to never ever re-request this URL
+      // claim STATUS_GONE to tell nutch to never ever re-request this URL
       return new ProtocolOutput(null, ProtocolStatus.STATUS_GONE);
     }
   }
@@ -137,8 +135,7 @@ public class Foo implements Protocol {
   @Override
   public BaseRobotRules getRobotRules(Text url, CrawlDatum datum,
       List<Content> robotsTxtContent) {
-    LOG.debug(
-        "getRobotRules({}, {}, {})", url, datum, robotsTxtContent);
+    LOG.debug("getRobotRules({}, {}, {})", url, datum, robotsTxtContent);
     return RobotRulesParser.EMPTY_RULES;
   }
 }

--- a/src/plugin/protocol-foo/src/java/org/apache/nutch/protocol/foo/Handler.java
+++ b/src/plugin/protocol-foo/src/java/org/apache/nutch/protocol/foo/Handler.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nutch.protocol.foo;
+
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+
+public class Handler extends URLStreamHandler {
+
+  protected URLConnection openConnection(URL u) {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+}


### PR DESCRIPTION
This issue addresses [NUTCH-2429](https://issues.apache.org/jira/browse/NUTCH-2429). Some notes
* supersedes #222 by updating everything which was done there (excellent work @HiranChaudhuri )
* incorporates @sebastian-nagel work a la  [/sebastian-nagel/nutch/tree/NUTCH-2429](https://github.com/sebastian-nagel/nutch/commit/e589f05ef42486892427d347ecd10abfa9e380d7)
* organizes the imports for each Class touched in this pull request
* addresses a couple of rogue Classes which declared `public static final Logger` --> `private static final Logger`
* adds `protocol-foo` to the `ant eclipse` target so it is included in the Eclipse development environment
* formats code where necessary using the Nutch eclipse formatting
* addresses improvements to Javadoc where relevant

I've run this on trace logging to verify that the handler is behaving as expected. I was able to index content from both `https` and `foo` protocols (~50 seeds >> 12K URLs when 'complete')... so things seem to be running nicely.

Of note, I have also marked [PluginRepository#finalize()](https://ci-builds.apache.org/job/Nutch/job/Nutch-trunk/javadoc/org/apache/nutch/plugin/PluginRepository.html#finalize()) as deprecated and slated for removal and linked to [JEP 421: Deprecate Finalization for Removal](https://openjdk.java.net/jeps/421). We can address this in another ticket. 