### PR TITLE
NUTCH-2897 Do not supress deprecated API warnings

### DIFF
--- a/src/java/org/apache/nutch/plugin/Plugin.java
+++ b/src/java/org/apache/nutch/plugin/Plugin.java
@@ -90,9 +90,7 @@ public class Plugin {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
   protected void finalize() throws Throwable {
-    super.finalize();
     shutDown();
   }
 }

--- a/src/java/org/apache/nutch/util/NutchJob.java
+++ b/src/java/org/apache/nutch/util/NutchJob.java
@@ -35,7 +35,18 @@ public class NutchJob extends Job {
 
   private static final String JOB_FAILURE_LOG_FORMAT = "%s job did not succeed, job id: %s, job status: %s, reason: %s";
 
-  @SuppressWarnings("deprecation")
+  /**
+   * @deprecated, use instead {@link #getInstance(Configuration)} or
+   * {@link Job#getInstance(Configuration, String)}.
+   * 
+   * @param conf
+   *          configuration for the job
+   * @param jobName
+   *          name of the job
+   * @throws IOException
+   *           see {@link Job#Job(Configuration, String)}
+   */
+  @Deprecated
   public NutchJob(Configuration conf, String jobName) throws IOException {
     super(conf, jobName);
     if (conf != null) {


### PR DESCRIPTION
- deprecate constructor of NutchJob
- remove deprocated call to Object.finalize() from Plugin.finalize()