### PR TITLE
NUTCH-2573 Suspend crawling if robots.txt fails to fetch with 5xx status

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -130,6 +130,32 @@
 </property>
 
 <property>
+  <name>http.robots.503.defer.visits</name>
+  <value>true</value>
+  <description>Temporarily suspend fetching from a host if the
+  robots.txt response is HTTP 503 or any other 5xx server error. See
+  also http.robots.503.defer.visits.delay and
+  http.robots.503.defer.visits.retries</description>
+</property>
+
+<property>
+  <name>http.robots.503.defer.visits.delay</name>
+  <value>300000</value>
+  <description>Time in milliseconds to suspend crawling a host if the
+  robots.txt response is HTTP 5xx - see
+  http.robots.503.defer.visits.</description>
+</property>
+
+<property>
+  <name>http.robots.503.defer.visits.retries</name>
+  <value>3</value>
+  <description>Number of retries crawling a host if the robots.txt
+  response is HTTP 5xx - see http.robots.503.defer.visits. After n
+  retries the host queue is dropped for this segment/cycle.
+  </description>
+</property>
+
+<property>
   <name>http.agent.description</name>
   <value></value>
   <description>Further description of our bot- this text is used in

--- a/src/java/org/apache/nutch/fetcher/FetchItemQueues.java
+++ b/src/java/org/apache/nutch/fetcher/FetchItemQueues.java
@@ -195,7 +195,11 @@ public class FetchItemQueues {
     return null;
   }
 
-  public boolean timelimitReached() {
+  /**
+   * @return true if the fetcher timelimit is defined and has been exceeded
+   *         ({@code fetcher.timelimit.mins} minutes after fetching started)
+   */
+  public boolean timelimitExceeded() {
     return timelimit != -1 && System.currentTimeMillis() >= timelimit;
   }
 
@@ -203,7 +207,7 @@ public class FetchItemQueues {
   public synchronized int checkTimelimit() {
     int count = 0;
 
-    if (timelimitReached()) {
+    if (timelimitExceeded()) {
       // emptying the queues
       count = emptyQueues();
 
@@ -283,6 +287,7 @@ public class FetchItemQueues {
     return 0;
   }
 
+  /** See {@link #checkExceptionThreshold(String, int, long)} */
   public int checkExceptionThreshold(String queueid) {
     return checkExceptionThreshold(queueid, this.maxExceptionsPerQueue, -1);
   }

--- a/src/java/org/apache/nutch/fetcher/FetchItemQueues.java
+++ b/src/java/org/apache/nutch/fetcher/FetchItemQueues.java
@@ -287,7 +287,16 @@ public class FetchItemQueues {
     return 0;
   }
 
-  /** See {@link #checkExceptionThreshold(String, int, long)} */
+  /**
+   * Increment the exception counter of a queue in case of an exception e.g.
+   * timeout; when higher than a given threshold simply empty the queue.
+   * 
+   * @see #checkExceptionThreshold(String, int, long)
+   * 
+   * @param queueid
+   *          queue identifier to locate and check
+   * @return number of purged items
+   */
   public int checkExceptionThreshold(String queueid) {
     return checkExceptionThreshold(queueid, this.maxExceptionsPerQueue, -1);
   }

--- a/src/java/org/apache/nutch/fetcher/FetchItemQueues.java
+++ b/src/java/org/apache/nutch/fetcher/FetchItemQueues.java
@@ -195,11 +195,15 @@ public class FetchItemQueues {
     return null;
   }
 
+  public boolean timelimitReached() {
+    return timelimit != -1 && System.currentTimeMillis() >= timelimit;
+  }
+
   // called only once the feeder has stopped
   public synchronized int checkTimelimit() {
     int count = 0;
 
-    if (System.currentTimeMillis() >= timelimit && timelimit != -1) {
+    if (timelimitReached()) {
       // emptying the queues
       count = emptyQueues();
 
@@ -209,6 +213,7 @@ public class FetchItemQueues {
       if (totalSize.get() != 0 && queues.size() == 0)
         totalSize.set(0);
     }
+
     return count;
   }
 
@@ -220,11 +225,9 @@ public class FetchItemQueues {
       FetchItemQueue fiq = queues.get(id);
       if (fiq.getQueueSize() == 0)
         continue;
-      LOG.info("* queue: " + id + " >> dropping! ");
+      LOG.info("* queue: {} >> dropping!", id);
       int deleted = fiq.emptyQueue();
-      for (int i = 0; i < deleted; i++) {
-        totalSize.decrementAndGet();
-      }
+      totalSize.addAndGet(-deleted);
       count += deleted;
     }
 
@@ -235,32 +238,53 @@ public class FetchItemQueues {
    * Increment the exception counter of a queue in case of an exception e.g.
    * timeout; when higher than a given threshold simply empty the queue.
    * 
-   * @param queueid a queue identifier to locate and check 
+   * The next fetch is delayed if specified by the param {@code delay} or
+   * configured by the property {@code fetcher.exceptions.per.queue.delay}.
+   * 
+   * @param queueid
+   *          a queue identifier to locate and check
+   * @param maxExceptions
+   *          custom-defined number of max. exceptions - if negative the value
+   *          of the property {@code fetcher.max.exceptions.per.queue} is used.
+   * @param delay
+   *          a custom-defined time span in milliseconds to delay the next fetch
+   *          in addition to the delay defined for the given queue. If a
+   *          negative value is passed the delay is chosen by
+   *          {@code fetcher.exceptions.per.queue.delay}
+   * 
    * @return number of purged items
    */
-  public synchronized int checkExceptionThreshold(String queueid) {
+  public synchronized int checkExceptionThreshold(String queueid,
+      int maxExceptions, long delay) {
     FetchItemQueue fiq = queues.get(queueid);
     if (fiq == null) {
       return 0;
     }
     int excCount = fiq.incrementExceptionCounter();
+    if (delay > 0) {
+      fiq.nextFetchTime.getAndAdd(delay);
+      LOG.info("* queue: {} >> delayed next fetch by {} ms", queueid, delay);
+    }
     if (fiq.getQueueSize() == 0) {
       return 0;
     }
-    if (maxExceptionsPerQueue != -1 && excCount >= maxExceptionsPerQueue) {
+    if (maxExceptions!= -1 && excCount >= maxExceptions) {
       // too many exceptions for items in this queue - purge it
       int deleted = fiq.emptyQueue();
-      LOG.info("* queue: " + queueid + " >> removed " + deleted
-          + " URLs from queue because " + excCount + " exceptions occurred");
-      for (int i = 0; i < deleted; i++) {
-        totalSize.decrementAndGet();
-      }
+      LOG.info(
+          "* queue: {} >> removed {} URLs from queue because {} exceptions occurred",
+          queueid, deleted, excCount);
+      totalSize.getAndAdd(-deleted);
       // keep queue IDs to ensure that these queues aren't created and filled
       // again, see addFetchItem(FetchItem)
       queuesMaxExceptions.add(queueid);
       return deleted;
     }
     return 0;
+  }
+
+  public int checkExceptionThreshold(String queueid) {
+    return checkExceptionThreshold(queueid, this.maxExceptionsPerQueue, -1);
   }
 
   /**

--- a/src/java/org/apache/nutch/fetcher/FetcherThread.java
+++ b/src/java/org/apache/nutch/fetcher/FetcherThread.java
@@ -325,7 +325,7 @@ public class FetcherThread extends Thread {
             if (rules.isDeferVisits()) {
               LOG.info("Defer visits for queue {} : {}", fit.queueID, fit.url);
               // retry the fetch item
-              if (fetchQueues.timelimitReached()) {
+              if (fetchQueues.timelimitExceeded()) {
                 fetchQueues.finishFetchItem(fit, true);
               } else {
                 fetchQueues.addFetchItem(fit);
@@ -335,8 +335,9 @@ public class FetcherThread extends Thread {
                   fit.getQueueID(), this.robotsDeferVisitsRetries + 1,
                   this.robotsDeferVisitsDelay);
               if (killedURLs != 0) {
-                context.getCounter("FetcherStatus",
-                    "DroppedRobotsTxtDeferVisits").increment(killedURLs);
+                context
+                    .getCounter("FetcherStatus", "robots_defer_visits_dropped")
+                    .increment(killedURLs);
               }
               continue;
             }
@@ -628,7 +629,7 @@ public class FetcherThread extends Thread {
       LOG.debug(" - ignoring redirect from {} to {} as duplicate", fit.url,
           redirUrl);
       return null;
-    } else if (fetchQueues.timelimitReached()) {
+    } else if (fetchQueues.timelimitExceeded()) {
       redirecting = false;
       context.getCounter("FetcherStatus", "hitByTimeLimit").increment(1);
       LOG.debug(" - ignoring redirect from {} to {} - timelimit reached",
@@ -817,7 +818,7 @@ public class FetcherThread extends Thread {
 
           // Only process depth N outlinks
           if (maxOutlinkDepth > 0 && outlinkDepth < maxOutlinkDepth
-              && !fetchQueues.timelimitReached()) {
+              && !fetchQueues.timelimitExceeded()) {
             FetchItem ft = FetchItem.create(url, null, queueMode);
             FetchItemQueue queue = fetchQueues.getFetchItemQueue(ft.queueID);
             queue.alreadyFetched.add(url.toString().hashCode());

--- a/src/java/org/apache/nutch/protocol/RobotRulesParser.java
+++ b/src/java/org/apache/nutch/protocol/RobotRulesParser.java
@@ -77,6 +77,19 @@ public abstract class RobotRulesParser implements Tool {
   public static BaseRobotRules FORBID_ALL_RULES = new SimpleRobotRules(
       RobotRulesMode.ALLOW_NONE);
 
+  /**
+   * A {@link BaseRobotRules} object appropriate for use when the
+   * {@code robots.txt} file failed to fetch with a 503 &quot;Internal Server
+   * Error&quot; (or other 5xx) status code. The crawler should suspend crawling
+   * for a certain (but not too long) time, see property
+   * <code>http.robots.503.defer.visits</code>.
+   */
+  public static final BaseRobotRules DEFER_VISIT_RULES = new SimpleRobotRules(
+      RobotRulesMode.ALLOW_NONE);
+  static {
+    DEFER_VISIT_RULES.setDeferVisits(true);
+  }
+
   private static SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
   static {
     robotParser.setMaxCrawlDelay(Long.MAX_VALUE);


### PR DESCRIPTION
- add properties
  - `http.robots.503.defer.visits` :
    enable/disable the feature (default: enabled)
  - `http.robots.503.defer.visits.delay` :
    delay to wait before the next trial to fetch the properties
    (default: wait 5 minutes)
  - `http.robots.503.defer.visits.retries` :
    max. number of retries before giving up and dropping all URLs from the given host / queue
    (default: give up after the 3rd retry, ie. after 4 attempts)
- handle HTTP 5xx in robots.txt parser
- handle delay, retries and dropping queues in Fetcher

Stop queuing fetch items if timelimit is reached
- re-queuing items where the robots.txt request returned a 5xx
- redirects (http.redirect.max > 0) or
- outlinks (fetcher.follow.outlinks.depth > 0)

In a first version, I forgot to verify whether the Fetcher timelimit (`fetcher.timelimit.mins`) was already reached before re-queuing the fetch item. This caused very few fetcher task to end up in an infinite loop. In detail, this happened:
1. fetcher thread starts fetching an item and requests the corresponding robots.txt. Ev., the server responds slowly.
2. fetcher timelimit is reached, all fetcher queues are flushed
3. robots.txt response "arrived". Because it's a 5xx the fetch item is re-queued and the fetch is delayed for 30 min. (custom configuration).

Then steps 1 and 3 are retried until the max number of retries is reached. But this was fixed and I've also made sure that redirects or outlinks are not queued if the timelimit is reached.

