### PR TITLE
NUTCH-2771 Tests in nightly builds: skip long runners

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -469,6 +469,12 @@
   <!-- ================================================================== -->
   <target name="test" depends="test-core, test-plugins" description="--> run JUnit tests"/>
 
+  <target name="test-full" description="--> run all JUnit tests, including slow ones">
+    <antcall target="test">
+      <param name="test.include.slow" value="true" />
+    </antcall>
+  </target>
+
   <target name="test-core" depends="compile-core-test, job" description="--> run core JUnit tests only">
 
     <delete dir="${test.build.data}"/>
@@ -496,6 +502,7 @@
       errorProperty="tests.failed" failureProperty="tests.failed" maxmemory="1000m">
       <sysproperty key="test.build.data" value="${test.build.data}"/>
       <sysproperty key="test.src.dir" value="${test.src.dir}"/>
+      <sysproperty key="test.include.slow" value="${test.include.slow}"/>
       <sysproperty key="javax.xml.parsers.DocumentBuilderFactory" value="com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"/>
       <classpath refid="test.classpath"/>
       <formatter type="${test.junit.output.format}" />

--- a/src/test/org/apache/nutch/segment/TestSegmentMerger.java
+++ b/src/test/org/apache/nutch/segment/TestSegmentMerger.java
@@ -31,7 +31,9 @@ import org.apache.nutch.parse.ParseText;
 import org.apache.nutch.util.NutchConfiguration;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestSegmentMerger {
@@ -42,6 +44,11 @@ public class TestSegmentMerger {
   Path seg2;
   Path out;
   int countSeg1, countSeg2;
+
+  @BeforeClass
+  public static void checkConditions() throws Exception {
+    Assume.assumeTrue(Boolean.getBoolean("test.include.slow"));
+  }
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/org/apache/nutch/segment/TestSegmentMergerCrawlDatums.java
+++ b/src/test/org/apache/nutch/segment/TestSegmentMergerCrawlDatums.java
@@ -32,7 +32,9 @@ import org.apache.hadoop.mapreduce.lib.output.MapFileOutputFormat;
 import org.apache.nutch.crawl.CrawlDatum;
 import org.apache.nutch.util.NutchConfiguration;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,13 +46,13 @@ import org.slf4j.LoggerFactory;
  * merging where we're looking for an expected status. A second test is able to
  * randomly inject redirects in segment, likely causing the segment merger to
  * fail resulting in a bad merged segment.
- * 
+ *
  * See also:
- * 
+ *
  * https://issues.apache.org/jira/browse/NUTCH-1113
  * https://issues.apache.org/jira/browse/NUTCH-1616
  * https://issues.apache.org/jira/browse/NUTCH-1520
- * 
+ *
  * Cheers!
  */
 public class TestSegmentMergerCrawlDatums {
@@ -60,6 +62,11 @@ public class TestSegmentMergerCrawlDatums {
 
   private static final Logger LOG = LoggerFactory
       .getLogger(MethodHandles.lookup().lookupClass());
+
+  @BeforeClass
+  public static void checkConditions() throws Exception {
+    Assume.assumeTrue(Boolean.getBoolean("test.include.slow"));
+  }
 
   @Before
   public void setUp() throws Exception {
@@ -222,7 +229,7 @@ public class TestSegmentMergerCrawlDatums {
   /**
    * Execute a sequence of creating segments, merging them and checking the
    * final output
-   * 
+   *
    * @param status
    *          to start with
    * @param status
@@ -281,7 +288,7 @@ public class TestSegmentMergerCrawlDatums {
 
   /**
    * Checks the merged segment and removes the stuff again.
-   * 
+   *
    * @param the
    *          test directory
    * @param the
@@ -326,7 +333,7 @@ public class TestSegmentMergerCrawlDatums {
 
   /**
    * Merge some segments!
-   * 
+   *
    * @param the
    *          test directory
    * @param the
@@ -349,7 +356,7 @@ public class TestSegmentMergerCrawlDatums {
 
   /**
    * Create a segment with the specified status.
-   * 
+   *
    * @param the
    *          segment's paths
    * @param the


### PR DESCRIPTION
- introduce target "test-full" which executes all unit tests, even slow ones
- slow unit tests are only run if the system property "test.include.slow" is true (it is set to true by the target "test-full")

- a solution based on JUnit tags isn't possible since we use Ant and are still on JUnit 4