### PR TITLE
NUTCH-3057 - Fix for index-arbitrary plugin improper retention and us…

### DIFF
--- a/src/plugin/index-arbitrary/src/java/org/apache/nutch/indexer/arbitrary/ArbitraryIndexingFilter.java
+++ b/src/plugin/index-arbitrary/src/java/org/apache/nutch/indexer/arbitrary/ArbitraryIndexingFilter.java
@@ -170,6 +170,7 @@ public class ArbitraryIndexingFilter implements IndexingFilter {
 
     int cfgCounter = 0;
     while (cfgCounter <  arbitraryAddsCount) {
+      result = null;
       setIndexedConf(conf,cfgCounter);
       cfgCounter++;
       try {
@@ -184,6 +185,7 @@ public class ArbitraryIndexingFilter implements IndexingFilter {
         LOG.error("Exception preparing reflection tasks. className was {}",
 		 String.valueOf(className));
         e.printStackTrace();
+        continue;
       }
       try {
         constrArgs = new String[userConstrArgs.length + 1];
@@ -207,6 +209,7 @@ public class ArbitraryIndexingFilter implements IndexingFilter {
           LOG.error("methodArgs[0] was {}", String.valueOf(methodArgs[0]));
         }
         e.printStackTrace();
+	continue;
       }
 
       LOG.debug("{}.{}() returned {} for field {}.", className,


### PR DESCRIPTION
Fix for NUTCH-3057 where index-arbitrary plugin retained value for a field and erroneously set it to the next field declared in its config stanzas