### PR TITLE
NUTCH-3087 BasicURLNormalizer to keep userinfo for protocols which mi…ght require it

### DIFF
--- a/src/plugin/urlnormalizer-basic/src/test/org/apache/nutch/net/urlnormalizer/basic/TestBasicURLNormalizer.java
+++ b/src/plugin/urlnormalizer-basic/src/test/org/apache/nutch/net/urlnormalizer/basic/TestBasicURLNormalizer.java
@@ -216,6 +216,32 @@ public class TestBasicURLNormalizer {
     normalizeTest("file:/var/www/html/////./bar/index.html",
         "file:/var/www/html/bar/index.html");
   }
+
+  @Test
+  public void testNUTCH3087() throws Exception {
+    // NUTCH-3087 userinfo to be kept in URLs with protocols usually requiring
+    // authentication
+    normalizeTest("ftp://user@ftp.example.org/path/file.txt",
+        "ftp://user@ftp.example.org/path/file.txt");
+    normalizeTest("ftp://john.doe@ftp.example.org/",
+        "ftp://john.doe@ftp.example.org/");
+    normalizeTest("ftp://user:password@ftp.example.org/path/file.txt",
+        "ftp://user:password@ftp.example.org/path/file.txt");
+    // But for HTTP(S) the userinfo should be removed.
+    // (example from https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
+    normalizeTest(
+        "https://john.doe@www.example.com:1234/forum/questions/?tag=networking&order=newest#top",
+        "https://www.example.com:1234/forum/questions/?tag=networking&order=newest");
+    // URLs with IPv6 address
+    normalizeTest("ftp://user@[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]/../path/file.txt",
+        "ftp://user@[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]/path/file.txt");
+    normalizeTest("https://user@[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]/",
+        "https://[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]/");
+    normalizeTest("https://user@[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]:443/",
+        "https://[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]/");
+    normalizeTest("https://user@[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]/path/../to/index.html",
+        "https://[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]/to/index.html");
+  }
   
   @Test
   public void testCurlyBraces() throws Exception {


### PR DESCRIPTION
…ght require it

- strip the userinfo from the authority only for HTTP and HTTPS

Thanks for your contribution to [Apache Nutch](https://nutch.apache.org/)! Your help is appreciated!

Before opening the pull request, please verify that
* there is an open issue on the [Nutch issue tracker](https://issues.apache.org/jira/projects/NUTCH) which describes the problem or the improvement. We cannot accept pull requests without an issue because the change wouldn't be listed in the release notes.
* the issue ID (`NUTCH-XXXX`)
  - is referenced in the title of the pull request
  - and placed in front of your commit messages surrounded by square brackets (`[NUTCH-XXXX] Issue or pull request title`)
* commits are squashed into a single one (or few commits for larger changes)
* Java source code follows [Nutch Eclipse Code Formatting rules](https://github.com/apache/nutch/blob/master/eclipse-codeformat.xml)
* Nutch is successfully built and unit tests pass by running `ant clean runtime test`
* there should be no conflicts when merging the pull request branch into the *recent* master branch. If there are conflicts, please try to rebase the pull request branch on top of a freshly pulled master branch.
* if new dependencies are added,
  - are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
  - are `LICENSE-binary` and `NOTICE-binary` updated accordingly?

We will be able to faster integrate your pull request if these conditions are met. If you have any questions how to fix your problem or about using Nutch in general, please sign up for the [Nutch mailing list](https://nutch.apache.org/mailing_lists.html). Thanks!
