### PR TITLE
NUTCH-2991 Support HTTP/S Header Authorization for Solr connections

### DIFF
--- a/conf/index-writers.xml.template
+++ b/conf/index-writers.xml.template
@@ -29,6 +29,16 @@
       <param name="auth" value="false"/>
       <param name="username" value="username"/>
       <param name="password" value="password"/>
+      <!-- Name for Authorization HTTP header
+           <param name="auth.header.name" value="Bearer"/>
+           HTTP header -> Authorization: Bearer 1234567890
+      -->
+      <param name="auth.header.name" value=""/>
+      <!-- Value for Authorization HTTP header
+           <param name="auth.header.value" value="1234567890"/>
+           HTTP header -> Authorization: Bearer 1234567890
+      -->
+      <param name="auth.header.value" value=""/>
     </parameters>
     <mapping>
       <copy>

--- a/src/plugin/indexer-solr/src/java/org/apache/nutch/indexwriter/solr/SolrConstants.java
+++ b/src/plugin/indexer-solr/src/java/org/apache/nutch/indexwriter/solr/SolrConstants.java
@@ -34,4 +34,8 @@ public interface SolrConstants {
 
   String PASSWORD = "password";
 
+  String AUTH_HEADER_NAME = "auth.header.name";
+
+  String AUTH_HEADER_VALUE = "auth.header.value";
+
 }

--- a/src/plugin/indexer-solr/src/java/org/apache/nutch/indexwriter/solr/SolrUtils.java
+++ b/src/plugin/indexer-solr/src/java/org/apache/nutch/indexwriter/solr/SolrUtils.java
@@ -22,10 +22,12 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHeader;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class SolrUtils {
@@ -39,7 +41,7 @@ public class SolrUtils {
 
   static CloudSolrClient getCloudSolrClient(List<String> urls, String username,
       String password) {
-    // Building http client
+    // Building HTTP client
     CredentialsProvider provider = new BasicCredentialsProvider();
     UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(
         username, password);
@@ -55,8 +57,98 @@ public class SolrUtils {
     return sc;
   }
 
+  /**
+   * Creates a new SolrClient, passing an Authorization header on the requests'
+   * HTTP Header:
+   * 
+   * <pre>
+   * Authorization: headerName headerValue
+   * </pre>
+   * 
+   * ie.
+   * 
+   * <pre>
+   * Authorization: Bearer XXXXXXXXXXX
+   * </pre>
+   * 
+   * @param url
+   *          Sorl URL
+   * @param headerName
+   *          Header name send on the Authorization: Bearer, Token, etc.
+   * @param headerValue
+   *          Header value send on the Authorization: JWT_TOKEN
+   * @return CloudSolrClient
+   */
+  static CloudSolrClient getCloudSolrClientHeaderAuthorization(
+      List<String> urls, String headerName, String headerValue) {
+    // Building http client
+    HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+    httpClientBuilder.setDefaultHeaders(Arrays.asList(
+        new BasicHeader("Authorization", headerName + " " + headerValue)));
+    // Building the client
+    CloudSolrClient sc = new CloudSolrClient.Builder(urls)
+        .withParallelUpdates(true).withHttpClient(httpClientBuilder.build())
+        .build();
+    sc.connect();
+    return sc;
+  }
+
   static SolrClient getHttpSolrClient(String url) {
     return new HttpSolrClient.Builder(url).build();
+  }
+
+  /**
+   * Creates a new SolrClient, passing an Authorization header on the requests'
+   * HTTP Header:
+   * 
+   * <pre>
+   * Authorization: headerName headerValue
+   * </pre>
+   * 
+   * ie.
+   * 
+   * <pre>
+   * Authorization: Bearer XXXXXXXXXXX
+   * </pre>
+   * 
+   * @param url
+   *          Solr URL
+   * @param headerName
+   *          Header name send on the Authorization: Bearer, Token, etc.
+   * @param headerValue
+   *          Header value send on the Authorization: JWT_TOKEN
+   * @return SolrClient
+   */
+  static SolrClient getHttpSolrClientHeaderAuthorization(String url,
+      String headerName, String headerValue) {
+    HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+    httpClientBuilder.setDefaultHeaders(Arrays.asList(
+        new BasicHeader("Authorization", headerName + " " + headerValue)));
+    return new HttpSolrClient.Builder(url)
+        .withHttpClient(httpClientBuilder.build()).build();
+  }
+
+  /**
+   * Creates a new SolrClient, using Basic Authentication.
+   * 
+   * @param url
+   *          Solr URL
+   * @param username
+   *          Username
+   * @param password
+   *          Password
+   * @return SolrClient
+   */
+  static SolrClient getHttpSolrClient(String url, String username,
+      String password) {
+    CredentialsProvider provider = new BasicCredentialsProvider();
+    UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(
+        username, password);
+    provider.setCredentials(AuthScope.ANY, credentials);
+    HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+    httpClientBuilder.setDefaultCredentialsProvider(provider);
+    return new HttpSolrClient.Builder(url)
+        .withHttpClient(httpClientBuilder.build()).build();
   }
 
   static String stripNonCharCodepoints(String input) {


### PR DESCRIPTION
(patch contributed by Marcos Gomez)

- adds params auth.header.name and auth.header.value for JWT Authentication with Bearer Tokens sent via the HTTP Authorization header