### PR TITLE
NUTCH-2947 Fetcher: keep state of empty fetch queues unless queue feeder is finished

### DIFF
--- a/src/java/org/apache/nutch/fetcher/FetchItemQueues.java
+++ b/src/java/org/apache/nutch/fetcher/FetchItemQueues.java
@@ -187,8 +187,10 @@ public class FetchItemQueues {
         if (!feederAlive) {
           // no more fetch items added
           it.remove();
-        } else if (maxExceptionsPerQueue > -1 && fiq.exceptionCounter.get() > 0) {
+        } else if ((maxExceptionsPerQueue > -1 || exceptionsPerQueueDelay > 0)
+            && fiq.exceptionCounter.get() > 0) {
           // keep queue because the exceptions counter is bound to it
+          // and is required to skip or delay items on this queue
         } else if (fiq.nextFetchTime.get() > System.currentTimeMillis()) {
           // keep queue to have it blocked in case new fetch items of this queue
           // are added by the QueueFeeder

--- a/src/java/org/apache/nutch/fetcher/FetchItemQueues.java
+++ b/src/java/org/apache/nutch/fetcher/FetchItemQueues.java
@@ -57,6 +57,7 @@ public class FetchItemQueues {
   long timelimit = -1;
   int maxExceptionsPerQueue = -1;
   long exceptionsPerQueueDelay = -1;
+  boolean feederAlive = true;
   Configuration conf;
 
   public static final String QUEUE_MODE_HOST = "byHost";
@@ -181,11 +182,23 @@ public class FetchItemQueues {
     while (it.hasNext()) {
       FetchItemQueue fiq = it.next().getValue();
 
-      // reap empty queues
+      // reap empty queues which do not hold state required to ensure politeness
       if (fiq.getQueueSize() == 0 && fiq.getInProgressSize() == 0) {
-        it.remove();
+        if (!feederAlive) {
+          // no more fetch items added
+          it.remove();
+        } else if (maxExceptionsPerQueue > -1 && fiq.exceptionCounter.get() > 0) {
+          // keep queue because the exceptions counter is bound to it
+        } else if (fiq.nextFetchTime.get() > System.currentTimeMillis()) {
+          // keep queue to have it blocked in case new fetch items of this queue
+          // are added by the QueueFeeder
+        } else {
+          // empty queue without state
+          it.remove();
+        }
         continue;
       }
+
       FetchItem fit = fiq.getFetchItem();
       if (fit != null) {
         totalSize.decrementAndGet();

--- a/src/java/org/apache/nutch/fetcher/QueueFeeder.java
+++ b/src/java/org/apache/nutch/fetcher/QueueFeeder.java
@@ -89,7 +89,7 @@ public class QueueFeeder extends Thread {
     int cnt = 0;
     int[] queuingStatus = new int[QueuingStatus.values().length];
     while (hasMore) {
-      if (System.currentTimeMillis() >= timelimit && timelimit != -1) {
+      if (timelimit != -1 && System.currentTimeMillis() >= timelimit) {
         // enough ... lets' simply read all the entries from the input without
         // processing them
         try {
@@ -155,6 +155,8 @@ public class QueueFeeder extends Thread {
         }
       }
     }
+    // signal queues that no more new fetch items are added
+    queues.feederAlive = false;
     LOG.info("QueueFeeder finished: total {} records", cnt);
     LOG.info("QueueFeeder queuing status:");
     for (QueuingStatus status : QueuingStatus.values()) {


### PR DESCRIPTION
Fetcher: keep state of empty but stateful fetch queues unless queue feeder is finished in order to ensure politeness
- next fetch time not yet reached
- non-zero exception counter and queue feeder still
  adding new fetch items to queues

Only if the the queue feeder is finished and no more new fetch items are added, these queues can finally removed.

Note: this PR needs to be adapted to #728 (NUTCH-2946) or vice verse whichever is merged first. The state of queues needs also preserved in case fetcher.max.exceptions.per.queue == -1 but fetcher.exceptions.per.queue.delay != -1.