### PR TITLE
NUTCH-3084 Improve CI by filtering and separating plugin and core test executiion

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - uses: dorny/paths-filter@$v3.0.2
+      - uses: dorny/paths-filter@$v3.0.0
         id: filter
         with:
           filters: |

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -21,10 +21,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [master]
-env:
-  CHECKOUT_VERSION: 'v4.2.2'
-  PATHS_FILTER_VERSION: 'v3.0.2'
-  SETUP_JAVA_VERSION: 'v4.5.0'
 jobs:
   javadoc:
     strategy:
@@ -33,9 +29,9 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@$CHECKOUT_VERSION
+      - uses: actions/checkout@v4.2.2
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@$SETUP_JAVA_VERSION
+        uses: actions/setup-java@$v4.5.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -48,9 +44,9 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@$CHECKOUT_VERSION
+      - uses: actions/checkout@v4.2.2
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@$SETUP_JAVA_VERSION
+        uses: actions/setup-java@$v4.5.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -71,13 +67,13 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@$CHECKOUT_VERSION
+      - uses: actions/checkout@v4.2.2
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@$SETUP_JAVA_VERSION
+        uses: actions/setup-java@$v4.5.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - uses: dorny/paths-filter@$PATHS_FILTER_VERSION
+      - uses: dorny/paths-filter@$v3.0.2
         id: filter
         with:
           filters: |

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -21,7 +21,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [master]
-
+env:
+  CHECKOUT_VERSION: 'v4.2.2'
+  PATHS_FILTER_VERSION: 'v3.0.2'
+  SETUP_JAVA_VERSION: 'v4.5.0'
 jobs:
   javadoc:
     strategy:
@@ -30,9 +33,9 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4.1.4
+      - uses: actions/checkout@$CHECKOUT_VERSION
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@$SETUP_JAVA_VERSION
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -45,9 +48,9 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4.1.4
+      - uses: actions/checkout@$CHECKOUT_VERSION
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@$SETUP_JAVA_VERSION
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -61,18 +64,32 @@ jobs:
       - name: Fail if any unknown licenses
         if: ${{ env.UNKNOWN_LICENSES != '0 Unknown Licenses' }}
         run: exit 1
-  test:
+  test_core:
     strategy:
       matrix:
         java: ['11']
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4.1.4
+      - uses: actions/checkout@$CHECKOUT_VERSION
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@$SETUP_JAVA_VERSION
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - name: Test
-        run: ant clean test -buildfile build.xml
+      - uses: dorny/paths-filter@$PATHS_FILTER_VERSION
+        id: filter
+        with:
+          filters: |
+            core:
+              - 'src/java/**'
+            plugins:
+              - 'src/plugins/**'
+      # run only if 'core' files were changed
+      - name: core tests
+        if: steps.filter.outputs.core == 'true'
+        run: ant clean test-core -buildfile build.xml
+      # run only if 'plugins' files were changed
+      - name: plugins tests
+        if: steps.filter.outputs.plugins == 'true'
+        run: ant clean test-plugins -buildfile build.xml

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -83,13 +83,15 @@ jobs:
           filters: |
             core:
               - 'src/java/**'
+              - 'src/test/**'
+              - 'src/testresources/**'
             plugins:
-              - 'src/plugins/**'
+              - 'src/plugin/**'
       # run only if 'core' files were changed
-      - name: core tests
+      - name: test core
         if: steps.filter.outputs.core == 'true'
         run: ant clean test-core -buildfile build.xml
       # run only if 'plugins' files were changed
-      - name: plugins tests
+      - name: test plugins
         if: steps.filter.outputs.plugins == 'true'
         run: ant clean test-plugins -buildfile build.xml

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 name: master pull request ci
-
 on:
   push:
     branches: [master]
@@ -31,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@$v4.5.0
+        uses: actions/setup-java@v4.5.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -46,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@$v4.5.0
+        uses: actions/setup-java@v4.5.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -60,7 +59,7 @@ jobs:
       - name: Fail if any unknown licenses
         if: ${{ env.UNKNOWN_LICENSES != '0 Unknown Licenses' }}
         run: exit 1
-  test_core:
+  tests:
     strategy:
       matrix:
         java: ['11']
@@ -69,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@$v4.5.0
+        uses: actions/setup-java@v4.5.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - uses: dorny/paths-filter@$v3.0.0
+      - uses: dorny/paths-filter@v3.0.2
         id: filter
         with:
           filters: |

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - uses: dorny/paths-filter@v3.0.2
+      - uses: dorny/paths-filter@v3.0.0
         id: filter
         with:
           filters: |


### PR DESCRIPTION
PR for https://issues.apache.org/jira/browse/NUTCH-3084
This does fundamentally change how the `tests` are executed. By default, we now no longer run tests. We only run tests if changes have been made to 

- the [core](https://github.com/apache/nutch/tree/master/src/java) or [core tests](https://github.com/apache/nutch/tree/master/src/test), or [testresources](https://github.com/apache/nutch/tree/master/src/testresources), or
- [plugins](https://github.com/apache/nutch/tree/master/src/plugin)