### PR TITLE
NUTCH-3061 URL filters to log name of the rules file

### DIFF
--- a/src/plugin/lib-regex-filter/src/java/org/apache/nutch/urlfilter/api/RegexURLFilterBase.java
+++ b/src/plugin/lib-regex-filter/src/java/org/apache/nutch/urlfilter/api/RegexURLFilterBase.java
@@ -52,8 +52,6 @@ import org.apache.nutch.util.URLUtil;
  * where plus (<code>+</code>)means go ahead and index it and minus (
  * <code>-</code>)means no.
  * </p>
- * 
- * @author J&eacute;r&ocirc;me Charron
  */
 public abstract class RegexURLFilterBase implements URLFilter {
 
@@ -283,6 +281,8 @@ public abstract class RegexURLFilterBase implements URLFilter {
       RegexRule rule = createRule(sign, regex, hostOrDomain);
       rules.add(rule);
     }
+    LOG.info("Read {} regex rules ({})", rules.size(),
+        this.getClass().getName());
     return rules;
   }
 

--- a/src/plugin/urlfilter-automaton/src/java/org/apache/nutch/urlfilter/automaton/AutomatonURLFilter.java
+++ b/src/plugin/urlfilter-automaton/src/java/org/apache/nutch/urlfilter/automaton/AutomatonURLFilter.java
@@ -19,6 +19,7 @@ package org.apache.nutch.urlfilter.automaton;
 import java.io.Reader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.lang.invoke.MethodHandles;
 import java.util.regex.PatternSyntaxException;
 
 import org.apache.hadoop.conf.Configuration;
@@ -27,18 +28,23 @@ import dk.brics.automaton.RegExp;
 import dk.brics.automaton.RunAutomaton;
 import org.apache.nutch.urlfilter.api.RegexRule;
 import org.apache.nutch.urlfilter.api.RegexURLFilterBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * RegexURLFilterBase implementation based on the <a
  * href="https://www.brics.dk/automaton/">dk.brics.automaton</a> Finite-State
  * Automata for Java<sup>TM</sup>.
  * 
- * @author J&eacute;r&ocirc;me Charron
  * @see <a href="https://www.brics.dk/automaton/">dk.brics.automaton</a>
  */
 public class AutomatonURLFilter extends RegexURLFilterBase {
+
   public static final String URLFILTER_AUTOMATON_FILE = "urlfilter.automaton.file";
   public static final String URLFILTER_AUTOMATON_RULES = "urlfilter.automaton.rules";
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(MethodHandles.lookup().lookupClass());
 
   public AutomatonURLFilter() {
     super();
@@ -54,11 +60,6 @@ public class AutomatonURLFilter extends RegexURLFilterBase {
     super(reader);
   }
 
-  /*
-   * ----------------------------------- * <implementation:RegexURLFilterBase> *
-   * -----------------------------------
-   */
-
   /**
    * Rules specified as a config property will override rules specified as a
    * config file.
@@ -67,9 +68,12 @@ public class AutomatonURLFilter extends RegexURLFilterBase {
   protected Reader getRulesReader(Configuration conf) throws IOException {
     String stringRules = conf.get(URLFILTER_AUTOMATON_RULES);
     if (stringRules != null) {
+      LOG.info("Reading urlfilter-automaton string rules from property: {}",
+          URLFILTER_AUTOMATON_RULES);
       return new StringReader(stringRules);
     }
     String fileRules = conf.get(URLFILTER_AUTOMATON_FILE);
+    LOG.info("Reading urlfilter-automaton rules file: {}", fileRules);
     return conf.getConfResourceAsReader(fileRules);
   }
 

--- a/src/plugin/urlfilter-fast/src/java/org/apache/nutch/urlfilter/fast/FastURLFilter.java
+++ b/src/plugin/urlfilter-fast/src/java/org/apache/nutch/urlfilter/fast/FastURLFilter.java
@@ -236,6 +236,7 @@ public class FastURLFilter implements URLFilter {
 
   public void reloadRules() throws IOException {
     String fileRules = conf.get(URLFILTER_FAST_FILE);
+    LOG.info("Reading urlfilter-fast rules file: {}", fileRules);
     InputStream is;
 
     Path fileRulesPath = new Path(fileRules);
@@ -328,6 +329,9 @@ public class FastURLFilter implements URLFilter {
           }
         }
       }
+      LOG.info(
+          "Read {} lines, {} host and {} domain rules from urlfilter-fast rules file",
+          lineno, hostRules.size(), domainRules.size());
     } catch (IOException e) {
       LOG.warn("Caught exception while reading rules file at line {}: {}",
           lineno, e.getMessage());

--- a/src/plugin/urlfilter-fast/src/test/org/apache/nutch/urlfilter/fast/TestFastURLFilter.java
+++ b/src/plugin/urlfilter-fast/src/test/org/apache/nutch/urlfilter/fast/TestFastURLFilter.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nutch.urlfilter.fast;
 
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;

--- a/src/plugin/urlfilter-regex/src/java/org/apache/nutch/urlfilter/regex/RegexURLFilter.java
+++ b/src/plugin/urlfilter-regex/src/java/org/apache/nutch/urlfilter/regex/RegexURLFilter.java
@@ -19,6 +19,7 @@ package org.apache.nutch.urlfilter.regex;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.lang.invoke.MethodHandles;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -26,6 +27,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.nutch.urlfilter.api.RegexRule;
 import org.apache.nutch.urlfilter.api.RegexURLFilterBase;
 import org.apache.nutch.util.NutchConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Filters URLs based on a file of regular expressions using the
@@ -35,6 +38,9 @@ public class RegexURLFilter extends RegexURLFilterBase {
 
   public static final String URLFILTER_REGEX_FILE = "urlfilter.regex.file";
   public static final String URLFILTER_REGEX_RULES = "urlfilter.regex.rules";
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(MethodHandles.lookup().lookupClass());
 
   public RegexURLFilter() {
     super();
@@ -49,11 +55,6 @@ public class RegexURLFilter extends RegexURLFilterBase {
     super(reader);
   }
 
-  /*
-   * ----------------------------------- * <implementation:RegexURLFilterBase> *
-   * -----------------------------------
-   */
-
   /**
    * Rules specified as a config property will override rules specified as a
    * config file.
@@ -62,9 +63,12 @@ public class RegexURLFilter extends RegexURLFilterBase {
   protected Reader getRulesReader(Configuration conf) throws IOException {
     String stringRules = conf.get(URLFILTER_REGEX_RULES);
     if (stringRules != null) {
+      LOG.info("Reading urlfilter-regex string rules from property: {}",
+          URLFILTER_REGEX_RULES);
       return new StringReader(stringRules);
     }
     String fileRules = conf.get(URLFILTER_REGEX_FILE);
+    LOG.info("Reading urlfilter-regex rules file: {}", fileRules);
     return conf.getConfResourceAsReader(fileRules);
   }
 
@@ -80,11 +84,6 @@ public class RegexURLFilter extends RegexURLFilterBase {
   }
   
   
-
-  /*
-   * ------------------------------------ * </implementation:RegexURLFilterBase>
-   * * ------------------------------------
-   */
 
   public static void main(String args[]) throws IOException {
     RegexURLFilter filter = new RegexURLFilter();


### PR DESCRIPTION
Let urlfilter-regex, urlfilter-automaton and urlfilter-fast log the name of the rules file. Also log the number of rules read from the file.

Cleanup (Javadoc) comments in the modified classes.