### PR TITLE
NUTCH-2974 Ant build fails with "Unparseable date" on certain platforms

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -102,7 +102,12 @@
     <mkdir dir="${test.build.classes}"/>
     <mkdir dir="${test.build.lib.dir}"/>
 
-    <touch datetime="01/25/1971 2:00 pm">
+    <touch millis="33660000000">
+      <!-- touch templates back in time to ensure that
+           custom-configured configuration files are never overwritten
+           even if the template was updated. Use millis instead of
+           datetime="01/25/1971 2:00:00 pm" to avoid issues with
+           non-English locales -->
       <fileset dir="${conf.dir}" includes="**/*.template"/>
     </touch>
 


### PR DESCRIPTION
- [touch](https://ant.apache.org/manual/Tasks/touch.html) using epoche millis instead of datetime to specify the touch time
- add comment to explain why configuration templates are touched back in time