### PR TITLE
NUTCH-3033 Upgrade Ivy to v2.5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,7 @@ build/
 runtime/
 logs/
 /bin/
-ivy/ivy-2.3.0.jar
-ivy/ivy-2.4.0.jar
-ivy/ivy-2.5.0-rc1.jar
-ivy/ivy-2.5.0.jar
+ivy/ivy-2.*
 ivy/spotbugs-*/
 naivebayes-model
 .naivebayes-model.crc

--- a/build.xml
+++ b/build.xml
@@ -529,13 +529,13 @@
   <!-- target: resolve  ================================================= -->
   <target name="resolve-default" depends="clean-default-lib, init" description="--> resolve and retrieve dependencies with ivy">
     <ivy:resolve file="${ivy.file}" conf="default" log="download-only"/>
-    <ivy:retrieve pattern="${build.lib.dir}/[artifact]-[revision](.[classifier])(-[classifier]).[ext]" symlink="false" log="quiet"/>
+    <ivy:retrieve pattern="${build.lib.dir}/[artifact]-[revision](-[classifier]).[ext]" symlink="false" log="quiet"/>
     <antcall target="copy-libs"/>
   </target>
 
   <target name="resolve-test" depends="clean-test-lib, init" description="--> resolve and retrieve dependencies with ivy">
     <ivy:resolve file="${ivy.file}" conf="test" log="download-only"/>
-    <ivy:retrieve pattern="${test.build.lib.dir}/[artifact]-[revision](.[classifier])(-[classifier]).[ext]" symlink="false" log="quiet"/>
+    <ivy:retrieve pattern="${test.build.lib.dir}/[artifact]-[revision](-[classifier]).[ext]" symlink="false" log="quiet"/>
     <antcall target="copy-libs"/>
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -529,13 +529,13 @@
   <!-- target: resolve  ================================================= -->
   <target name="resolve-default" depends="clean-default-lib, init" description="--> resolve and retrieve dependencies with ivy">
     <ivy:resolve file="${ivy.file}" conf="default" log="download-only"/>
-    <ivy:retrieve pattern="${build.lib.dir}/[artifact]-[revision](.[classifier]).[ext]" symlink="false" log="quiet"/>
+    <ivy:retrieve pattern="${build.lib.dir}/[artifact]-[revision](.[classifier])(-[classifier]).[ext]" symlink="false" log="quiet"/>
     <antcall target="copy-libs"/>
   </target>
 
   <target name="resolve-test" depends="clean-test-lib, init" description="--> resolve and retrieve dependencies with ivy">
     <ivy:resolve file="${ivy.file}" conf="test" log="download-only"/>
-    <ivy:retrieve pattern="${test.build.lib.dir}/[artifact]-[revision](.[classifier]).[ext]" symlink="false" log="quiet"/>
+    <ivy:retrieve pattern="${test.build.lib.dir}/[artifact]-[revision](.[classifier])(-[classifier]).[ext]" symlink="false" log="quiet"/>
     <antcall target="copy-libs"/>
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -529,13 +529,13 @@
   <!-- target: resolve  ================================================= -->
   <target name="resolve-default" depends="clean-default-lib, init" description="--> resolve and retrieve dependencies with ivy">
     <ivy:resolve file="${ivy.file}" conf="default" log="download-only"/>
-    <ivy:retrieve pattern="${build.lib.dir}/[artifact]-[revision](-[classifier]).[ext]" symlink="false" log="quiet"/>
+    <ivy:retrieve pattern="${build.lib.dir}/[artifact]-[revision](.[classifier]).[ext]" symlink="false" log="quiet"/>
     <antcall target="copy-libs"/>
   </target>
 
   <target name="resolve-test" depends="clean-test-lib, init" description="--> resolve and retrieve dependencies with ivy">
     <ivy:resolve file="${ivy.file}" conf="test" log="download-only"/>
-    <ivy:retrieve pattern="${test.build.lib.dir}/[artifact]-[revision](-[classifier]).[ext]" symlink="false" log="quiet"/>
+    <ivy:retrieve pattern="${test.build.lib.dir}/[artifact]-[revision](.[classifier]).[ext]" symlink="false" log="quiet"/>
     <antcall target="copy-libs"/>
   </target>
 

--- a/default.properties
+++ b/default.properties
@@ -67,12 +67,12 @@ ivy.jar=${ivy.dir}/ivy-${ivy.version}.jar
 ivy.repo.url=https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.version}/ivy-${ivy.version}.jar
 
 ivy.local.default.root=${ivy.default.ivy.user.dir}/local
-ivy.local.default.ivy.pattern=[organisation]/[module]/[revision]/[type]s/[artifact].[ext]
-ivy.local.default.artifact.pattern=[organisation]/[module]/[revision]/[type]s/[artifact].[ext]
+ivy.local.default.ivy.pattern=[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]
+ivy.local.default.artifact.pattern=[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]
 
 ivy.shared.default.root=${ivy.default.ivy.user.dir}/shared
-ivy.shared.default.ivy.pattern=[organisation]/[module]/[revision]/[type]s/[artifact].[ext]
-ivy.shared.default.artifact.pattern=[organisation]/[module]/[revision]/[type]s/[artifact].[ext]
+ivy.shared.default.ivy.pattern=[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]
+ivy.shared.default.artifact.pattern=[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]
 
 #
 # Plugins API

--- a/default.properties
+++ b/default.properties
@@ -60,7 +60,7 @@ runtime.dir=./runtime
 runtime.deploy=${runtime.dir}/deploy
 runtime.local=${runtime.dir}/local
 
-ivy.version=2.5.0
+ivy.version=2.5.2
 ivy.dir=${basedir}/ivy
 ivy.file=${ivy.dir}/ivy.xml
 ivy.jar=${ivy.dir}/ivy-${ivy.version}.jar

--- a/default.properties
+++ b/default.properties
@@ -60,7 +60,7 @@ runtime.dir=./runtime
 runtime.deploy=${runtime.dir}/deploy
 runtime.local=${runtime.dir}/local
 
-ivy.version=2.5.2
+ivy.version=2.5.1
 ivy.dir=${basedir}/ivy
 ivy.file=${ivy.dir}/ivy.xml
 ivy.jar=${ivy.dir}/ivy-${ivy.version}.jar

--- a/default.properties
+++ b/default.properties
@@ -67,12 +67,12 @@ ivy.jar=${ivy.dir}/ivy-${ivy.version}.jar
 ivy.repo.url=https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.version}/ivy-${ivy.version}.jar
 
 ivy.local.default.root=${ivy.default.ivy.user.dir}/local
-ivy.local.default.ivy.pattern=[organisation]/[module]/[revision]/[module]-[revision](.[classifier]).[ext]
-ivy.local.default.artifact.pattern=[organisation]/[module]/[revision]/[module]-[revision](.[classifier]).[ext]
+ivy.local.default.ivy.pattern=[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]
+ivy.local.default.artifact.pattern=[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]
 
 ivy.shared.default.root=${ivy.default.ivy.user.dir}/shared
-ivy.shared.default.ivy.pattern=[organisation]/[module]/[revision]/[module]-[revision](.[classifier]).[ext]
-ivy.shared.default.artifact.pattern=[organisation]/[module]/[revision]/[module]-[revision](.[classifier]).[ext]
+ivy.shared.default.ivy.pattern=[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]
+ivy.shared.default.artifact.pattern=[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]
 
 #
 # Plugins API

--- a/default.properties
+++ b/default.properties
@@ -60,7 +60,7 @@ runtime.dir=./runtime
 runtime.deploy=${runtime.dir}/deploy
 runtime.local=${runtime.dir}/local
 
-ivy.version=2.5.1
+ivy.version=2.5.2
 ivy.dir=${basedir}/ivy
 ivy.file=${ivy.dir}/ivy.xml
 ivy.jar=${ivy.dir}/ivy-${ivy.version}.jar

--- a/default.properties
+++ b/default.properties
@@ -67,12 +67,12 @@ ivy.jar=${ivy.dir}/ivy-${ivy.version}.jar
 ivy.repo.url=https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.version}/ivy-${ivy.version}.jar
 
 ivy.local.default.root=${ivy.default.ivy.user.dir}/local
-ivy.local.default.ivy.pattern=[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]
-ivy.local.default.artifact.pattern=[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]
+ivy.local.default.ivy.pattern=[organisation]/[module]/[revision]/[module]-[revision](.[classifier]).[ext]
+ivy.local.default.artifact.pattern=[organisation]/[module]/[revision]/[module]-[revision](.[classifier]).[ext]
 
 ivy.shared.default.root=${ivy.default.ivy.user.dir}/shared
-ivy.shared.default.ivy.pattern=[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]
-ivy.shared.default.artifact.pattern=[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]
+ivy.shared.default.ivy.pattern=[organisation]/[module]/[revision]/[module]-[revision](.[classifier]).[ext]
+ivy.shared.default.artifact.pattern=[organisation]/[module]/[revision]/[module]-[revision](.[classifier]).[ext]
 
 #
 # Plugins API

--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -16,7 +16,9 @@
    limitations under the License.
 -->
 
-<ivy-module xmlns:ns0="http://ant.apache.org/ivy/maven" version="1.0">
+<ivy-module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd" 
+	xmlns:ns0="http://ant.apache.org/ivy/maven" version="2.0">
 	<info organisation="org.apache.nutch" module="nutch">
 		<license name="Apache 2.0" url="https://www.apache.org/licenses/LICENSE-2.0.txt" />
 		<ivyauthor name="Apache Nutch Team" url="https://nutch.apache.org/" />

--- a/ivy/ivysettings.xml
+++ b/ivy/ivysettings.xml
@@ -38,7 +38,7 @@
       <artifact
           pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]" />
       <ivy
-          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision].pom" />
+          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).pom" />
     </filesystem>
     <ibiblio name="maven2"
       root="${repo.maven.org}"

--- a/ivy/ivysettings.xml
+++ b/ivy/ivysettings.xml
@@ -26,7 +26,7 @@
     value="https://repository.apache.org/content/repositories/snapshots/"
     override="false"/>
   <property name="maven2.pattern"
-    value="[organisation]/[module]/[revision]/[module]-[revision](-[classifier])"/>
+    value="[organisation]/[module]/[revision]/[module]-[revision](.[classifier])"/>
   <property name="maven2.pattern.ext"
     value="${maven2.pattern}.[ext]"/>
   <!-- pull in the local repository -->
@@ -36,9 +36,9 @@
   <resolvers>
     <filesystem name="local-maven-2" m2compatible="true">
       <artifact
-          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]" />
+          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](.[classifier]).[ext]" />
       <ivy
-          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).pom" />
+          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](.[classifier]).pom" />
     </filesystem>
     <ibiblio name="maven2"
       root="${repo.maven.org}"

--- a/ivy/ivysettings.xml
+++ b/ivy/ivysettings.xml
@@ -36,7 +36,7 @@
   <resolvers>
     <filesystem name="local-maven-2" m2compatible="true">
       <artifact
-          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]"
+          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]" />
       <ivy
           pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision].pom" />
     </filesystem>

--- a/ivy/ivysettings.xml
+++ b/ivy/ivysettings.xml
@@ -36,7 +36,7 @@
   <resolvers>
     <filesystem name="local-maven-2" m2compatible="true">
       <artifact
-          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision].[ext]" />
+          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]"
       <ivy
           pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision].pom" />
     </filesystem>

--- a/ivy/ivysettings.xml
+++ b/ivy/ivysettings.xml
@@ -26,7 +26,7 @@
     value="https://repository.apache.org/content/repositories/snapshots/"
     override="false"/>
   <property name="maven2.pattern"
-    value="[organisation]/[module]/[revision]/[module]-[revision](.[classifier])"/>
+    value="[organisation]/[module]/[revision]/[module]-[revision](.[classifier])(-[classifier])"/>
   <property name="maven2.pattern.ext"
     value="${maven2.pattern}.[ext]"/>
   <!-- pull in the local repository -->
@@ -36,9 +36,9 @@
   <resolvers>
     <filesystem name="local-maven-2" m2compatible="true">
       <artifact
-          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](.[classifier]).[ext]" />
+          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](.[classifier])(-[classifier]).[ext]" />
       <ivy
-          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](.[classifier]).pom" />
+          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](.[classifier])(-[classifier]).pom" />
     </filesystem>
     <ibiblio name="maven2"
       root="${repo.maven.org}"

--- a/ivy/ivysettings.xml
+++ b/ivy/ivysettings.xml
@@ -26,7 +26,7 @@
     value="https://repository.apache.org/content/repositories/snapshots/"
     override="false"/>
   <property name="maven2.pattern"
-    value="[organisation]/[module]/[revision]/[module]-[revision](.[classifier])(-[classifier])"/>
+    value="[organisation]/[module]/[revision]/[module]-[revision](-[classifier])"/>
   <property name="maven2.pattern.ext"
     value="${maven2.pattern}.[ext]"/>
   <!-- pull in the local repository -->
@@ -36,9 +36,9 @@
   <resolvers>
     <filesystem name="local-maven-2" m2compatible="true">
       <artifact
-          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](.[classifier])(-[classifier]).[ext]" />
+          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]" />
       <ivy
-          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](.[classifier])(-[classifier]).pom" />
+          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).pom" />
     </filesystem>
     <ibiblio name="maven2"
       root="${repo.maven.org}"


### PR DESCRIPTION
PR for https://issues.apache.org/jira/browse/NUTCH-3033
I was having trouble locally resolving the Ivy version to 2.5.2… I can’t yet figure out why 2.5.1 was being used. I’ll check out the CI log and see if the newer version is used. 