### PR TITLE
NUTCH-3066 Protocol plugin unit tests fail randomly

### DIFF
--- a/src/plugin/protocol-http/src/test/org/apache/nutch/protocol/http/TestResponse.java
+++ b/src/plugin/protocol-http/src/test/org/apache/nutch/protocol/http/TestResponse.java
@@ -70,7 +70,7 @@ public class TestResponse extends AbstractHttpProtocolPluginTest {
 
   protected HttpResponse getResponse(int statusCode, String headerName) {
     try {
-      URL url = new URL(protocol, localHost, defaultPort, "/" + headerName);
+      URL url = new URL(protocol, localHost, serverPort, "/" + headerName);
       LOG.info("Emulating fetch of {}", url);
       return new HttpResponse((Http) http, url, new CrawlDatum(statusCode, 1000));
     } catch (ProtocolException | IOException e) {

--- a/src/plugin/protocol-okhttp/src/test/org/apache/nutch/protocol/okhttp/TestResponse.java
+++ b/src/plugin/protocol-okhttp/src/test/org/apache/nutch/protocol/okhttp/TestResponse.java
@@ -70,7 +70,7 @@ public class TestResponse extends AbstractHttpProtocolPluginTest {
 
   protected OkHttpResponse getResponse(int statusCode, String headerName) {
     try {
-      URL url = new URL(protocol, localHost, defaultPort, "/" + headerName);
+      URL url = new URL(protocol, localHost, serverPort, "/" + headerName);
       LOG.info("Emulating fetch of {}", url);
       return new OkHttpResponse((OkHttp) http, url, new CrawlDatum(statusCode, 1000));
     } catch (ProtocolException | IOException e) {


### PR DESCRIPTION
- use random free ephemeral port in AbstractHttpProtocolPluginTest
- store used port in field "serverPort", inherited by plugin tests
- use serverPort to sleep longer until server is up and set its port number
