### PR TITLE
Nutch 3085

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -66,13 +66,18 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - name: Check out Repository
+        uses: actions/checkout@v4.2.2
+        # Disabling shallow clone is recommended for improving sonarcloud reporting
+        with:
+          fetch-depth: 0
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4.5.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - uses: dorny/paths-filter@v3.0.0
+      - name: Filter 'core' and 'plugins' paths
+        uses: dorny/paths-filter@v3.0.0
         id: filter
         with:
           filters: |
@@ -83,10 +88,37 @@ jobs:
             plugins:
               - 'src/plugin/**'
       # run only if 'core' files were changed
-      - name: test core
+      - name: Test core
         if: steps.filter.outputs.core == 'true'
         run: ant clean test-core -buildfile build.xml
       # run only if 'plugins' files were changed
-      - name: test plugins
+      - name: Test plugins
         if: steps.filter.outputs.plugins == 'true'
         run: ant clean test-plugins -buildfile build.xml
+      - name: Fix code coverage paths
+        if: |
+          steps.filter.outputs.core == 'true' ||
+          steps.filter.outputs.plugins == 'true'
+        run: |
+          find . -name jacoco_report.xml -exec sed -i 's#/home/runner/work/nutch/nutch#/github/workspace#g' {} +
+      - name: Analyze with SonarCloud
+        if: |
+          steps.filter.outputs.core == 'true' ||
+          steps.filter.outputs.plugins == 'true'
+        uses: sonarsource/sonarcloud-github-action@v3.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.organization=apache
+            -Dsonar.projectKey=apache-nutch
+            -Dsonar.sources=src/java
+            -Dsonar.test.exclusions=src/test/**
+            -Dsonar.tests=src/test/
+            -Dsonar.verbose=true
+            -Dsonar.java.binaries=build/classes,build/**/classes
+            -Dsonar.java.libraries=build/lib/*.jar   
+            -Dsonar.java.test.binaries=build/test/classes/,build/**/test/
+            -Dsonar.java.test.libraries=build/test/lib/*.jar
+            -Dsonar.java.source=11

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ ivy/dependency-check-ant/*
 .gradle*
 ivy/apache-rat-*
 .vscode
+ivy/jacoco-*

--- a/build.xml
+++ b/build.xml
@@ -20,7 +20,8 @@
          xmlns:ivy="antlib:org.apache.ivy.ant"
          xmlns:artifact="antlib:org.apache.maven.artifact.ant"
          xmlns:rat="antlib:org.apache.rat.anttasks"
-         xmlns="antlib:org.apache.tools.ant">
+         xmlns="antlib:org.apache.tools.ant"
+         xmlns:jacoco="antlib:org.jacoco.ant">
 
   <!-- Load all the default properties, and any the user wants    -->
   <!-- to contribute (without having to type -D or edit this file -->
@@ -47,6 +48,15 @@
   <property name="apache-rat.version" value="0.16.1" />
   <property name="apache-rat.home" value="${ivy.dir}/apache-rat-${apache-rat.version}" />
   <property name="apache-rat.jar" value="${apache-rat.home}/apache-rat-${apache-rat.version}.jar" />
+
+  <property name="jacoco.version" value="0.8.12" />
+  <property name="jacoco.home" value="${ivy.dir}/jacoco-${jacoco.version}" />
+  <property name="jacoco.jar" value="${jacoco.home}/lib/jacocoant.jar" />
+  <property name="jacoco.output.dir" location="${build.dir}/jacoco" />
+  <property name="jacoco.destfile" location="${jacoco.output.dir}/jacoco.exec" />
+  <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml">
+    <classpath path="${jacoco.jar}" />
+  </taskdef>
 
   <condition property="using.jdk.11">
     <matches string="${java.version}" pattern="11.+" casesensitive="false" />
@@ -469,7 +479,7 @@
   <!-- ================================================================== -->
   <target name="test" depends="test-core, test-plugins" description="--> run JUnit tests"/>
 
-  <target name="test-core" depends="compile-core-test, job" description="--> run core JUnit tests only">
+  <target name="test-core" depends="jacoco-download, compile-core-test, job" description="--> run core JUnit tests only">
 
     <delete dir="${test.build.data}"/>
     <mkdir dir="${test.build.data}"/>
@@ -492,31 +502,54 @@
     <copy file="${test.src.dir}/filter-all.txt"
         todir="${test.build.classes}"/>
 
-    <junit printsummary="yes" haltonfailure="no" fork="yes" dir="${basedir}"
-      errorProperty="tests.failed" failureProperty="tests.failed" maxmemory="1000m">
-      <sysproperty key="test.build.data" value="${test.build.data}"/>
-      <sysproperty key="test.src.dir" value="${test.src.dir}"/>
-      <sysproperty key="javax.xml.parsers.DocumentBuilderFactory" value="com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"/>
-      <classpath refid="test.classpath"/>
-      <formatter type="${test.junit.output.format}" />
-      <batchtest todir="${test.build.dir}" unless="testcase">
-        <fileset dir="${test.src.dir}"
-                 includes="**/Test*.java" excludes="**/${test.exclude}.java" />
-      </batchtest>
-      <batchtest todir="${test.build.dir}" if="testcase">
-        <fileset dir="${test.src.dir}" includes="**/${testcase}.java"/>
-      </batchtest>
-    </junit>
+    <mkdir dir="${build.dir}/jacoco"/>
+    <jacoco:coverage destfile="${build.dir}/jacoco/jacoco.exec">
+      <junit printsummary="yes" haltonfailure="no" fork="true" dir="${basedir}"
+        errorProperty="tests.failed" failureProperty="tests.failed" 
+        maxmemory="1000m" forkmode="once" >
+        <sysproperty key="test.build.data" value="${test.build.data}"/>
+        <sysproperty key="test.src.dir" value="${test.src.dir}"/>
+        <sysproperty key="javax.xml.parsers.DocumentBuilderFactory" value="com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"/>
+        <classpath refid="test.classpath"/>
+        <formatter type="${test.junit.output.format}" />
+        <batchtest todir="${test.build.dir}" unless="testcase">
+          <fileset dir="${test.src.dir}"
+                   includes="**/Test*.java" excludes="**/${test.exclude}.java" />
+        </batchtest>
+        <batchtest todir="${test.build.dir}" if="testcase">
+          <fileset dir="${test.src.dir}" includes="**/${testcase}.java"/>
+        </batchtest>
+      </junit>
+    </jacoco:coverage>
+
+    <mkdir dir="${jacoco.output.dir}/html"/>
+    <mkdir dir="${jacoco.output.dir}/xml"/>
+    <jacoco:report>
+      <executiondata>
+          <file file="${jacoco.destfile}"/>
+      </executiondata>
+      <structure name="${final.name} Jacoco report">
+          <classfiles>
+              <fileset dir="${build.classes}"/>
+          </classfiles>
+          <sourcefiles encoding="UTF-8">
+              <fileset dir="${src.dir}"/>
+          </sourcefiles>
+      </structure>
+      <html destdir="${jacoco.output.dir}/html"
+        footer="${final.name} Jacoco report" encoding="UTF-8"/>
+      <xml destfile="${jacoco.output.dir}/xml/jacoco_report.xml" encoding="UTF-8"/>
+    </jacoco:report>
 
     <fail if="tests.failed">Tests failed!</fail>
 
   </target>
 
-  <target name="test-plugins" depends="resolve-test, compile" description="--> run plugin JUnit tests only">
+  <target name="test-plugins" depends="resolve-test, jacoco-download, compile" description="--> run plugin JUnit tests only">
     <ant dir="src/plugin" target="test" inheritAll="false"/>
   </target>
 
-  <target name="test-plugin" depends="resolve-test, compile" description="--> run a single plugin's JUnit tests">
+  <target name="test-plugin" depends="resolve-test, jacoco-download, compile" description="--> run a single plugin's JUnit tests">
     <ant dir="src/plugin" target="test-single" inheritAll="false"/>
   </target>
 
@@ -1042,9 +1075,9 @@
     </rat:report>
   </target>
 
-  <!-- ================================================================== -->
-  <!-- Spotbugs                                                           -->
-  <!-- ================================================================== -->
+  <!-- ========= -->
+  <!-- Spotbugs  -->
+  <!-- ========= -->
   <target name="spotbugs-download" description="--> download spotbugs jar">
     <available file="${spotbugs.jar}" property="spotbugs.jar.found"/>
     <antcall target="spotbugs-download-unchecked"/>
@@ -1052,7 +1085,7 @@
 
   <target name="spotbugs-download-unchecked" unless="spotbugs.jar.found"
           description="--> downloads the spotbugs binary (spotbugs-*.tgz).">
-    <get src="https://github.com/spotbugs/spotbugs/releases/download/${spotbugs.version}/spotbugs-${spotbugs.version}.tgz "
+    <get src="https://github.com/spotbugs/spotbugs/releases/download/${spotbugs.version}/spotbugs-${spotbugs.version}.tgz"
          dest="${ivy.dir}/spotbugs-${spotbugs.version}.tgz" usetimestamp="false" />
 
     <untar src="${ivy.dir}/spotbugs-${spotbugs.version}.tgz"
@@ -1109,11 +1142,26 @@
     </fileset>
   </path>
 
+  <!-- ======= -->
+  <!-- Jacoco  -->
+  <!-- ======= -->
+  <target name="jacoco-download" description="--> download jacoco jar">
+    <available file="${jacoco.jar}" property="jacoco.jar.found"/>
+    <antcall target="jacoco-download-unchecked"/>
+  </target>
 
-  <!-- ================================================================== -->
-  <!-- Eclipse targets                                                    -->
-  <!-- ================================================================== -->
+  <target name="jacoco-download-unchecked" unless="jacoco.jar.found"
+    description="--> downloads the jacoco binary">
+    <get src="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/${jacoco.version}/jacoco-${jacoco.version}.zip"
+      dest="${jacoco.home}.zip" usetimestamp="false" />
+    <unzip src="${jacoco.home}.zip" dest="${jacoco.home}" />
+    <delete file="${jacoco.home}.zip" />
+  </target>
 
+
+  <!-- ================ -->
+  <!-- Eclipse targets  -->
+  <!-- ================ -->
   <!-- classpath for generating eclipse project -->
   <path id="eclipse.classpath">
     <fileset dir="${build.lib.dir}">

--- a/src/plugin/build-plugin.xml
+++ b/src/plugin/build-plugin.xml
@@ -240,10 +240,10 @@
       </executiondata>
       <structure name="${final.name} Jacoco report">
           <classfiles>
-              <fileset dir="${build.plugins}"/>
+              <fileset dir="${build.classes}"/>
           </classfiles>
           <sourcefiles encoding="UTF-8">
-              <fileset dir="${plugins.dir}"/>
+              <fileset dir="${root}/src/java"/>
           </sourcefiles>
       </structure>
       <html destdir="${jacoco.output.dir}/html"

--- a/src/plugin/build-plugin.xml
+++ b/src/plugin/build-plugin.xml
@@ -16,7 +16,8 @@
  limitations under the License.
 -->
 <!-- Imported by plugin build.xml files to define default targets. -->
-<project xmlns:ivy="antlib:org.apache.ivy.ant">
+<project xmlns:ivy="antlib:org.apache.ivy.ant"
+         xmlns:jacoco="antlib:org.jacoco.ant">
 
   <property name="name" value="${ant.project.name}"/>
   <property name="root" value="${basedir}"/>
@@ -43,6 +44,9 @@
 
   <!-- load nutch defaults last so that they can be overridden above -->
   <property file="${nutch.root}/default.properties" />
+
+  <property name="jacoco.output.dir" location="${nutch.root}/build/jacoco"/>
+  <property name="jacoco.destfile" location="${jacoco.output.dir}/jacoco.exec"/>
 
   <ivy:settings id="ivy.instance" file="${nutch.root}/ivy/ivysettings.xml" />
 
@@ -208,21 +212,44 @@
   <target name="test" depends="compile-test, deploy" if="test.available">
     <echo message="Testing plugin: ${name}"/>
 
-    <junit printsummary="yes" haltonfailure="no" fork="yes"
-      errorProperty="tests.failed" failureProperty="tests.failed">
-      <sysproperty key="test.data" value="${build.test}/data"/>
-      <sysproperty key="test.input" value="${root}/data"/>
-      <sysproperty key="javax.xml.parsers.DocumentBuilderFactory" value="com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"/> 
-      <classpath refid="test.classpath"/>
-      <formatter type="${test.junit.output.format}" />
-      <batchtest todir="${build.test}" unless="testcase">
-        <fileset dir="${src.test}"
-                 includes="**/Test*.java" excludes="**/${test.exclude}.java" />
-      </batchtest>
-      <batchtest todir="${build.test}" if="testcase">
-        <fileset dir="${src.test}" includes="**/${testcase}.java"/>
-      </batchtest>
-    </junit>
+    <mkdir dir="${jacoco.output.dir}"/>
+    <jacoco:coverage destfile="${jacoco.destfile}">
+      <junit printsummary="yes" haltonfailure="no" fork="true"
+        errorProperty="tests.failed" failureProperty="tests.failed"
+        forkmode="once" >
+        <sysproperty key="test.data" value="${build.test}/data"/>
+        <sysproperty key="test.input" value="${root}/data"/>
+        <sysproperty key="javax.xml.parsers.DocumentBuilderFactory" value="com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"/> 
+        <classpath refid="test.classpath"/>
+        <formatter type="${test.junit.output.format}" />
+        <batchtest todir="${build.test}" unless="testcase">
+          <fileset dir="${src.test}"
+                   includes="**/Test*.java" excludes="**/${test.exclude}.java" />
+        </batchtest>
+        <batchtest todir="${build.test}" if="testcase">
+          <fileset dir="${src.test}" includes="**/${testcase}.java"/>
+        </batchtest>
+      </junit>
+    </jacoco:coverage>
+
+    <mkdir dir="${jacoco.output.dir}/html"/>
+    <mkdir dir="${jacoco.output.dir}/xml"/>
+    <jacoco:report>
+      <executiondata>
+          <file file="${jacoco.destfile}"/>
+      </executiondata>
+      <structure name="${final.name} Jacoco report">
+          <classfiles>
+              <fileset dir="${build.plugins}"/>
+          </classfiles>
+          <sourcefiles encoding="UTF-8">
+              <fileset dir="${plugins.dir}"/>
+          </sourcefiles>
+      </structure>
+      <html destdir="${jacoco.output.dir}/html"
+        footer="${final.name} Jacoco report" encoding="UTF-8"/>
+      <xml destfile="${jacoco.output.dir}/xml/jacoco_report.xml" encoding="UTF-8"/>
+    </jacoco:report>
 
     <fail if="tests.failed">Tests failed!</fail>
 

--- a/src/plugin/creativecommons/build.xml
+++ b/src/plugin/creativecommons/build.xml
@@ -22,7 +22,6 @@
   <!-- Deploy Unit test dependencies -->
   <target name="deps-test">
     <ant target="deploy" inheritall="false" dir="../nutch-extensionpoints"/>
-   <!--  <ant target="deploy" inheritall="false" dir="../parse-html"/> -->
   </target>
 
 </project>


### PR DESCRIPTION
PR for https://issues.apache.org/jira/browse/NUTCH-3085

The Jacoco code coverage reporting is working fine. 

Later down the line we can consider incorporating the existing Spotbugs reporting into this new SonarCloud scanning.

We need to work with INFRA on creating the following secrets for use in the new CI
* `secrets.GITHUB_TOKEN`
* `secrets.SONAR_TOKEN`

This CI will likely fail for a while until I figure out the above kinks. 