### PR TITLE
[NUTCH-3025] urlfilter-fast to filter based on the length of the URL

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1877,6 +1877,30 @@ CAUTION: Set the parser.timeout to -1 or a bigger value than 30, when using this
 </property>
 
 <property>
+  <name>urlfilter.fast.url.max.length</name>
+  <value>-1</value>
+  <description>Filters URLs based on their overall length.
+  The default value of -1 means that it is deactivated.
+  </description>
+</property>
+
+<property>
+  <name>urlfilter.fast.url.path.max.length</name>
+  <value>-1</value>
+  <description>Filters URLs based on the length of their path element.
+  The default value of -1 means that it is deactivated.
+  </description>
+</property>
+
+<property>
+  <name>urlfilter.fast.url.query.max.length</name>
+  <value>-1</value>
+  <description>Filters URLs based on the length of their query element.
+  The default value of -1 means that it is deactivated.
+  </description>
+</property>
+
+<property>
   <name>urlfilter.order</name>
   <value></value>
   <description>The order by which URL filters are applied.

--- a/src/plugin/urlfilter-fast/README.md
+++ b/src/plugin/urlfilter-fast/README.md
@@ -73,3 +73,8 @@ the end of the line.
 
 The rules file is defined via the property `urlfilter.fast.file`,
 the default name is `fast-urlfilter.txt`.
+
+In addition to this, the filter checks that the length of the path element of the URL and its query
+done not exceed the values set in the properties `urlfilter.fast.url.path.max.length` and 
+`urlfilter.fast.url.query.max.length` if set. 
+

--- a/src/plugin/urlfilter-fast/README.md
+++ b/src/plugin/urlfilter-fast/README.md
@@ -76,5 +76,6 @@ the default name is `fast-urlfilter.txt`.
 
 In addition to this, the filter checks that the length of the path element of the URL and its query
 done not exceed the values set in the properties `urlfilter.fast.url.path.max.length` and 
-`urlfilter.fast.url.query.max.length` if set. 
+`urlfilter.fast.url.query.max.length` if set. The overall length of the URL can also be used for 
+filtering through the config `urlfilter.fast.url.max.length`.
 

--- a/src/plugin/urlfilter-fast/src/test/org/apache/nutch/urlfilter/fast/TestFastURLFilter.java
+++ b/src/plugin/urlfilter-fast/src/test/org/apache/nutch/urlfilter/fast/TestFastURLFilter.java
@@ -16,10 +16,12 @@
  */
 package org.apache.nutch.urlfilter.fast;
 
+import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.nutch.net.URLFilter;
 import org.apache.nutch.urlfilter.api.RegexURLFilterBaseTest;
 import org.junit.Assert;
@@ -53,4 +55,24 @@ public class TestFastURLFilter extends RegexURLFilterBaseTest {
     bench(800, "fast-urlfilter-benchmark.txt", "Benchmarks.urls");
   }
 
+  public void lengthQueryAndPath() throws FileNotFoundException {
+    URLFilter filter = getURLFilter(new FileReader(SAMPLES + SEPARATOR + "fast-urlfilter-test.txt"));
+    Configuration conf = new Configuration();
+    conf.setInt(FastURLFilter.URLFILTER_FAST_PATH_MAX_LENGTH, 50);
+    conf.setInt(FastURLFilter.URLFILTER_FAST_QUERY_MAX_LENGTH, 50);
+    filter.setConf(conf);
+
+    StringBuilder url = new StringBuilder("http://nutch.apache.org/");
+    for (int i = 0; i < 50; i++) {
+      url.append(i);
+    }
+    Assert.assertEquals(null, filter.filter(url.toString()));
+
+    url = new StringBuilder("http://nutch.apache.org/path?");
+    for (int i = 0; i < 50; i++) {
+      url.append(i);
+    }
+
+    Assert.assertEquals(null, filter.filter(url.toString()));
+  }
 }

--- a/src/plugin/urlfilter-fast/src/test/org/apache/nutch/urlfilter/fast/TestFastURLFilter.java
+++ b/src/plugin/urlfilter-fast/src/test/org/apache/nutch/urlfilter/fast/TestFastURLFilter.java
@@ -16,17 +16,16 @@
  */
 package org.apache.nutch.urlfilter.fast;
 
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.io.StringReader;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.nutch.net.URLFilter;
 import org.apache.nutch.urlfilter.api.RegexURLFilterBaseTest;
 import org.junit.Assert;
 import org.junit.Test;
-
 
 public class TestFastURLFilter extends RegexURLFilterBaseTest {
 
@@ -55,12 +54,13 @@ public class TestFastURLFilter extends RegexURLFilterBaseTest {
     bench(800, "fast-urlfilter-benchmark.txt", "Benchmarks.urls");
   }
 
-  public void lengthQueryAndPath() throws FileNotFoundException {
-    URLFilter filter = getURLFilter(new FileReader(SAMPLES + SEPARATOR + "fast-urlfilter-test.txt"));
+  @Test
+  public void lengthQueryAndPath() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(FastURLFilter.URLFILTER_FAST_PATH_MAX_LENGTH, 50);
     conf.setInt(FastURLFilter.URLFILTER_FAST_QUERY_MAX_LENGTH, 50);
-    filter.setConf(conf);
+    // not interested in testing rules
+    URLFilter filter = new FastURLFilter(new StringReader(""), conf);
 
     StringBuilder url = new StringBuilder("http://nutch.apache.org/");
     for (int i = 0; i < 50; i++) {
@@ -73,6 +73,20 @@ public class TestFastURLFilter extends RegexURLFilterBaseTest {
       url.append(i);
     }
 
+    Assert.assertEquals(null, filter.filter(url.toString()));
+  }
+
+  @Test
+  public void overalLengthTest() throws Exception {
+    Configuration conf = new Configuration();
+    conf.setInt(FastURLFilter.URLFILTER_FAST_MAX_LENGTH, 100);
+    // not interested in testing rules
+    URLFilter filter = new FastURLFilter(new StringReader(""), conf);
+
+    StringBuilder url = new StringBuilder("http://nutch.apache.org/");
+    for (int i = 0; i < 500; i++) {
+      url.append(i);
+    }
     Assert.assertEquals(null, filter.filter(url.toString()));
   }
 }


### PR DESCRIPTION
Checks the length of the query and path elements of a URL. 
see https://issues.apache.org/jira/browse/NUTCH-3025