### PR TITLE
NUTCH-2952 Upgrade core dependencies

### DIFF
--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -36,10 +36,10 @@
 	</publications>
 
 	<dependencies>
-		<dependency org="org.apache.logging.log4j" name="log4j-api" rev="2.17.0" conf="*->master" />
-		<dependency org="org.apache.logging.log4j" name="log4j-core" rev="2.17.0" conf="*->master" />
-		<dependency org="org.apache.logging.log4j" name="log4j-slf4j-impl" rev="2.17.0" conf="*->master" />
-		<dependency org="org.slf4j" name="slf4j-api" rev="1.7.32" conf="*->master" />
+		<dependency org="org.apache.logging.log4j" name="log4j-api" rev="2.17.2" conf="*->master" />
+		<dependency org="org.apache.logging.log4j" name="log4j-core" rev="2.17.2" conf="*->master" />
+		<dependency org="org.apache.logging.log4j" name="log4j-slf4j-impl" rev="2.17.2" conf="*->master" />
+		<dependency org="org.slf4j" name="slf4j-api" rev="1.7.36" conf="*->master" />
 
 		<dependency org="org.apache.commons" name="commons-lang3" rev="3.12.0" conf="*->default" />
 		<dependency org="org.apache.commons" name="commons-collections4" rev="4.4" conf="*->master" />
@@ -50,7 +50,7 @@
 		<dependency org="com.tdunning" name="t-digest" rev="3.2" />
 
 		<!-- Hadoop Dependencies -->
-		<dependency org="org.apache.hadoop" name="hadoop-common" rev="3.1.3" conf="*->default">
+		<dependency org="org.apache.hadoop" name="hadoop-common" rev="3.3.3" conf="*->default">
 			<exclude org="hsqldb" name="hsqldb" />
 			<exclude org="net.sf.kosmosfs" name="kfs" />
 			<exclude org="net.java.dev.jets3t" name="jets3t" />
@@ -58,23 +58,23 @@
 			<exclude org="org.mortbay.jetty" name="jsp-*" />
 			<exclude org="ant" name="ant" />
 		</dependency>
-		<dependency org="org.apache.hadoop" name="hadoop-hdfs" rev="3.1.3" conf="*->default" />
-		<dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-core" rev="3.1.3" conf="*->default" />
-		<dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-jobclient" rev="3.1.3" conf="*->default" />
+		<dependency org="org.apache.hadoop" name="hadoop-hdfs" rev="3.3.3" conf="*->default" />
+		<dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-core" rev="3.3.3" conf="*->default" />
+		<dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-jobclient" rev="3.3.3" conf="*->default" />
 		<!-- End of Hadoop Dependencies -->
 
 		<dependency org="org.apache.tika" name="tika-core" rev="2.3.0" />
 
 		<dependency org="xml-apis" name="xml-apis" rev="1.4.01" /><!-- force this version as it is required by Tika -->
-		<dependency org="xerces" name="xercesImpl" rev="2.12.1" />
+		<dependency org="xerces" name="xercesImpl" rev="2.12.2" />
 
-		<dependency org="com.ibm.icu" name="icu4j" rev="68.2" />
+		<dependency org="com.ibm.icu" name="icu4j" rev="71.1" />
 
-		<dependency org="com.google.guava" name="guava" rev="30.1-jre" />
+		<dependency org="com.google.guava" name="guava" rev="31.1-jre" />
 
 		<dependency org="com.github.crawler-commons" name="crawler-commons" rev="1.2" />
 
-		<dependency org="com.google.code.gson" name="gson" rev="2.8.9"/>
+		<dependency org="com.google.code.gson" name="gson" rev="2.9.0"/>
 		<dependency org="com.martinkl.warc" name="warc-hadoop" rev="0.1.0">
 			<exclude module="hadoop-client" />
 		</dependency>
@@ -84,10 +84,10 @@
 		<dependency org="org.apache.cxf" name="cxf-rt-transports-http" rev="3.4.1" conf="*->default" />
 		<dependency org="org.apache.cxf" name="cxf-rt-transports-http-jetty" rev="3.4.1" conf="*->default" />
 		<dependency org="org.apache.cxf" name="cxf-rt-rs-client" rev="3.4.1" conf="test->default" />
-		<dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.12.0" conf="*->default" />
-		<dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.12.0" conf="*->default" />
-		<dependency org="com.fasterxml.jackson.dataformat" name="jackson-dataformat-cbor" rev="2.12.0" conf="*->default" />
-		<dependency org="com.fasterxml.jackson.jaxrs" name="jackson-jaxrs-json-provider" rev="2.12.0" conf="*->default" />
+		<dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.13.3" conf="*->default" />
+		<dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.13.3" conf="*->default" />
+		<dependency org="com.fasterxml.jackson.dataformat" name="jackson-dataformat-cbor" rev="2.13.3" conf="*->default" />
+		<dependency org="com.fasterxml.jackson.jaxrs" name="jackson-jaxrs-json-provider" rev="2.13.3" conf="*->default" />
 
 		<!-- WARC artifacts needed -->
 		<dependency org="org.netpreserve.commons" name="webarchive-commons" rev="1.1.9" conf="*->default">
@@ -111,15 +111,11 @@
 			<artifact name="mrunit" ns0:classifier="hadoop2" />
 			<exclude org="log4j" module="log4j" />
 		</dependency>
-		<dependency org="org.mortbay.jetty" name="jetty-client" rev="6.1.26" conf="test->default" />
 
-		<!-- web app dependencies -->
-		<dependency org="org.mortbay.jetty" name="jetty" rev="6.1.26" />
+		<dependency org="org.mortbay.jetty" name="jetty-client" rev="6.1.26" conf="test->default" />
+		<dependency org="org.mortbay.jetty" name="jetty" rev="6.1.26" conf="test->default" />
 
 		<dependency org="org.apache.commons" name="commons-collections4" rev="4.1" conf="*->default" />
-
-		<!-- RabbitMQ dependencies -->
-		<dependency org="com.rabbitmq" name="amqp-client" rev="5.2.0" conf="*->default" />
 
 		<!--Added Because of Elasticsearch JEST client-->
 		<!--TODO refactor these to indexer-elastic-rest plugin somehow, currently doesn't resolve correctly-->

--- a/src/plugin/publish-rabbitmq/ivy.xml
+++ b/src/plugin/publish-rabbitmq/ivy.xml
@@ -34,5 +34,5 @@
     <!--get the artifact from our module name-->
     <artifact conf="master"/>
   </publications>
-  
+
 </ivy-module>


### PR DESCRIPTION
Upgrade of core dependencies
- Hadoop 3.1.3 -> 3.3.3
- log4j 2.17.0 -> 2.17.2
- and some more

Note: I've observed that some unit tests are failing with same/similar errors than observed in NUTCH-2936. Eventually, this PR needs to be rebased on top of #733.