### PR TITLE
NUTCH-2951 Crawl datum with metadata WRITABLE_GENERATE_TIME_KEY awaits fetching forever

### DIFF
--- a/src/java/org/apache/nutch/crawl/Generator.java
+++ b/src/java/org/apache/nutch/crawl/Generator.java
@@ -238,10 +238,11 @@ public class Generator extends NutchTool implements Tool {
       LongWritable oldGenTime = (LongWritable) crawlDatum.getMetaData()
           .get(Nutch.WRITABLE_GENERATE_TIME_KEY);
       if (oldGenTime != null) { // awaiting fetch & update
-        if (oldGenTime.get() + genDelay > curTime) // still wait for
+        if (oldGenTime.get() + genDelay > curTime) { // still wait for
           // update
           context.getCounter("Generator", "WAIT_FOR_UPDATE").increment(1);
-        return;
+          return;
+        }
       }
       float sort = 1.0f;
       try {


### PR DESCRIPTION
- bug fix: add missing braces (introduced with NUTCH-2737)