### PR TITLE
NUTCH-2982 Generator: parameter for URL normalization not passed forward

### DIFF
--- a/src/java/org/apache/nutch/crawl/Generator.java
+++ b/src/java/org/apache/nutch/crawl/Generator.java
@@ -750,7 +750,7 @@ public class Generator extends NutchTool implements Tool {
    * @param curTime
    *          Current time in milliseconds
    * @param filter whether to apply filtering operation
-   * @param norm whether to apply normilization operation
+   * @param norm whether to apply normalization operation
    * @param force if true, and the target lockfile exists, consider it valid. If false
    *          and the target file exists, throw an IOException.
    * @param maxNumSegments maximum number of segments to generate
@@ -768,8 +768,8 @@ public class Generator extends NutchTool implements Tool {
       long curTime, boolean filter, boolean norm, boolean force,
       int maxNumSegments, String expr)
       throws IOException, InterruptedException, ClassNotFoundException {
-    return generate(dbDir, segments, numLists, topN, curTime, filter, true,
-        force, 1, expr, null);
+    return generate(dbDir, segments, numLists, topN, curTime, filter, norm,
+        force, maxNumSegments, expr, null);
   }
 
   /**
@@ -789,7 +789,7 @@ public class Generator extends NutchTool implements Tool {
    * @param curTime
    *          Current time in milliseconds
    * @param filter whether to apply filtering operation
-   * @param norm whether to apply normilization operation
+   * @param norm whether to apply normalization operation
    * @param force if true, and the target lockfile exists, consider it valid. If false
    *          and the target file exists, throw an IOException.
    * @param maxNumSegments maximum number of segments to generate


### PR DESCRIPTION
- pass forward params `norm` and `maxNumSegments`
- fix typos in Javadoc