### PR TITLE
NUTCH-3008 indexer-elastic: downgrade to ES 7.10.2 to address licensing issues

### DIFF
--- a/src/plugin/indexer-elastic/howto_upgrade_es.md
+++ b/src/plugin/indexer-elastic/howto_upgrade_es.md
@@ -37,7 +37,7 @@
      (eventually with different versions)
    - duplicated libs can be added to the exclusions of transitive dependencies in
        build/plugins/indexer-elastic/ivy.xml
-   - but it should be made sure that the library versions in ivy/ivy.xml correspend to
+   - but it should be made sure that the library versions in ivy/ivy.xml correspond to
      those required by Tika
 
 5. Remove the locally "installed" dependencies in src/plugin/indexer-elastic/lib/:

--- a/src/plugin/indexer-elastic/ivy.xml
+++ b/src/plugin/indexer-elastic/ivy.xml
@@ -36,7 +36,7 @@
   </publications>
 
   <dependencies>
-    <dependency org="org.elasticsearch.client" name="elasticsearch-rest-high-level-client" rev="7.13.2">
+    <dependency org="org.elasticsearch.client" name="elasticsearch-rest-high-level-client" rev="7.10.2">
       <!-- exclusions of dependencies provided in Nutch core (ivy/ivy.xml) -->
       <exclude org="commons-codec" name="commons-codec" />
       <exclude org="commons-logging" name="commons-logging" />

--- a/src/plugin/indexer-elastic/plugin.xml
+++ b/src/plugin/indexer-elastic/plugin.xml
@@ -22,18 +22,17 @@
     </library>
     <!-- Elastic Rest Client Dependencies -->
     <!-- end of Elastic Rest Client dependencies -->
-    <library name="HdrHistogram-2.1.9.jar"/>
-    <library name="aggs-matrix-stats-client-7.13.2.jar"/>
+    <library name="aggs-matrix-stats-client-7.10.2.jar"/>
     <library name="compiler-0.9.6.jar"/>
-    <library name="elasticsearch-7.13.2.jar"/>
-    <library name="elasticsearch-cli-7.13.2.jar"/>
-    <library name="elasticsearch-core-7.13.2.jar"/>
-    <library name="elasticsearch-geo-7.13.2.jar"/>
-    <library name="elasticsearch-plugin-classloader-7.13.2.jar"/>
-    <library name="elasticsearch-rest-client-7.13.2.jar"/>
-    <library name="elasticsearch-rest-high-level-client-7.13.2.jar"/>
-    <library name="elasticsearch-secure-sm-7.13.2.jar"/>
-    <library name="elasticsearch-x-content-7.13.2.jar"/>
+    <library name="elasticsearch-7.10.2.jar"/>
+    <library name="elasticsearch-cli-7.10.2.jar"/>
+    <library name="elasticsearch-core-7.10.2.jar"/>
+    <library name="elasticsearch-geo-7.10.2.jar"/>
+    <library name="elasticsearch-rest-client-7.10.2.jar"/>
+    <library name="elasticsearch-rest-high-level-client-7.10.2.jar"/>
+    <library name="elasticsearch-secure-sm-7.10.2.jar"/>
+    <library name="elasticsearch-x-content-7.10.2.jar"/>
+    <library name="HdrHistogram-2.1.9.jar"/>
     <library name="hppc-0.8.1.jar"/>
     <library name="httpasyncclient-4.1.4.jar"/>
     <library name="httpclient-4.5.10.jar"/>
@@ -43,10 +42,10 @@
     <library name="jackson-dataformat-cbor-2.10.4.jar"/>
     <library name="jackson-dataformat-smile-2.10.4.jar"/>
     <library name="jackson-dataformat-yaml-2.10.4.jar"/>
-    <library name="jna-5.7.0-1.jar"/>
-    <library name="joda-time-2.10.10.jar"/>
+    <library name="jna-5.5.0.jar"/>
+    <library name="joda-time-2.10.4.jar"/>
     <library name="jopt-simple-5.0.2.jar"/>
-    <library name="lang-mustache-client-7.13.2.jar"/>
+    <library name="lang-mustache-client-7.10.2.jar"/>
     <library name="lucene-analyzers-common-8.11.2.jar"/>
     <library name="lucene-backward-codecs-8.11.2.jar"/>
     <library name="lucene-core-8.11.2.jar"/>
@@ -58,12 +57,12 @@
     <library name="lucene-queries-8.11.2.jar"/>
     <library name="lucene-queryparser-8.11.2.jar"/>
     <library name="lucene-sandbox-8.11.2.jar"/>
-    <library name="lucene-spatial-extras-8.11.2.jar"/>
     <library name="lucene-spatial3d-8.11.2.jar"/>
+    <library name="lucene-spatial-extras-8.11.2.jar"/>
     <library name="lucene-suggest-8.11.2.jar"/>
-    <library name="mapper-extras-client-7.13.2.jar"/>
-    <library name="parent-join-client-7.13.2.jar"/>
-    <library name="rank-eval-client-7.13.2.jar"/>
+    <library name="mapper-extras-client-7.10.2.jar"/>
+    <library name="parent-join-client-7.10.2.jar"/>
+    <library name="rank-eval-client-7.10.2.jar"/>
     <library name="s2-geometry-library-java-1.0.0.jar"/>
     <library name="snakeyaml-1.26.jar"/>
     <library name="spatial4j-0.7.jar"/>

--- a/src/plugin/indexer-elastic/src/java/org/apache/nutch/indexwriter/elastic/ElasticIndexWriter.java
+++ b/src/plugin/indexer-elastic/src/java/org/apache/nutch/indexwriter/elastic/ElasticIndexWriter.java
@@ -149,7 +149,7 @@ public class ElasticIndexWriter implements IndexWriter {
         .builder(
             (request, bulkListener) -> client.bulkAsync(request,
                 RequestOptions.DEFAULT, bulkListener),
-            bulkProcessorListener(), "nutch-indexer-elastic")
+            bulkProcessorListener())
         .setBulkActions(maxBulkDocs)
         .setBulkSize(new ByteSizeValue(maxBulkLength, ByteSizeUnit.BYTES))
         .setConcurrentRequests(1)


### PR DESCRIPTION
This PR downgrades the ES client to version 7.10.2 which is licensed under ASF 2.0 - it's a quick fix to stay compatible with ASF policies.

Not yet tested: indexing into ES

To be done: update the LICENSE and NOTICE files. I'll do this as part of a separate issue NUTCH-3035.