### PR TITLE
NUTCH-2936 Early registration of URL stream handlers provided by plugins may fail Hadoop jobs running in distributed mode

### DIFF
--- a/src/java/org/apache/nutch/plugin/Extension.java
+++ b/src/java/org/apache/nutch/plugin/Extension.java
@@ -140,13 +140,15 @@ public class Extension {
   }
 
   /**
-   * Return an instance of the extension implementatio. Before we create a
+   * Return an instance of the extension implementation. Before we create a
    * extension instance we startup the plugin if it is not already done. The
    * plugin instance and the extension instance use the same
-   * <code>PluginClassLoader</code>. Each Plugin use its own classloader. The
-   * PluginClassLoader knows only own <i>Plugin runtime libraries </i> setuped
-   * in the plugin manifest file and exported libraries of the depenedend
-   * plugins.
+   * {@link org.apache.nutch.plugin.PluginClassLoader}.
+   * Each Plugin use its own classloader. The
+   * {@link org.apache.nutch.plugin.PluginClassLoader} knows only its own
+   * <i>plugin runtime libraries</i> defined
+   * in the <code>plugin.xml</code> manifest file and exported libraries
+   * of the dependent plugins.
    * 
    * @return Object An instance of the extension implementation
    * @throws PluginRuntimeException if there is a fatal runtime error

--- a/src/java/org/apache/nutch/plugin/ExtensionPoint.java
+++ b/src/java/org/apache/nutch/plugin/ExtensionPoint.java
@@ -44,7 +44,7 @@ public class ExtensionPoint {
     setId(pId);
     setName(pName);
     setSchema(pSchema);
-    fExtensions = new ArrayList<>();
+    this.fExtensions = new ArrayList<>();
   }
 
   /**
@@ -53,7 +53,7 @@ public class ExtensionPoint {
    * @return String
    */
   public String getId() {
-    return ftId;
+    return this.ftId;
   }
 
   /**
@@ -62,7 +62,7 @@ public class ExtensionPoint {
    * @return String
    */
   public String getName() {
-    return fName;
+    return this.fName;
   }
 
   /**
@@ -71,7 +71,7 @@ public class ExtensionPoint {
    * @return String
    */
   public String getSchema() {
-    return fSchema;
+    return this.fSchema;
   }
 
   /**
@@ -81,7 +81,7 @@ public class ExtensionPoint {
    *          extension point id
    */
   private void setId(String pId) {
-    ftId = pId;
+    this.ftId = pId;
   }
 
   /**
@@ -90,7 +90,7 @@ public class ExtensionPoint {
    * @param pName
    */
   private void setName(String pName) {
-    fName = pName;
+    this.fName = pName;
   }
 
   /**
@@ -99,7 +99,7 @@ public class ExtensionPoint {
    * @param pSchema
    */
   private void setSchema(String pSchema) {
-    fSchema = pSchema;
+    this.fSchema = pSchema;
   }
 
   /**
@@ -109,7 +109,7 @@ public class ExtensionPoint {
    * to install
    */
   public void addExtension(Extension extension) {
-    fExtensions.add(extension);
+    this.fExtensions.add(extension);
   }
 
   /**
@@ -118,7 +118,7 @@ public class ExtensionPoint {
    * @return Extension[]
    */
   public Extension[] getExtensions() {
-    return fExtensions.toArray(new Extension[fExtensions.size()]);
+    return this.fExtensions.toArray(new Extension[this.fExtensions.size()]);
   }
 
 }

--- a/src/java/org/apache/nutch/plugin/PluginManifestParser.java
+++ b/src/java/org/apache/nutch/plugin/PluginManifestParser.java
@@ -19,6 +19,7 @@ package org.apache.nutch.plugin;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -50,7 +51,7 @@ public class PluginManifestParser {
   private static final String ATTR_CLASS = "class";
   private static final String ATTR_ID = "id";
 
-  protected static final Logger LOG = LoggerFactory.getLogger(PluginManifestParser.class);
+  protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private static final boolean WINDOWS = System.getProperty("os.name").startsWith("Windows");
 

--- a/src/java/org/apache/nutch/plugin/PluginRepository.java
+++ b/src/java/org/apache/nutch/plugin/PluginRepository.java
@@ -605,8 +605,8 @@ public class PluginRepository implements URLStreamHandlerFactory {
 
             // return the handler here, if possible
             String handlerClass = extension.getAttribute("urlStreamHandler");
-            LOG.debug("Located URLStreamHandler: {}", handlerClass);
             if (handlerClass != null) {
+              LOG.debug("Located URLStreamHandler: {}", handlerClass);
               // the nutch classloader
               ClassLoader cl = this.getClass().getClassLoader();
               if (extinst != null) {

--- a/src/java/org/apache/nutch/plugin/PluginRepository.java
+++ b/src/java/org/apache/nutch/plugin/PluginRepository.java
@@ -64,6 +64,7 @@ public class PluginRepository implements URLStreamHandlerFactory {
 
   private HashMap<String, Plugin> fActivatedPlugins;
 
+  @SuppressWarnings("rawtypes")
   private static final Map<String, Map<PluginClassLoader, Class>> CLASS_CACHE = new HashMap<>();
 
   private Configuration conf;
@@ -75,8 +76,8 @@ public class PluginRepository implements URLStreamHandlerFactory {
    * @throws RuntimeException if a fatal runtime error is encountered 
    */
   public PluginRepository(Configuration conf) throws RuntimeException {
-    fActivatedPlugins = new HashMap<>();
-    fExtensionPoints = new HashMap<>();
+    this.fActivatedPlugins = new HashMap<>();
+    this.fExtensionPoints = new HashMap<>();
     this.conf = new Configuration(conf);
     this.auto = conf.getBoolean("plugin.auto-activation", true);
     String[] pluginFolders = conf.getStrings("plugin.folders");
@@ -92,11 +93,11 @@ public class PluginRepository implements URLStreamHandlerFactory {
     Pattern includes = Pattern.compile(conf.get("plugin.includes", ""));
     Map<String, PluginDescriptor> filteredPlugins = filter(excludes, includes,
             allPlugins);
-    fRegisteredPlugins = getDependencyCheckedPlugins(filteredPlugins,
+    this.fRegisteredPlugins = getDependencyCheckedPlugins(filteredPlugins,
             this.auto ? allPlugins : filteredPlugins);
-    installExtensionPoints(fRegisteredPlugins);
+    installExtensionPoints(this.fRegisteredPlugins);
     try {
-      installExtensions(fRegisteredPlugins);
+      installExtensions(this.fRegisteredPlugins);
     } catch (PluginRuntimeException e) {
       LOG.error("Could not install extensions.", e.toString());
       throw new RuntimeException(e.getMessage());
@@ -134,7 +135,7 @@ public class PluginRepository implements URLStreamHandlerFactory {
       for (ExtensionPoint point : plugin.getExtenstionPoints()) {
         String xpId = point.getId();
         LOG.debug("Adding extension point {}", xpId);
-        fExtensionPoints.put(xpId, point);
+        this.fExtensionPoints.put(xpId, point);
       }
     }
   }
@@ -236,8 +237,8 @@ public class PluginRepository implements URLStreamHandlerFactory {
    * @return PluginDescriptor[]
    */
   public PluginDescriptor[] getPluginDescriptors() {
-    return fRegisteredPlugins
-            .toArray(new PluginDescriptor[fRegisteredPlugins.size()]);
+    return this.fRegisteredPlugins
+            .toArray(new PluginDescriptor[this.fRegisteredPlugins.size()]);
   }
 
   /**
@@ -248,7 +249,7 @@ public class PluginRepository implements URLStreamHandlerFactory {
    */
   public PluginDescriptor getPluginDescriptor(String pPluginId) {
 
-    for (PluginDescriptor descriptor : fRegisteredPlugins) {
+    for (PluginDescriptor descriptor : this.fRegisteredPlugins) {
       if (descriptor.getPluginId().equals(pPluginId))
         return descriptor;
     }
@@ -282,8 +283,8 @@ public class PluginRepository implements URLStreamHandlerFactory {
    */
   public Plugin getPluginInstance(PluginDescriptor pDescriptor)
           throws PluginRuntimeException {
-    if (fActivatedPlugins.containsKey(pDescriptor.getPluginId()))
-      return fActivatedPlugins.get(pDescriptor.getPluginId());
+    if (this.fActivatedPlugins.containsKey(pDescriptor.getPluginId()))
+      return this.fActivatedPlugins.get(pDescriptor.getPluginId());
     try {
       // Must synchronize here to make sure creation and initialization
       // of a plugin instance are done by one and only one thread.
@@ -297,7 +298,7 @@ public class PluginRepository implements URLStreamHandlerFactory {
         Plugin plugin = (Plugin) constructor
                 .newInstance(new Object[] { pDescriptor, this.conf });
         plugin.startUp();
-        fActivatedPlugins.put(pDescriptor.getPluginId(), plugin);
+        this.fActivatedPlugins.put(pDescriptor.getPluginId(), plugin);
         return plugin;
       }
     } catch (ClassNotFoundException e) {
@@ -318,6 +319,7 @@ public class PluginRepository implements URLStreamHandlerFactory {
    * @deprecated
    * @see <a href="https://openjdk.java.net/jeps/421">JEP 421: Deprecate Finalization for Removal</a>
    * @see java.lang.Object#finalize()
+   * @deprecated
    */
   @Deprecated
   public void finalize() throws Throwable {
@@ -330,12 +332,13 @@ public class PluginRepository implements URLStreamHandlerFactory {
    * @throws PluginRuntimeException
    */
   private void shutDownActivatedPlugins() throws PluginRuntimeException {
-    for (Plugin plugin : fActivatedPlugins.values()) {
+    for (Plugin plugin : this.fActivatedPlugins.values()) {
       plugin.shutDown();
     }
   }
 
-  public Class getCachedClass(PluginDescriptor pDescriptor, String className)
+  @SuppressWarnings("rawtypes")
+  public static Class getCachedClass(PluginDescriptor pDescriptor, String className)
           throws ClassNotFoundException {
     Map<PluginClassLoader, Class> descMap = CLASS_CACHE.get(className);
     if (descMap == null) {
@@ -355,19 +358,19 @@ public class PluginRepository implements URLStreamHandlerFactory {
     LOG.info("Plugin Auto-activation mode: [{}]", this.auto);
     LOG.info("Registered Plugins:");
 
-    if ((fRegisteredPlugins == null) || (fRegisteredPlugins.size() == 0)) {
+    if ((this.fRegisteredPlugins == null) || (this.fRegisteredPlugins.size() == 0)) {
       LOG.info("\tNONE");
     } else {
-      for (PluginDescriptor plugin : fRegisteredPlugins) {
+      for (PluginDescriptor plugin : this.fRegisteredPlugins) {
         LOG.info("\t{} ({})", plugin.getName(), plugin.getPluginId());
       }
     }
 
     LOG.info("Registered Extension-Points:");
-    if ((fExtensionPoints == null) || (fExtensionPoints.size() == 0)) {
+    if ((this.fExtensionPoints == null) || (this.fExtensionPoints.size() == 0)) {
       LOG.info("\tNONE");
     } else {
-      for (ExtensionPoint ep : fExtensionPoints.values()) {
+      for (ExtensionPoint ep : this.fExtensionPoints.values()) {
         LOG.info("\t ({})", ep.getName(), ep.getId());
       }
     }
@@ -384,7 +387,7 @@ public class PluginRepository implements URLStreamHandlerFactory {
    *          Map of plugins
    * @return map of plugins matching the configuration
    */
-  private Map<String, PluginDescriptor> filter(Pattern excludes,
+  private static Map<String, PluginDescriptor> filter(Pattern excludes,
           Pattern includes, Map<String, PluginDescriptor> plugins) {
 
     Map<String, PluginDescriptor> map = new HashMap<>();
@@ -434,11 +437,11 @@ public class PluginRepository implements URLStreamHandlerFactory {
   public synchronized Object[] getOrderedPlugins(Class<?> clazz,
           String xPointId, String orderProperty) {
     Object[] filters;
-    ObjectCache objectCache = ObjectCache.get(conf);
+    ObjectCache objectCache = ObjectCache.get(this.conf);
     filters = (Object[]) objectCache.getObject(clazz.getName());
 
     if (filters == null) {
-      String order = conf.get(orderProperty);
+      String order = this.conf.get(orderProperty);
       List<String> orderOfFilters = new ArrayList<>();
       boolean userDefinedOrder = false;
       if (order != null && !order.trim().isEmpty()) {
@@ -447,7 +450,7 @@ public class PluginRepository implements URLStreamHandlerFactory {
       }
 
       try {
-        ExtensionPoint point = PluginRepository.get(conf)
+        ExtensionPoint point = PluginRepository.get(this.conf)
                 .getExtensionPoint(xPointId);
         if (point == null)
           throw new RuntimeException(xPointId + " not found.");
@@ -579,8 +582,8 @@ public class PluginRepository implements URLStreamHandlerFactory {
   public URLStreamHandler createURLStreamHandler(String protocol) {
     LOG.debug("Creating URLStreamHandler for protocol: {}", protocol);
 
-    if (fExtensionPoints != null) {
-      ExtensionPoint ep = fExtensionPoints
+    if (this.fExtensionPoints != null) {
+      ExtensionPoint ep = this.fExtensionPoints
               .get("org.apache.nutch.protocol.Protocol");
       if (ep != null) {
         Extension[] extensions = ep.getExtensions();
@@ -622,11 +625,11 @@ public class PluginRepository implements URLStreamHandlerFactory {
               }
             }
 
-            LOG.debug("suitable protocol extension found that did not declare a handler");
+            LOG.debug("Suitable protocol extension found that did not declare a handler");
             return null;
           }
         }
-        LOG.debug("No suitable protocol extensions registered");
+        LOG.debug("No suitable protocol extensions registered for protocol: {}", protocol);
       } else {
         LOG.debug("No protocol extensions registered?");
       }

--- a/src/java/org/apache/nutch/plugin/URLStreamHandlerFactory.java
+++ b/src/java/org/apache/nutch/plugin/URLStreamHandlerFactory.java
@@ -59,7 +59,7 @@ public class URLStreamHandlerFactory
   }
   
   private URLStreamHandlerFactory() {
-    prs = new ArrayList<>();
+    this.prs = new ArrayList<>();
   }
 
   /** 
@@ -75,7 +75,7 @@ public class URLStreamHandlerFactory
    * @param pr The PluginRepository to be registered.
    */
   public void registerPluginRepository(PluginRepository pr) {
-    prs.add(new WeakReference<PluginRepository>(pr));
+    this.prs.add(new WeakReference<PluginRepository>(pr));
     
     removeInvalidRefs();
   }
@@ -88,7 +88,7 @@ public class URLStreamHandlerFactory
     
     // find the 'correct' PluginRepository. For now we simply take the first.
     // then ask it to return the URLStreamHandler
-    for(WeakReference<PluginRepository> ref: prs) {
+    for(WeakReference<PluginRepository> ref: this.prs) {
       PluginRepository pr = ref.get();
       if(pr != null) {
         // found PluginRepository. Let's get the URLStreamHandler...
@@ -103,13 +103,12 @@ public class URLStreamHandlerFactory
    * garbage collected meanwhile.
    */
   private void removeInvalidRefs() {
-    LOG.debug("removeInvalidRefs()");
-    ArrayList<WeakReference<PluginRepository>> copy = new ArrayList<>(prs);
+    ArrayList<WeakReference<PluginRepository>> copy = new ArrayList<>(this.prs);
     for(WeakReference<PluginRepository> ref: copy) {
       if(ref.get() == null) {
-        prs.remove(ref);
+        this.prs.remove(ref);
       }
     }
-    LOG.debug("Removed the following invalid references: '{}' Remaining: '{}'", copy.size()-prs.size(), prs.size());
+    LOG.debug("Removed '{}' invalid references. '{}' remaining.", copy.size()-this.prs.size(), this.prs.size());
   }
 }

--- a/src/plugin/protocol-foo/plugin.xml
+++ b/src/plugin/protocol-foo/plugin.xml
@@ -40,7 +40,7 @@
       <implementation id="org.apache.nutch.protocol.foo.Foo"
                       class="org.apache.nutch.protocol.foo.Foo">
         <parameter name="protocolName" value="foo"/>
-		<parameter name="urlStreamHandler" value="org.apache.nutch.protocol.foo.Handler"/>
+        <parameter name="urlStreamHandler" value="org.apache.nutch.protocol.foo.Handler"/>
       </implementation>
       
    </extension>

--- a/src/plugin/protocol-okhttp/ivy.xml
+++ b/src/plugin/protocol-okhttp/ivy.xml
@@ -36,8 +36,8 @@
   </publications>
 
   <dependencies>
-    <dependency org="com.squareup.okhttp3" name="okhttp" rev="4.9.1"/>
-    <dependency org="com.squareup.okhttp3" name="okhttp-brotli" rev="4.9.1"/>
+    <dependency org="com.squareup.okhttp3" name="okhttp" rev="4.9.3"/>
+    <dependency org="com.squareup.okhttp3" name="okhttp-brotli" rev="4.9.3"/>
   </dependencies>
   
 </ivy-module>

--- a/src/plugin/protocol-okhttp/plugin.xml
+++ b/src/plugin/protocol-okhttp/plugin.xml
@@ -26,15 +26,15 @@
          <export name="*"/>
       </library>
       <!-- dependencies of OkHttp -->
-      <library name="okhttp-4.9.1.jar"/>
-      <library name="okhttp-brotli-4.9.1.jar"/>
-      <library name="okio-2.8.0.jar"/>
+      <library name="annotations-13.0.jar"/>
+      <library name="dec-0.1.2.jar"/>
       <library name="kotlin-stdlib-1.4.10.jar"/>
       <library name="kotlin-stdlib-common-1.4.10.jar"/>
       <library name="kotlin-stdlib-jdk7-1.4.10.jar"/>
       <library name="kotlin-stdlib-jdk8-1.4.10.jar"/>
-      <library name="annotations-13.0.jar"/>
-      <library name="dec-0.1.2.jar"/>
+      <library name="okhttp-4.9.3.jar"/>
+      <library name="okhttp-brotli-4.9.3.jar"/>
+      <library name="okio-2.8.0.jar"/>
       <!-- end of dependencies of OkHttp -->
    </runtime>
 
@@ -54,7 +54,7 @@
 
       <implementation id="org.apache.nutch.protocol.okhttp.OkHttp"
                        class="org.apache.nutch.protocol.okhttp.OkHttp">
-           <parameter name="protocolName" value="https"/>
+        <parameter name="protocolName" value="https"/>
       </implementation>
 
    </extension>

--- a/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttp.java
+++ b/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttp.java
@@ -112,7 +112,7 @@ public class OkHttp extends HttpBase {
 
     // protocols in order of preference
     List<okhttp3.Protocol> protocols = new ArrayList<>();
-    if (useHttp2) {
+    if (this.useHttp2) {
       protocols.add(okhttp3.Protocol.HTTP_2);
     }
     protocols.add(okhttp3.Protocol.HTTP_1_1);
@@ -121,11 +121,11 @@ public class OkHttp extends HttpBase {
         .protocols(protocols) //
         .retryOnConnectionFailure(true) //
         .followRedirects(false) //
-        .connectTimeout(timeout, TimeUnit.MILLISECONDS)
-        .writeTimeout(timeout, TimeUnit.MILLISECONDS)
-        .readTimeout(timeout, TimeUnit.MILLISECONDS);
+        .connectTimeout(this.timeout, TimeUnit.MILLISECONDS)
+        .writeTimeout(this.timeout, TimeUnit.MILLISECONDS)
+        .readTimeout(this.timeout, TimeUnit.MILLISECONDS);
 
-    if (!tlsCheckCertificate) {
+    if (!this.tlsCheckCertificate) {
       builder.sslSocketFactory(trustAllSslSocketFactory,
           (X509TrustManager) trustAllCerts[0]);
       builder.hostnameVerifier(new HostnameVerifier() {
@@ -136,23 +136,23 @@ public class OkHttp extends HttpBase {
       });
     }
 
-    if (!accept.isEmpty()) {
-      getCustomRequestHeaders().add(new String[] { "Accept", accept });
+    if (!this.accept.isEmpty()) {
+      getCustomRequestHeaders().add(new String[] { "Accept", this.accept });
     }
 
-    if (!acceptLanguage.isEmpty()) {
+    if (!this.acceptLanguage.isEmpty()) {
       getCustomRequestHeaders()
-          .add(new String[] { "Accept-Language", acceptLanguage });
+          .add(new String[] { "Accept-Language", this.acceptLanguage });
     }
 
-    if (!acceptCharset.isEmpty()) {
+    if (!this.acceptCharset.isEmpty()) {
       getCustomRequestHeaders()
-          .add(new String[] { "Accept-Charset", acceptCharset });
+          .add(new String[] { "Accept-Charset", this.acceptCharset });
     }
 
-    if (useProxy) {
-      Proxy proxy = new Proxy(proxyType,
-          new InetSocketAddress(proxyHost, proxyPort));
+    if (this.useProxy) {
+      Proxy proxy = new Proxy(this.proxyType,
+          new InetSocketAddress(this.proxyHost, this.proxyPort));
       String proxyUsername = conf.get("http.proxy.username");
       if (proxyUsername == null) {
         ProxySelector selector = new ProxySelector() {
@@ -172,9 +172,9 @@ public class OkHttp extends HttpBase {
           @Override
           public List<Proxy> select(URI uri) {
             if (useProxy(uri)) {
-              return proxyList;
+              return this.proxyList;
             }
-            return noProxyList;
+            return this.noProxyList;
           }
 
           @Override
@@ -192,7 +192,7 @@ public class OkHttp extends HttpBase {
          * ProxySelector class with proxy auth. If a proxy username is present,
          * the configured proxy will be used for ALL requests.
          */
-        if (proxyException.size() > 0) {
+        if (this.proxyException.size() > 0) {
           LOG.warn(
               "protocol-okhttp does not respect 'http.proxy.exception.list' setting when "
                   + "'http.proxy.username' is set. This is a limitation of the current okhttp3 "
@@ -214,14 +214,14 @@ public class OkHttp extends HttpBase {
       }
     }
 
-    if (storeIPAddress || storeHttpHeaders || storeHttpRequest) {
+    if (this.storeIPAddress || this.storeHttpHeaders || this.storeHttpRequest) {
       builder.addNetworkInterceptor(new HTTPHeadersInterceptor());
     }
 
     // enable support for Brotli compression (Content-Encoding)
     builder.addInterceptor(BrotliInterceptor.INSTANCE);
 
-    client = builder.build();
+    this.client = builder.build();
   }
 
   class HTTPHeadersInterceptor implements Interceptor {
@@ -241,7 +241,7 @@ public class OkHttp extends HttpBase {
 
       Connection connection = chain.connection();
       String ipAddress = null;
-      if (storeIPAddress) {
+      if (OkHttp.this.storeIPAddress) {
         InetAddress address = connection.socket().getInetAddress();
         ipAddress = address.getHostAddress();
       }
@@ -252,7 +252,7 @@ public class OkHttp extends HttpBase {
       StringBuilder requestverbatim = null;
       StringBuilder responseverbatim = null;
 
-      if (storeHttpRequest) {
+      if (OkHttp.this.storeHttpRequest) {
         requestverbatim = new StringBuilder();
 
         requestverbatim.append(request.method()).append(' ');
@@ -277,7 +277,7 @@ public class OkHttp extends HttpBase {
         requestverbatim.append("\r\n");
       }
 
-      if (storeHttpHeaders) {
+      if (OkHttp.this.storeHttpHeaders) {
         responseverbatim = new StringBuilder();
 
         responseverbatim.append(getNormalizedProtocolName(response.protocol()))
@@ -322,11 +322,11 @@ public class OkHttp extends HttpBase {
   }
 
   protected List<String[]> getCustomRequestHeaders() {
-    return customRequestHeaders;
+    return this.customRequestHeaders;
   }
 
   protected OkHttpClient getClient() {
-    return client;
+    return this.client;
   }
 
   @Override

--- a/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttpResponse.java
+++ b/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttpResponse.java
@@ -55,15 +55,15 @@ public class OkHttpResponse implements Response {
     }
 
     public void setReason(TruncatedContentReason val) {
-      value = val;
+      this.value = val;
    }
 
     public TruncatedContentReason getReason() {
-       return value;
+       return this.value;
     }
 
     public boolean booleanValue() {
-      return value != TruncatedContentReason.NOT_TRUNCATED;
+      return this.value != TruncatedContentReason.NOT_TRUNCATED;
     }
   }
 
@@ -123,7 +123,7 @@ public class OkHttpResponse implements Response {
           response.message());
 
       TruncatedContent truncated = new TruncatedContent();
-      content = toByteArray(response.body(), truncated, okhttp.getMaxContent(),
+      this.content = toByteArray(response.body(), truncated, okhttp.getMaxContent(),
           okhttp.getMaxDuration(), okhttp.isStorePartialAsTruncated());
       responsemetadata.add(FETCH_TIME,
           Long.toString(System.currentTimeMillis()));
@@ -135,11 +135,11 @@ public class OkHttpResponse implements Response {
         responsemetadata.set(TRUNCATED_CONTENT_REASON,
             truncated.getReason().toString().toLowerCase(Locale.ROOT));
         LOG.debug("HTTP content truncated to {} bytes (reason: {})",
-            content.length, truncated.getReason());
+            this.content.length, truncated.getReason());
       }
 
-      code = response.code();
-      headers = responsemetadata;
+      this.code = response.code();
+      this.headers = responsemetadata;
     }
   }
 
@@ -179,7 +179,7 @@ public class OkHttpResponse implements Response {
         if (partialAsTruncated && source.getBuffer().size() > 0) {
           // treat already fetched content as truncated
           truncated.setReason(TruncatedContentReason.DISCONNECT);
-          LOG.info("Truncated content for {}, partial fetch caused by:", url,
+          LOG.info("Truncated content for {}, partial fetch caused by:", this.url,
               e);
         } else {
           throw e;
@@ -222,23 +222,23 @@ public class OkHttpResponse implements Response {
   }
 
   public URL getUrl() {
-    return url;
+    return this.url;
   }
 
   public int getCode() {
-    return code;
+    return this.code;
   }
 
   public String getHeader(String name) {
-    return headers.get(name);
+    return this.headers.get(name);
   }
 
   public Metadata getHeaders() {
-    return headers;
+    return this.headers;
   }
 
   public byte[] getContent() {
-    return content;
+    return this.content;
   }
 
 }


### PR DESCRIPTION
I ended up producing this PR as a result of investigating NUTCH-2936. This PR does not fix NUTCH-2936.
The problem is that the [trustAllSslSocketFactory](https://github.com/apache/nutch/blob/master/src/plugin/protocol-okhttp/src/java/org/apache/nutch/protocol/okhttp/OkHttp.java#L129) variable is `null` when passed into `okhttp3.OkHttpClient.Builder.sslSocketFactory`.
I have not yet tried to verify if running protocol-okhttp is distributed mode. I can try that early next week. It might be worthwhile us reverting NUTCH-2429.