### PR TITLE
NUTCH-2963 Upgrade dependencies before release of 1.19

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -360,6 +360,7 @@ org.apache.cxf:cxf-rt-transports-http-jetty
 org.apache.cxf:cxf-rt-ws-addr
 org.apache.cxf:cxf-rt-ws-policy
 org.apache.cxf:cxf-rt-wsdl
+org.apache.geronimo.specs:geronimo-jta_1.1_spec
 org.apache.hadoop:hadoop-annotations
 org.apache.hadoop:hadoop-auth
 org.apache.hadoop:hadoop-common
@@ -679,8 +680,12 @@ Eclipse Distribution License v1.0
 
 com.sun.activation:jakarta.activation
 com.sun.istack:istack-commons-runtime
+com.sun.xml.messaging.saaj:saaj-impl
 jakarta.activation:jakarta.activation-api
+jakarta.jws:jakarta.jws-api
 jakarta.xml.bind:jakarta.xml.bind-api
+jakarta.xml.soap:jakarta.xml.soap-api
+jakarta.xml.ws:jakarta.xml.ws-api
 org.eclipse.rdf4j:rdf4j-http-client
 org.eclipse.rdf4j:rdf4j-http-protocol
 org.eclipse.rdf4j:rdf4j-model
@@ -717,6 +722,7 @@ org.eclipse.rdf4j:rdf4j-sail-memory
 org.eclipse.rdf4j:rdf4j-util
 org.glassfish.jaxb:jaxb-runtime
 org.glassfish.jaxb:txw2
+org.jvnet.staxex:stax-ex
 
 
 GNU General Public License, version 2 (GPL2), with the classpath exception

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -253,7 +253,6 @@ com.pff:java-libpst
 com.rabbitmq:amqp-client
 com.rometools:rome
 com.rometools:rome-utils
-com.squareup.okhttp:okhttp
 com.squareup.okhttp3:okhttp
 com.squareup.okhttp3:okhttp-brotli
 com.squareup.okio:okio
@@ -285,12 +284,33 @@ io.netty:netty
 io.netty:netty-all
 io.netty:netty-buffer
 io.netty:netty-codec
+io.netty:netty-codec-dns
+io.netty:netty-codec-haproxy
+io.netty:netty-codec-http
+io.netty:netty-codec-http2
+io.netty:netty-codec-memcache
+io.netty:netty-codec-mqtt
+io.netty:netty-codec-redis
+io.netty:netty-codec-smtp
+io.netty:netty-codec-socks
+io.netty:netty-codec-stomp
+io.netty:netty-codec-xml
 io.netty:netty-common
 io.netty:netty-handler
+io.netty:netty-handler-proxy
 io.netty:netty-resolver
+io.netty:netty-resolver-dns
+io.netty:netty-resolver-dns-classes-macos
+io.netty:netty-resolver-dns-native-macos
 io.netty:netty-transport
+io.netty:netty-transport-classes-epoll
+io.netty:netty-transport-classes-kqueue
 io.netty:netty-transport-native-epoll
+io.netty:netty-transport-native-kqueue
 io.netty:netty-transport-native-unix-common
+io.netty:netty-transport-rxtx
+io.netty:netty-transport-sctp
+io.netty:netty-transport-udt
 javax.inject:javax.inject
 joda-time:joda-time
 net.arnx:jsonic
@@ -451,7 +471,6 @@ org.codehaus.jackson:jackson-core-asl
 org.codehaus.jackson:jackson-jaxrs
 org.codehaus.jackson:jackson-mapper-asl
 org.codehaus.jackson:jackson-xc
-org.codehaus.woodstox:woodstox-core-asl
 org.eclipse.jetty:jetty-alpn-client
 org.eclipse.jetty:jetty-alpn-java-client
 org.eclipse.jetty:jetty-client
@@ -651,7 +670,6 @@ EPL 2.0
 
 jakarta.annotation:jakarta.annotation-api
 jakarta.ws.rs:jakarta.ws.rs-api
-javax.ws.rs:javax.ws.rs-api
 
 
 Eclipse Distribution License v1.0

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -408,12 +408,9 @@ ROME (http://rometools.github.io/rome/)
 rome-utils (http://rometools.github.io/rome-utils/)
 - license: The Apache Software License, Version 2.0
 
-# com.squareup.okhttp:okhttp
-OkHttp (https://square.github.io/okhttp/)
-- license: Apache 2.0
 # com.squareup.okhttp3:okhttp
 OkHttp (https://square.github.io/okhttp/)
-- license: Apache 2.0
+- license: The Apache Software License, Version 2.0
 # com.squareup.okhttp3:okhttp-brotli
 okhttp-brotli (https://square.github.io/okhttp/)
 - license: The Apache Software License, Version 2.0
@@ -459,6 +456,11 @@ jersey-guice
 JAXB RI (http://jaxb.java.net/)
 - license: CDDL 1.1
   (licenses-binary/LICENSE-cddl-1.1.txt)
+
+# com.sun.xml.messaging.saaj:saaj-impl
+Jakarta SOAP Implementation
+- license: Eclipse Distribution License - v 1.0
+  (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
 
 # com.tdunning:t-digest
 T-Digest (https://github.com/tdunning/t-digest)
@@ -526,6 +528,11 @@ Jakarta Annotations API (https://projects.eclipse.org/projects/ee4j.ca)
 - license: EPL 2.0
   (licenses-binary/LICENSE-epl-2.0.txt)
 
+# jakarta.jws:jakarta.jws-api
+Jakarta Web Services Metadata API (https://github.com/eclipse-ee4j/jws-api)
+- license: Eclipse Distribution License - v 1.0
+  (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
+
 # jakarta.ws.rs:jakarta.ws.rs-api
 jakarta.ws.rs-api (https://github.com/eclipse-ee4j/jaxrs-api)
 - license: EPL 2.0
@@ -533,6 +540,16 @@ jakarta.ws.rs-api (https://github.com/eclipse-ee4j/jaxrs-api)
 
 # jakarta.xml.bind:jakarta.xml.bind-api
 Jakarta XML Binding API
+- license: Eclipse Distribution License - v 1.0
+  (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
+
+# jakarta.xml.soap:jakarta.xml.soap-api
+Jakarta SOAP with Attachments API (https://github.com/eclipse-ee4j/saaj-api)
+- license: Eclipse Distribution License - v 1.0
+  (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
+
+# jakarta.xml.ws:jakarta.xml.ws-api
+Jakarta XML Web Services API (https://github.com/eclipse-ee4j/jax-ws-api)
 - license: Eclipse Distribution License - v 1.0
   (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
 
@@ -708,16 +725,9 @@ Animal Sniffer Annotations
   (licenses-binary/LICENSE-mit-license.txt)
 
 # org.codehaus.woodstox:stax2-api
-Stax2 API (http://wiki.fasterxml.com/WoodstoxStax2)
-- license: The BSD License
-  (licenses-binary/LICENSE-bsd-2-clause.txt)
-# org.codehaus.woodstox:stax2-api
 Stax2 API (http://github.com/FasterXML/stax2-api)
 - license: The BSD License
   (licenses-binary/LICENSE-bsd-2-clause.txt)
-# org.codehaus.woodstox:woodstox-core-asl
-Woodstox (http://woodstox.codehaus.org)
-- license: The Apache Software License, Version 2.0
 
 # org.codelibs:jhighlight
 JHighlight (https://github.com/codelibs/jhighlight)
@@ -733,9 +743,6 @@ Jetty :: ALPN :: JDK9 Client Implementation
 # org.eclipse.jetty:jetty-client
 Jetty :: Asynchronous HTTP Client (http://www.eclipse.org/jetty)
 - license: Apache Software License - Version 2.0
-# org.eclipse.jetty:jetty-client
-Jetty :: Asynchronous HTTP Client
-- license: Apache Software License - Version 2.0
 # org.eclipse.jetty:jetty-continuation
 Jetty :: Continuation
 - license: Apache Software License - Version 2.0
@@ -743,15 +750,9 @@ Jetty :: Continuation
 Jetty :: Http Utility (http://www.eclipse.org/jetty)
 - license: Apache Software License - Version 2.0
 # org.eclipse.jetty:jetty-http
-Jetty :: Http Utility
-- license: Apache Software License - Version 2.0
-# org.eclipse.jetty:jetty-io
 Jetty :: IO Utility (http://www.eclipse.org/jetty)
 - license: Apache Software License - Version 2.0
 # org.eclipse.jetty:jetty-io
-Jetty :: IO Utility
-- license: Apache Software License - Version 2.0
-# org.eclipse.jetty:jetty-security
 Jetty :: Security
 - license: Apache Software License - Version 2.0
 # org.eclipse.jetty:jetty-server
@@ -764,8 +765,6 @@ Jetty :: Servlet Handling
 Jetty :: Utilities (http://www.eclipse.org/jetty)
 - license: Apache Software License - Version 2.0
 # org.eclipse.jetty:jetty-util
-Jetty :: Utilities
-- license: Apache Software License - Version 2.0
 # org.eclipse.jetty:jetty-util-ajax
 Jetty :: Utilities :: Ajax(JSON)
 - license: Apache Software License - Version 2.0
@@ -955,16 +954,8 @@ Apache Tika plugin for Ogg, Vorbis and FLAC (https://github.com/Gagravarr/Vorbis
 JAXB Runtime (https://eclipse-ee4j.github.io/jaxb-ri/)
 - license: Eclipse Distribution License - v 1.0
   (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
-# org.glassfish.jaxb:jaxb-runtime
-JAXB Runtime
-- license: Eclipse Distribution License - v 1.0
-  (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
 # org.glassfish.jaxb:txw2
 TXW2 Runtime (https://eclipse-ee4j.github.io/jaxb-ri/)
-- license: Eclipse Distribution License - v 1.0
-  (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
-# org.glassfish.jaxb:txw2
-TXW2 Runtime
 - license: Eclipse Distribution License - v 1.0
   (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
 
@@ -1012,6 +1003,11 @@ JLine Bundle
 jsoup Java HTML Parser (https://jsoup.org/)
 - license: The MIT License
   (licenses-binary/LICENSE-mit-license.txt)
+
+# org.jvnet.staxex:stax-ex
+Extended StAX API
+- license: Eclipse Distribution License - v 1.0
+  (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
 
 # org.lz4:lz4-java
 LZ4 and xxHash (https://github.com/lz4/lz4-java)

--- a/build.xml
+++ b/build.xml
@@ -569,13 +569,13 @@
   <!-- target: resolve  ================================================= -->
   <target name="resolve-default" depends="clean-default-lib, init" description="--> resolve and retrieve dependencies with ivy">
     <ivy:resolve file="${ivy.file}" conf="default" log="download-only"/>
-    <ivy:retrieve pattern="${build.lib.dir}/[artifact]-[revision].[ext]" symlink="false" log="quiet"/>
+    <ivy:retrieve pattern="${build.lib.dir}/[artifact]-[revision](-[classifier]).[ext]" symlink="false" log="quiet"/>
     <antcall target="copy-libs"/>
   </target>
 
   <target name="resolve-test" depends="clean-test-lib, init" description="--> resolve and retrieve dependencies with ivy">
     <ivy:resolve file="${ivy.file}" conf="test" log="download-only"/>
-    <ivy:retrieve pattern="${test.build.lib.dir}/[artifact]-[revision].[ext]" symlink="false" log="quiet"/>
+    <ivy:retrieve pattern="${test.build.lib.dir}/[artifact]-[revision](-[classifier]).[ext]" symlink="false" log="quiet"/>
     <antcall target="copy-libs"/>
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -37,7 +37,7 @@
   <property name="maven-javadoc-jar" value="${release.dir}/${artifactId}-${version}-javadoc.jar" />
   <property name="maven-sources-jar" value="${release.dir}/${artifactId}-${version}-sources.jar" />
 
-  <property name="dependency-check-ant.version" value="6.1.0" />
+  <property name="dependency-check-ant.version" value="7.1.1" />
   <property name="dependency-check-ant.home" value="${ivy.dir}/dependency-check-ant" />
   <property name="dependency-check-ant.jar" value="${dependency-check-ant.home}/dependency-check-ant.jar" />
 

--- a/build.xml
+++ b/build.xml
@@ -305,73 +305,61 @@
     </jar>
   </target>
 
-  <!-- ================================================================== -->
-  <!-- Deploy to Apache Nexus                                             -->
-  <!-- ================================================================== -->
-  <!--                                                                    -->
-  <!-- ================================================================== -->
-  <target name="deploy" depends="release" description="--> deploy to Apache Nexus">
-
-  <!-- generate a pom file -->
-  <ivy:makepom ivyfile="${ivy.file}" pomfile="${basedir}/pom.xml" templatefile="ivy/mvn.template">
-     <mapping conf="default" scope="compile"/>
-     <mapping conf="runtime" scope="runtime"/>
-  </ivy:makepom>
-
-  <!-- sign and deploy the main artifact -->
-  <artifact:mvn mavenHome="${env.MVN_HOME}" fork="true" failonerror="true">
-    <jvmarg value="-Dmaven.multiModuleProjectDirectory=false" />
-    <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.6:sign-and-deploy-file" />
-    <arg value="-Durl=${maven-repository-url}" />
-    <arg value="-DrepositoryId=${maven-repository-id}" />
-    <arg value="-DpomFile=pom.xml" />
-    <arg value="-Dfile=${maven-jar}" />
-    <arg value="-Papache-release" />
-  </artifact:mvn>
-
-  <!-- sign and deploy the sources artifact -->
-  <artifact:mvn mavenHome="${env.MVN_HOME}" fork="true" failonerror="true">
-    <jvmarg value="-Dmaven.multiModuleProjectDirectory=false" />
-    <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.6:sign-and-deploy-file" />
-    <arg value="-Durl=${maven-repository-url}" />
-    <arg value="-DrepositoryId=${maven-repository-id}" />
-    <arg value="-DpomFile=pom.xml" />
-    <arg value="-Dfile=${maven-sources-jar}" />
-    <arg value="-Dclassifier=sources" />
-    <arg value="-Papache-release" />
-  </artifact:mvn>
-
-  <!-- sign and deploy the javadoc artifact -->
-  <artifact:mvn mavenHome="${env.MVN_HOME}" fork="true" failonerror="true">
-    <jvmarg value="-Dmaven.multiModuleProjectDirectory=false" />
-    <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.6:sign-and-deploy-file" />
-    <arg value="-Durl=${maven-repository-url}" />
-    <arg value="-DrepositoryId=${maven-repository-id}" />
-    <arg value="-DpomFile=pom.xml" />
-    <arg value="-Dfile=${maven-javadoc-jar}" />
-    <arg value="-Dclassifier=javadoc" />
-    <arg value="-Papache-release" />
-  </artifact:mvn>
-  </target>
-
-  <!-- ================================================================== -->
-  <!-- Generate REST API Documentation with Miredot                       -->
-  <!-- ================================================================== -->
-  <target name="restdocs" description="--> generate REST API Documentation with Miredot">
-
+  <target name="makepom" depends="" description="--> generate pom file for deployment">
     <!-- generate a pom file -->
     <ivy:makepom ivyfile="${ivy.file}" pomfile="${basedir}/pom.xml" templatefile="ivy/mvn.template">
       <mapping conf="default" scope="compile"/>
       <mapping conf="runtime" scope="runtime"/>
     </ivy:makepom>
+  </target>
 
-    <!--artifact:dependencies pathId="dependency.classpath">
-      <dependency groupId="log4j" artifactId="log4j" version="1.2.15" >
-        <exclusion groupId="javax.jms" artifactId="jms" />
-        <exclusion groupId="com.sun.jdmk" artifactId="jmxtools" />
-        <exclusion groupId="com.sun.jmx" artifactId="jmxri" />
-      </dependency>
-    </artifact:dependencies-->
+  <!-- ================================================================== -->
+  <!-- Deploy to Apache Nexus                                             -->
+  <!-- ================================================================== -->
+  <!--                                                                    -->
+  <!-- ================================================================== -->
+  <target name="deploy" depends="release, makepom" description="--> deploy to Apache Nexus">
+
+    <!-- sign and deploy the main artifact -->
+    <artifact:mvn mavenHome="${env.MVN_HOME}" fork="true" failonerror="true">
+      <jvmarg value="-Dmaven.multiModuleProjectDirectory=false" />
+      <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.6:sign-and-deploy-file" />
+      <arg value="-Durl=${maven-repository-url}" />
+      <arg value="-DrepositoryId=${maven-repository-id}" />
+      <arg value="-DpomFile=pom.xml" />
+      <arg value="-Dfile=${maven-jar}" />
+      <arg value="-Papache-release" />
+    </artifact:mvn>
+
+    <!-- sign and deploy the sources artifact -->
+    <artifact:mvn mavenHome="${env.MVN_HOME}" fork="true" failonerror="true">
+      <jvmarg value="-Dmaven.multiModuleProjectDirectory=false" />
+      <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.6:sign-and-deploy-file" />
+      <arg value="-Durl=${maven-repository-url}" />
+      <arg value="-DrepositoryId=${maven-repository-id}" />
+      <arg value="-DpomFile=pom.xml" />
+      <arg value="-Dfile=${maven-sources-jar}" />
+      <arg value="-Dclassifier=sources" />
+      <arg value="-Papache-release" />
+    </artifact:mvn>
+
+    <!-- sign and deploy the javadoc artifact -->
+    <artifact:mvn mavenHome="${env.MVN_HOME}" fork="true" failonerror="true">
+      <jvmarg value="-Dmaven.multiModuleProjectDirectory=false" />
+      <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.6:sign-and-deploy-file" />
+      <arg value="-Durl=${maven-repository-url}" />
+      <arg value="-DrepositoryId=${maven-repository-id}" />
+      <arg value="-DpomFile=pom.xml" />
+      <arg value="-Dfile=${maven-javadoc-jar}" />
+      <arg value="-Dclassifier=javadoc" />
+      <arg value="-Papache-release" />
+    </artifact:mvn>
+  </target>
+
+  <!-- ================================================================== -->
+  <!-- Generate REST API Documentation with Miredot                       -->
+  <!-- ================================================================== -->
+  <target name="restdocs" depends="makepom" description="--> generate REST API Documentation with Miredot">
 
     <artifact:mvn mavenHome="${env.MVN_HOME}" fork="true" failonerror="true">
       <jvmarg value="-Dmaven.multiModuleProjectDirectory=false" />

--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -36,9 +36,9 @@
 	</publications>
 
 	<dependencies>
-		<dependency org="org.apache.logging.log4j" name="log4j-api" rev="2.17.2" conf="*->master" />
-		<dependency org="org.apache.logging.log4j" name="log4j-core" rev="2.17.2" conf="*->master" />
-		<dependency org="org.apache.logging.log4j" name="log4j-slf4j-impl" rev="2.17.2" conf="*->master" />
+		<dependency org="org.apache.logging.log4j" name="log4j-api" rev="2.18.0" conf="*->master" />
+		<dependency org="org.apache.logging.log4j" name="log4j-core" rev="2.18.0" conf="*->master" />
+		<dependency org="org.apache.logging.log4j" name="log4j-slf4j-impl" rev="2.18.0" conf="*->master" />
 		<dependency org="org.slf4j" name="slf4j-api" rev="1.7.36" conf="*->master" />
 
 		<dependency org="org.apache.commons" name="commons-lang3" rev="3.12.0" conf="*->default" />
@@ -46,8 +46,8 @@
 		<dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.13" conf="*->master" />
 		<dependency org="commons-codec" name="commons-codec" rev="1.15" conf="*->default" />
 		<dependency org="org.apache.commons" name="commons-compress" rev="1.21" conf="*->default" />
-		<dependency org="org.apache.commons" name="commons-jexl3" rev="3.1" conf="*->default" />
-		<dependency org="com.tdunning" name="t-digest" rev="3.2" />
+		<dependency org="org.apache.commons" name="commons-jexl3" rev="3.2.1" conf="*->default" />
+		<dependency org="com.tdunning" name="t-digest" rev="3.3" />
 
 		<!-- Hadoop Dependencies -->
 		<dependency org="org.apache.hadoop" name="hadoop-common" rev="3.3.4" conf="*->default">
@@ -74,16 +74,16 @@
 
 		<dependency org="com.github.crawler-commons" name="crawler-commons" rev="1.3" />
 
-		<dependency org="com.google.code.gson" name="gson" rev="2.9.0"/>
+		<dependency org="com.google.code.gson" name="gson" rev="2.9.1"/>
 		<dependency org="com.martinkl.warc" name="warc-hadoop" rev="0.1.0">
 			<exclude module="hadoop-client" />
 		</dependency>
 
-		<dependency org="org.apache.cxf" name="cxf-rt-frontend-jaxws" rev="3.4.1" conf="*->default" />
-		<dependency org="org.apache.cxf" name="cxf-rt-frontend-jaxrs" rev="3.4.1" conf="*->default" />
-		<dependency org="org.apache.cxf" name="cxf-rt-transports-http" rev="3.4.1" conf="*->default" />
-		<dependency org="org.apache.cxf" name="cxf-rt-transports-http-jetty" rev="3.4.1" conf="*->default" />
-		<dependency org="org.apache.cxf" name="cxf-rt-rs-client" rev="3.4.1" conf="test->default" />
+		<dependency org="org.apache.cxf" name="cxf-rt-frontend-jaxws" rev="3.5.3" conf="*->default" />
+		<dependency org="org.apache.cxf" name="cxf-rt-frontend-jaxrs" rev="3.5.3" conf="*->default" />
+		<dependency org="org.apache.cxf" name="cxf-rt-transports-http" rev="3.5.3" conf="*->default" />
+		<dependency org="org.apache.cxf" name="cxf-rt-transports-http-jetty" rev="3.5.3" conf="*->default" />
+		<dependency org="org.apache.cxf" name="cxf-rt-rs-client" rev="3.5.3" conf="test->default" />
 		<dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.13.3" conf="*->default" />
 		<dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.13.3" conf="*->default" />
 		<dependency org="com.fasterxml.jackson.dataformat" name="jackson-dataformat-cbor" rev="2.13.3" conf="*->default" />
@@ -117,7 +117,7 @@
 
 		<!--Added Because of Elasticsearch JEST client-->
 		<!--TODO refactor these to indexer-elastic-rest plugin somehow, currently doesn't resolve correctly-->
-		<dependency org="org.apache.httpcomponents" name="httpcore-nio" rev="4.4.9" />
+		<dependency org="org.apache.httpcomponents" name="httpcore-nio" rev="4.4.14" />
 		<dependency org="org.apache.httpcomponents" name="httpcore" rev="4.4.14" />
 
 		<dependency org="de.vandermeer" name="asciitable" rev="0.3.2" />

--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -50,7 +50,7 @@
 		<dependency org="com.tdunning" name="t-digest" rev="3.2" />
 
 		<!-- Hadoop Dependencies -->
-		<dependency org="org.apache.hadoop" name="hadoop-common" rev="3.3.3" conf="*->default">
+		<dependency org="org.apache.hadoop" name="hadoop-common" rev="3.3.4" conf="*->default">
 			<exclude org="hsqldb" name="hsqldb" />
 			<exclude org="net.sf.kosmosfs" name="kfs" />
 			<exclude org="net.java.dev.jets3t" name="jets3t" />
@@ -58,9 +58,9 @@
 			<exclude org="org.mortbay.jetty" name="jsp-*" />
 			<exclude org="ant" name="ant" />
 		</dependency>
-		<dependency org="org.apache.hadoop" name="hadoop-hdfs" rev="3.3.3" conf="*->default" />
-		<dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-core" rev="3.3.3" conf="*->default" />
-		<dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-jobclient" rev="3.3.3" conf="*->default" />
+		<dependency org="org.apache.hadoop" name="hadoop-hdfs" rev="3.3.4" conf="*->default" />
+		<dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-core" rev="3.3.4" conf="*->default" />
+		<dependency org="org.apache.hadoop" name="hadoop-mapreduce-client-jobclient" rev="3.3.4" conf="*->default" />
 		<!-- End of Hadoop Dependencies -->
 
 		<dependency org="org.apache.tika" name="tika-core" rev="2.3.0" />

--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -115,13 +115,10 @@
 		<dependency org="org.mortbay.jetty" name="jetty-client" rev="6.1.26" conf="test->default" />
 		<dependency org="org.mortbay.jetty" name="jetty" rev="6.1.26" conf="test->default" />
 
-		<dependency org="org.apache.commons" name="commons-collections4" rev="4.1" conf="*->default" />
-
 		<!--Added Because of Elasticsearch JEST client-->
 		<!--TODO refactor these to indexer-elastic-rest plugin somehow, currently doesn't resolve correctly-->
 		<dependency org="org.apache.httpcomponents" name="httpcore-nio" rev="4.4.9" />
 		<dependency org="org.apache.httpcomponents" name="httpcore" rev="4.4.14" />
-		<dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.5" />
 
 		<dependency org="de.vandermeer" name="asciitable" rev="0.3.2" />
 

--- a/src/plugin/indexer-solr/ivy.xml
+++ b/src/plugin/indexer-solr/ivy.xml
@@ -32,16 +32,23 @@
 
 	<dependencies>
 		<dependency org="org.apache.solr" name="solr-solrj"
-			rev="8.5.1">
+			          rev="8.11.2" conf="*->default">
 			<!-- exclusions of dependencies provided by Nutch core -->
-			<exclude org="org.apache.commons" name="commons-codec" />
-			<exclude org="org.apache.commons" name="commons-logging" />
+			<exclude org="commons-codec" name="commons-codec" />
+			<exclude org="commons-logging" name="commons-logging" />
 			<exclude org="org.slf4j" name="slf4j-api" />
 		</dependency>
 		<dependency org="org.apache.httpcomponents" name="httpmime"
-			rev="4.5.10" conf="*->default" />
+			          rev="4.5.13" conf="*->default">
+			<!-- exclusions of dependencies provided by Nutch core -->
+			<exclude org="commons-codec" name="commons-codec" />
+			<exclude org="commons-logging" name="commons-logging" />
+		</dependency>
 		<dependency org="org.apache.httpcomponents" name="httpcore"
-			rev="4.4.12" conf="*->default" />
+			          rev="4.4.15" conf="*->default">
+			<!-- exclusions of dependencies provided by Nutch core -->
+			<exclude org="commons-logging" name="commons-logging" />
+		</dependency>
 	</dependencies>
 
 </ivy-module>

--- a/src/plugin/indexer-solr/plugin.xml
+++ b/src/plugin/indexer-solr/plugin.xml
@@ -17,38 +17,38 @@
 			<export name="*" />
 		</library>
 		<!-- Solr dependencies -->
-		<library name="commons-io-2.6.jar" />
-		<library name="netty-buffer-4.1.29.Final.jar" />
-		<library name="netty-codec-4.1.29.Final.jar" />
-		<library name="netty-common-4.1.29.Final.jar" />
-		<library name="netty-handler-4.1.29.Final.jar" />
-		<library name="netty-resolver-4.1.29.Final.jar" />
-		<library name="netty-transport-4.1.29.Final.jar" />
-		<library name="netty-transport-native-epoll-4.1.29.Final.jar" />
-		<library
-			name="netty-transport-native-unix-common-4.1.29.Final.jar" />
-		<library name="commons-math3-3.6.1.jar" />
-		<library name="httpmime-4.5.10.jar" />
-		<library name="httpclient-4.5.10.jar" />
-		<library name="httpcore-4.4.12.jar" />
-		<library name="zookeeper-3.5.5.jar" />
-		<library name="zookeeper-jute-3.5.5.jar" />
-		<library name="stax2-api-3.1.4.jar" />
-		<library name="woodstox-core-asl-4.4.1.jar" />
-		<library name="jetty-alpn-client-9.4.24.v20191120.jar" />
-		<library name="jetty-alpn-java-client-9.4.24.v20191120.jar" />
-		<library name="jetty-client-9.4.24.v20191120.jar" />
-		<library name="jetty-http-9.4.24.v20191120.jar" />
-		<library name="jetty-io-9.4.24.v20191120.jar" />
-		<library name="jetty-util-9.4.24.v20191120.jar" />
-		<library name="http2-client-9.4.24.v20191120.jar" />
-		<library name="http2-common-9.4.24.v20191120.jar" />
-		<library name="http2-hpack-9.4.24.v20191120.jar" />
-		<library
-			name="http2-http-client-transport-9.4.24.v20191120.jar" />
-		<library name="jcl-over-slf4j-1.7.24.jar" />
+		<library name="commons-io-2.8.0.jar"/>
+		<library name="commons-lang-2.6.jar"/>
+		<library name="commons-math3-3.6.1.jar"/>
+		<library name="http2-client-9.4.44.v20210927.jar"/>
+		<library name="http2-common-9.4.44.v20210927.jar"/>
+		<library name="http2-hpack-9.4.44.v20210927.jar"/>
+		<library name="http2-http-client-transport-9.4.44.v20210927.jar"/>
+		<library name="httpclient-4.5.13.jar"/>
+		<library name="httpcore-4.4.15.jar"/>
+		<library name="httpmime-4.5.13.jar"/>
+		<library name="jcl-over-slf4j-1.7.24.jar"/>
+		<library name="jetty-alpn-client-9.4.44.v20210927.jar"/>
+		<library name="jetty-alpn-java-client-9.4.44.v20210927.jar"/>
+		<library name="jetty-client-9.4.44.v20210927.jar"/>
+		<library name="jetty-http-9.4.44.v20210927.jar"/>
+		<library name="jetty-io-9.4.44.v20210927.jar"/>
+		<library name="jetty-util-9.4.44.v20210927.jar"/>
+		<library name="netty-buffer-4.1.68.Final.jar"/>
+		<library name="netty-codec-4.1.68.Final.jar"/>
+		<library name="netty-common-4.1.68.Final.jar"/>
+		<library name="netty-handler-4.1.68.Final.jar"/>
+		<library name="netty-resolver-4.1.68.Final.jar"/>
+		<library name="netty-transport-4.1.68.Final.jar"/>
+		<library name="netty-transport-native-epoll-4.1.68.Final.jar"/>
+		<library name="netty-transport-native-unix-common-4.1.68.Final.jar"/>
+		<library name="snappy-java-1.1.7.6.jar"/>
+		<library name="solr-solrj-8.11.2.jar"/>
+		<library name="stax2-api-4.2.1.jar"/>
+		<library name="woodstox-core-6.2.4.jar"/>
+		<library name="zookeeper-3.6.2.jar"/>
+		<library name="zookeeper-jute-3.6.2.jar"/>
 		<!-- end of Solr dependencies -->
-		<library name="solr-solrj-8.5.1.jar" />
 	</runtime>
 
 	<requires>

--- a/src/plugin/urlfilter-automaton/ivy.xml
+++ b/src/plugin/urlfilter-automaton/ivy.xml
@@ -36,7 +36,7 @@
   </publications>
 
   <dependencies>
-    <dependency org="dk.brics" name="automaton" rev="1.12-1" conf="*->default" />
+    <dependency org="dk.brics" name="automaton" rev="1.12-4" conf="*->default" />
   </dependencies>
   
 </ivy-module>

--- a/src/plugin/urlfilter-automaton/plugin.xml
+++ b/src/plugin/urlfilter-automaton/plugin.xml
@@ -25,7 +25,7 @@
       <library name="urlfilter-automaton.jar">
          <export name="*"/>
       </library>
-      <library name="automaton-1.12-1.jar"/>
+      <library name="automaton-1.12-4.jar"/>
    </runtime>
 
    <requires>


### PR DESCRIPTION
- upgrade Hadoop 3.3.3 -> 3.3.4
- adapt ivy retrieve pattern to optionally include the `classifier`
  (used in Hadoop deps to differentiate between architecture: x86_64 vs. aarch_64)
- upgrade Nutch core dependencies
   httpcore-nio 4.4.9 -> 4.4.14
   cxf 2.9.0 -> 2.9.1
   commons-jexl3 3.2.1 -> 3.3
   log4j 2.17.2 -> 2.18.0
   t-digest 3.2 -> 3.3
- upgrade indexer-solr dependencies:
  - Solr 8.5.1 -> 8.11.2
  - httpmime 4.5.10 -> 4.5.13
  - httpcore 4.4.12 -> 4.4.15
- upgrade urlfilter-automaton to depend on dk.brics automaton 1.12-4
- upgrade dependency-check ant plugin

NUTCH-2843 Duplicate declaration of dependencies in ivy.xml
- remove duplicated dependencies: commons-collections4 and httpclient
- move Maven POM creation into separate target to reproduce issue