### PR TITLE
NUTCH-3067 Improve performance of FetchItemQueues if error state is preserved

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1198,7 +1198,11 @@
   <name>fetcher.throughput.threshold.retries</name>
   <value>5</value>
   <description>The number of times the fetcher.throughput.threshold.pages is allowed to be exceeded.
-  This settings prevents accidental slow downs from immediately killing the fetcher thread.
+  This settings prevents accidental slow downs from immediately shutting down the fetcher threads.
+  The throughput is checked approx. every second. Note: the number of retries should be lower
+  than the timeout defined by mapreduce.task.timeout and fetcher.threads.timeout.divisor (see there).
+  For the default values, the timeout is 300 seconds. Consequently, the number of retries should be
+  significantly lower.
   </description>
 </property>
 

--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1174,6 +1174,17 @@
 </property>
 
 <property>
+  <name>fetcher.exceptions.per.queue.clear.after</name>
+  <value>1800</value>
+  <description>Time in seconds after which exception counters in
+  queues can be cleared. This happens only if no items are queued in
+  this queue and the configured time span has elapsed in addition to
+  the crawl delay including the exponential backoff time, see
+  fetcher.exceptions.per.queue.delay.
+  </description>
+</property>
+
+<property>
   <name>fetcher.throughput.threshold.pages</name>
   <value>-1</value>
   <description>The threshold of minimum pages per second. If the fetcher downloads less

--- a/src/java/org/apache/nutch/fetcher/FetchItemQueue.java
+++ b/src/java/org/apache/nutch/fetcher/FetchItemQueue.java
@@ -41,6 +41,8 @@ public class FetchItemQueue {
   private static final Logger LOG = LoggerFactory
       .getLogger(MethodHandles.lookup().lookupClass());
 
+  private static Text variableFetchDelayKey = new Text("_variableFetchDelay_");
+
   List<FetchItem> queue = Collections
       .synchronizedList(new LinkedList<FetchItem>());
   AtomicInteger inProgress = new AtomicInteger();
@@ -50,18 +52,20 @@ public class FetchItemQueue {
   long minCrawlDelay;
   int maxThreads;
   Text cookie;
-  Text variableFetchDelayKey = new Text("_variableFetchDelay_");
   boolean variableFetchDelaySet = false;
   // keep track of duplicates if fetcher.follow.outlinks.depth > 0. Some urls may 
   // not get followed due to hash collisions. Hashing is used to reduce memory
   // usage.
-  Set<Integer> alreadyFetched = new HashSet<>();
+  Set<Integer> alreadyFetched;
   
   public FetchItemQueue(Configuration conf, int maxThreads, long crawlDelay,
       long minCrawlDelay) {
     this.maxThreads = maxThreads;
     this.crawlDelay = crawlDelay;
     this.minCrawlDelay = minCrawlDelay;
+    if (conf.getInt("fetcher.follow.outlinks.depth", -1) > 0) {
+      alreadyFetched = new HashSet<>();
+    }
     // ready to start
     setEndTime(System.currentTimeMillis() - crawlDelay);
   }

--- a/src/java/org/apache/nutch/fetcher/FetchItemQueues.java
+++ b/src/java/org/apache/nutch/fetcher/FetchItemQueues.java
@@ -260,7 +260,7 @@ public class FetchItemQueues {
 
   // empties the queues (used by fetcher timelimit and throughput threshold)
   public synchronized int emptyQueues() {
-    int count = 0;
+    int count = 0, queuesDropped = 0;
 
     for (String id : queues.keySet()) {
       FetchItemQueue fiq = queues.get(id);
@@ -270,7 +270,11 @@ public class FetchItemQueues {
       int deleted = fiq.emptyQueue();
       totalSize.addAndGet(-deleted);
       count += deleted;
+      queuesDropped++;
     }
+
+    LOG.info("Emptied all queues: {} queues with {} items",
+        queuesDropped, count);
 
     return count;
   }

--- a/src/java/org/apache/nutch/fetcher/Fetcher.java
+++ b/src/java/org/apache/nutch/fetcher/Fetcher.java
@@ -212,11 +212,11 @@ public class Fetcher extends NutchTool implements Tool {
         int timeoutDivisor = conf.getInt("fetcher.threads.timeout.divisor", 2);
         LOG.info("Fetcher: time-out divisor: {}", timeoutDivisor);
 
-        int queueDepthMuliplier = conf.getInt("fetcher.queue.depth.multiplier",
+        int queueDepthMultiplier = conf.getInt("fetcher.queue.depth.multiplier",
             50);
 
         feeder = new QueueFeeder(innerContext, fetchQueues,
-            threadCount * queueDepthMuliplier);
+            threadCount * queueDepthMultiplier);
 
         // the value of the time limit is either -1 or the time where it should
         // finish


### PR DESCRIPTION
Address NUTCH-3067:

1. do not keep every stateful queue: drop queues which have a low exception count after a configurable amount of time. If a second URL from the same host/domain/IP is fetched after a considerably long time span (eg. 30 minutes), the effect on performance and politeness should be negligible.

   This is configured by `fetcher.exceptions.per.queue.clear.after` (default 30 minutes): if this time has elapsed after the next fetch time in the queue, that is in addition to any delay defined by the exponential backoff, empty queues are dropped.

2. reviewed and improved the handling of the exponential backoff in [FetchQueues.checkExceptionThreshold](https://nutch.apache.org/documentation/javadoc/api/org/apache/nutch/fetcher/FetchItemQueues.html#checkExceptionThreshold(java.lang.String,int,long)): if the delayed next fetch would happen after the fetcher timelimit (if configured), the queue is purged and blocked because no fetch item will be fetched from the queue anyway.

3. reduce the memory footprint of a single FetchQueue - important if there are many of them.

In addition, logging and documentation has been improved. While testing this PR on a production crawl, a NUTCH-3072 has been detected. 