### PR TITLE
NUTCH-2946 Fetcher: optionally slow down fetching from hosts with repeated exceptions

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1081,10 +1081,21 @@
 <property>
   <name>fetcher.max.exceptions.per.queue</name>
   <value>-1</value>
-  <description>The maximum number of protocol-level exceptions (e.g. timeouts) per
-  host (or IP) queue. Once this value is reached, any remaining entries from this
-  queue are purged, effectively stopping the fetching from this host/IP. The default
-  value of -1 deactivates this limit.
+  <description>The maximum number of protocol-level exceptions
+  (e.g. timeouts) or HTTP status codes mapped to ProtocolStatus.EXCEPTION
+  per host (or IP) queue. Once this value is reached, any remaining entries
+  from this queue are purged, effectively stopping the fetching from this
+  host/IP. The default value of -1 deactivates this limit.
+  </description>
+</property>
+
+<property>
+  <name>fetcher.exceptions.per.queue.delay</name>
+  <value>-1</value>
+  <description>Additional delay in milliseconds slowing down fetches from a queue
+  if an exception has occurred (see also fetcher.max.exceptions.per.queue).
+  The delay grows logarithmically with the number of observed exceptions:
+     delay = fetcher.exceptions.per.queue.delay * log2(1 + num_exception_in_queue)
   </description>
 </property>
 

--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1091,11 +1091,15 @@
 
 <property>
   <name>fetcher.exceptions.per.queue.delay</name>
-  <value>-1</value>
-  <description>Additional delay in milliseconds slowing down fetches from a queue
-  if an exception has occurred (see also fetcher.max.exceptions.per.queue).
-  The delay grows logarithmically with the number of observed exceptions:
-     delay = fetcher.exceptions.per.queue.delay * log2(1 + num_exception_in_queue)
+  <value>${fetcher.server.delay}</value>
+  <description>Initial value (in seconds) of an additional dynamic
+  delay slowing down fetches from a queue after an exception has
+  occurred (see also fetcher.max.exceptions.per.queue). Starting with
+  the initial value the delay doubles with every observed exception:
+
+    delay = fetcher.exceptions.per.queue.delay * 2^num_exception_in_queue
+
+  An initial value of 0.0 disables this exponential backoff mechanism.
   </description>
 </property>
 


### PR DESCRIPTION
Fetcher to slow down fetching from hosts where requests fail repeatedly with exceptions or HTTP status codes mapped to ProtocolStatus.EXCEPTION (HTTP 403 Forbidden, 429 Too many requests, 5xx server errors, etc.)