### PR TITLE
NUTCH-3020 -- ParseSegment should check for okhttp's truncation flag

### DIFF
--- a/src/java/org/apache/nutch/parse/ParseSegment.java
+++ b/src/java/org/apache/nutch/parse/ParseSegment.java
@@ -182,8 +182,14 @@ public class ParseSegment extends NutchTool implements Tool {
       return false;
 
     //check for okhttp or other protocol's truncated flag
-    if ("true".equals(metadata.get(Response.TRUNCATED_CONTENT))) {
-      return true;
+    //if the flag is there, no matter the value, trust it.
+    if (metadata.get(Response.TRUNCATED_CONTENT) != null) {
+      if ("true".equals(metadata.get(Response.TRUNCATED_CONTENT))) {
+        LOG.info(content.getUrl() + " skipped. Protocol metadata indicates truncated content, " +
+                "actualSize= " + content.getContent().length);
+        return true;
+      }
+      return false;
     }
 
     String lengthStr = metadata.get(Response.CONTENT_LENGTH);

--- a/src/java/org/apache/nutch/parse/ParseSegment.java
+++ b/src/java/org/apache/nutch/parse/ParseSegment.java
@@ -181,6 +181,11 @@ public class ParseSegment extends NutchTool implements Tool {
     if (metadata == null)
       return false;
 
+    //check for okhttp's truncated flag
+    if ("true".equals(metadata.get("http.content.truncated"))) {
+      return true;
+    }
+
     String lengthStr = metadata.get(Response.CONTENT_LENGTH);
     if (lengthStr != null)
       lengthStr = lengthStr.trim();

--- a/src/java/org/apache/nutch/parse/ParseSegment.java
+++ b/src/java/org/apache/nutch/parse/ParseSegment.java
@@ -181,8 +181,8 @@ public class ParseSegment extends NutchTool implements Tool {
     if (metadata == null)
       return false;
 
-    //check for okhttp's truncated flag
-    if ("true".equals(metadata.get("http.content.truncated"))) {
+    //check for okhttp or other protocol's truncated flag
+    if ("true".equals(metadata.get(Response.TRUNCATED_CONTENT))) {
       return true;
     }
 

--- a/src/test/org/apache/nutch/parse/TestParseSegment.java
+++ b/src/test/org/apache/nutch/parse/TestParseSegment.java
@@ -45,7 +45,7 @@ public class TestParseSegment {
     //test that truncated_content does override length field
     metadata = new Metadata();
     metadata.set(Response.TRUNCATED_CONTENT, "false");
-    metadata.set(Response.CONTENT_LENGTH, Integer.toString(BYTES.length - 10));
+    metadata.set(Response.CONTENT_LENGTH, Integer.toString(BYTES.length + 10));
     assertFalse(ParseSegment.isTruncated(content));
 
     //test that truncated_content does override length field

--- a/src/test/org/apache/nutch/parse/TestParseSegment.java
+++ b/src/test/org/apache/nutch/parse/TestParseSegment.java
@@ -24,8 +24,6 @@ import java.nio.charset.StandardCharsets;
 import org.apache.nutch.metadata.Metadata;
 import org.apache.nutch.net.protocols.Response;
 import org.apache.nutch.protocol.Content;
-import org.apache.nutch.util.WritableTestUtils;
-import org.bouncycastle.jcajce.provider.symmetric.IDEA;
 import org.junit.Test;
 
 public class TestParseSegment {

--- a/src/test/org/apache/nutch/parse/TestParseSegment.java
+++ b/src/test/org/apache/nutch/parse/TestParseSegment.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nutch.parse;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.nutch.metadata.Metadata;
+import org.apache.nutch.net.protocols.Response;
+import org.apache.nutch.protocol.Content;
+import org.apache.nutch.util.WritableTestUtils;
+import org.bouncycastle.jcajce.provider.symmetric.IDEA;
+import org.junit.Test;
+
+public class TestParseSegment {
+
+  @Test
+  public void testMetadataFlag() throws Exception {
+    Content content = new Content();
+    Metadata metadata = new Metadata();
+    metadata.set(Response.TRUNCATED_CONTENT, "true");
+    content.setMetadata(metadata);
+    content.setContent("the quick brown fox".getBytes(StandardCharsets.UTF_8));
+    assertTrue(ParseSegment.isTruncated(content));
+  }
+
+  @Test
+  public void testLength() throws Exception {
+    byte[] bytes = "the quick brown fox".getBytes(StandardCharsets.UTF_8);
+    Content content = new Content();
+    Metadata metadata = new Metadata();
+    metadata.set(Response.CONTENT_LENGTH, Integer.toString(bytes.length));
+    content.setMetadata(metadata);
+    content.setContent(bytes);
+    assertFalse(ParseSegment.isTruncated(content));
+
+    metadata.set(Response.CONTENT_LENGTH, Integer.toString(bytes.length * 2));
+    assertTrue(ParseSegment.isTruncated(content));
+  }
+}


### PR DESCRIPTION
Thanks for your contribution to [Apache Nutch](https://nutch.apache.org/)! Your help is appreciated!

Before opening the pull request, please verify that
* there is an open issue on the [Nutch issue tracker](https://issues.apache.org/jira/projects/NUTCH) which describes the problem or the improvement. We cannot accept pull requests without an issue because the change wouldn't be listed in the release notes.
* the issue ID (`NUTCH-XXXX`)
  - is referenced in the title of the pull request
  - and placed in front of your commit messages surrounded by square brackets (`[NUTCH-XXXX] Issue or pull request title`)
* commits are squashed into a single one (or few commits for larger changes)
* Java source code follows [Nutch Eclipse Code Formatting rules](https://github.com/apache/nutch/blob/master/eclipse-codeformat.xml)
* Nutch is successfully built and unit tests pass by running `ant clean runtime test`
* there should be no conflicts when merging the pull request branch into the *recent* master branch. If there are conflicts, please try to rebase the pull request branch on top of a freshly pulled master branch.
* if new dependencies are added,
  - are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
  - are `LICENSE-binary` and `NOTICE-binary` updated accordingly?

We will be able to faster integrate your pull request if these conditions are met. If you have any questions how to fix your problem or about using Nutch in general, please sign up for the [Nutch mailing list](https://nutch.apache.org/mailing_lists.html). Thanks!
