### PR TITLE
NUTCH-2936 / NUTCH-2949 URLStreamHandler may fail jobs in distributed mode

### DIFF
--- a/src/java/org/apache/nutch/plugin/Extension.java
+++ b/src/java/org/apache/nutch/plugin/Extension.java
@@ -143,15 +143,15 @@ public class Extension {
    * Return an instance of the extension implementation. Before we create a
    * extension instance we startup the plugin if it is not already done. The
    * plugin instance and the extension instance use the same
-   * {@link org.apache.nutch.plugin.PluginClassLoader}.
-   * Each Plugin use its own classloader. The
-   * {@link org.apache.nutch.plugin.PluginClassLoader} knows only its own
-   * <i>plugin runtime libraries</i> defined
-   * in the <code>plugin.xml</code> manifest file and exported libraries
-   * of the dependent plugins.
+   * {@link org.apache.nutch.plugin.PluginClassLoader}. Each Plugin uses its own
+   * classloader. The {@link org.apache.nutch.plugin.PluginClassLoader} knows
+   * only its own <i>plugin runtime libraries</i> defined in the
+   * <code>plugin.xml</code> manifest file and exported libraries of the
+   * dependent plugins.
    * 
    * @return Object An instance of the extension implementation
-   * @throws PluginRuntimeException if there is a fatal runtime error
+   * @throws PluginRuntimeException
+   *           if there is a fatal runtime error
    */
   public Object getExtensionInstance() throws PluginRuntimeException {
     // Must synchronize here to make sure creation and initialization

--- a/src/java/org/apache/nutch/plugin/Plugin.java
+++ b/src/java/org/apache/nutch/plugin/Plugin.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.conf.Configuration;
  * provide a API and invoke one or a set of installed extensions.
  * 
  * Each plugin may extend the base <code>Plugin</code>. <code>Plugin</code>
- * instances are used as the point of life cycle managemet of plugin related
+ * instances are used as the point of life cycle management of plugin related
  * functionality.
  * 
  * The <code>Plugin</code> will be started up and shutdown by the nutch plugin

--- a/src/java/org/apache/nutch/plugin/PluginRepository.java
+++ b/src/java/org/apache/nutch/plugin/PluginRepository.java
@@ -541,8 +541,8 @@ public class PluginRepository implements URLStreamHandlerFactory {
 
   /**
    * Registers this PluginRepository to be invoked whenever URLs have to be
-   * parsed. This allows to check the registered protocol plugins for uncommon
-   * protocols.
+   * parsed. This allows to check the registered protocol plugins for custom
+   * protocols not covered by standard {@link URLStreamHandler}s of the JVM.
    */
   private void registerURLStreamHandlerFactory() {
     org.apache.nutch.plugin.URLStreamHandlerFactory.getInstance().registerPluginRepository(this);

--- a/src/java/org/apache/nutch/plugin/PluginRepository.java
+++ b/src/java/org/apache/nutch/plugin/PluginRepository.java
@@ -38,11 +38,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * <p>The plugin repositority is a registry of all plugins.</p>
+ * <p>The plugin repository is a registry of all plugins.</p>
  * 
- * <p>At system boot up a repositority is built by parsing the mainifest files of
+ * <p>At system boot up a repository is built by parsing the manifest files of
  * all plugins. Plugins that require other plugins which do not exist are not
- * registed. For each plugin a plugin descriptor instance will be created. The
+ * registered. For each plugin a plugin descriptor instance will be created. The
  * descriptor represents all meta information about a plugin. So a plugin
  * instance will be created later when it is required, this allow lazy plugin
  * loading.</p>
@@ -64,8 +64,7 @@ public class PluginRepository implements URLStreamHandlerFactory {
 
   private HashMap<String, Plugin> fActivatedPlugins;
 
-  @SuppressWarnings("rawtypes")
-  private static final Map<String, Map<PluginClassLoader, Class>> CLASS_CACHE = new HashMap<>();
+  private static final Map<String, Map<PluginClassLoader, Class<?>>> CLASS_CACHE = new HashMap<>();
 
   private Configuration conf;
 
@@ -267,14 +266,14 @@ public class PluginRepository implements URLStreamHandlerFactory {
   }
 
   /**
-   * <p>Returns a instance of a plugin. Plugin instances are cached. So a plugin
-   * exist only as one instance. This allow a central management of plugin own
+   * <p>Returns an instance of a plugin. Plugin instances are cached. So a plugin
+   * exist only as one instance. This allow a central management of plugin's own
    * resources.</p>
    * 
    * <p>After creating the plugin instance the startUp() method is invoked. The
    * plugin use a own classloader that is used as well by all instance of
    * extensions of the same plugin. This class loader use all exported libraries
-   * from the dependend plugins and all plugin libraries.</p>
+   * from the dependent plugins and all plugin libraries.</p>
    * 
    * @param pDescriptor a {@link PluginDescriptor} for which to retrieve a 
    * {@link Plugin} instance
@@ -337,16 +336,15 @@ public class PluginRepository implements URLStreamHandlerFactory {
     }
   }
 
-  @SuppressWarnings("rawtypes")
-  public static Class getCachedClass(PluginDescriptor pDescriptor, String className)
+  public Class<?> getCachedClass(PluginDescriptor pDescriptor, String className)
           throws ClassNotFoundException {
-    Map<PluginClassLoader, Class> descMap = CLASS_CACHE.get(className);
+    Map<PluginClassLoader, Class<?>> descMap = CLASS_CACHE.get(className);
     if (descMap == null) {
       descMap = new HashMap<>();
       CLASS_CACHE.put(className, descMap);
     }
     PluginClassLoader loader = pDescriptor.getClassLoader();
-    Class clazz = descMap.get(loader);
+    Class<?> clazz = descMap.get(loader);
     if (clazz == null) {
       clazz = loader.loadClass(className);
       descMap.put(loader, clazz);


### PR DESCRIPTION
Fixes to address the failing of Nutch jobs in (pseudo-)distributed mode. Implements:
- caching of URLStreamHandlers per protocol to avoid that handlers are created anew

- enforce routing of standard protocols (http, https, file, jar) to handlers implemented by the JVM
  - utilizes the URLStreamHandler cache
  - fixes NUTCH-2936 (verified in pseudo-distributed mode)

Also:
- code improvements in classes of the package "org.apache.nutch.plugin"
  - use `Class<?>` and remove suppressions of warnings
  - javadocs: fix typos
  - remove superfluous white space
  - autoformat using code style template
- protocol-okhttp: initialize SSLContext not in a static code block (SSLContext is used to ignore SSL/TLS certificate verification): this was the initial fix for the needless warning in parsechecker even in local mode. This seems also fixed by the enforced routing of standard URLStreamHandlers, but I left it in, to avoid that all the testing in pseudo-distributed mode needs to be run again.

Next week I will test the fixes in real distributed mode.