### PR TITLE
NUTCH-2929 Fetcher: start threads slowly to avoid that resources are temporarily exhausted

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -976,6 +976,15 @@
 </property>
 
 <property>
+  <name>fetcher.threads.start.delay</name>
+  <value>10</value>
+  <description>Delay in milliseconds between starting Fetcher threads
+  to avoid that all threads simultaneously fetch the first pages and
+  cause that DNS or other resources are temporarily exhausted.
+  </description>
+</property>
+
+<property>
   <name>fetcher.threads.per.queue</name>
   <value>1</value>
   <description>This number is the maximum number of threads that

--- a/src/java/org/apache/nutch/fetcher/Fetcher.java
+++ b/src/java/org/apache/nutch/fetcher/Fetcher.java
@@ -223,7 +223,13 @@ public class Fetcher extends NutchTool implements Tool {
           feeder.setTimeLimit(timelimit);
         feeder.start();
 
+        int startDelay = conf.getInt("fetcher.threads.start.delay", 10);
         for (int i = 0; i < threadCount; i++) { // spawn threads
+          if (startDelay > 0 && i > 0) {
+            // short delay to avoid that DNS or other resources are temporarily
+            // exhausted by all threads fetching simultaneously the first pages
+            Thread.sleep(startDelay);
+          }
           FetcherThread t = new FetcherThread(conf, getActiveThreads(),
               fetchQueues, feeder, spinWaiting, lastRequestStart, innerContext,
               errors, segmentName, parsing, storingContent, pages, bytes);


### PR DESCRIPTION
Sleep for a configurable delay (fetcher.threads.start.delay) before starting the next Fetcher thread to avoid that resources (DNS, Tika XML parser pools) are temporarily exhausted when Fetcher threads fetch the first pages simultaneously

The default delay (10 milliseconds) practically does not impact the behavior/performance of Fetcher - 100 threads are started per second. By choosing a longer delay (500 milliseconds) all Tika warnings about the SAXParser pool size disappeared.