### PR TITLE
[NUTCH-3106] fix Issue with SSLHandshakeException

### DIFF
--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -135,6 +135,7 @@
 		<dependency org="org.apache.httpcomponents" name="httpcore" rev="4.4.14" />
 
 		<dependency org="de.vandermeer" name="asciitable" rev="0.3.2" />
+		<dependency org="org.littleshoot" name="littleproxy" rev="1.1.2" conf="test->default"/>
 
 		<!--global exclusion -->
 		<exclude module="jmxtools" />

--- a/src/plugin/protocol-http/ivy.xml
+++ b/src/plugin/protocol-http/ivy.xml
@@ -37,6 +37,8 @@
   </publications>
 
   <dependencies>
+      <dependency org="org.littleshoot" name="littleproxy" rev="1.1.2" />
+      <dependency org="com.google.guava" name="guava" rev="20.0" force="true" />
   </dependencies>
   
 </ivy-module>

--- a/src/plugin/protocol-http/src/test/org/apache/nutch/protocol/http/TestProtocolHttpByProxy.java
+++ b/src/plugin/protocol-http/src/test/org/apache/nutch/protocol/http/TestProtocolHttpByProxy.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nutch.protocol.http;
+
+import org.apache.hadoop.io.Text;
+import org.apache.nutch.crawl.CrawlDatum;
+import org.apache.nutch.protocol.AbstractHttpProtocolPluginTest;
+import org.apache.nutch.protocol.Content;
+import org.apache.nutch.protocol.ProtocolOutput;
+import org.apache.nutch.protocol.ProtocolStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test cases for protocol-http by proxy
+ */
+public class TestProtocolHttpByProxy extends AbstractHttpProtocolPluginTest {
+
+  public static final String PROXY_HOST = "localhost";
+  public static final Integer PROXY_PORT = 8888;
+
+  public static final String TARGET_HOST = "www.baidu.com";
+  public static final Integer TARGET_PORT = 443;
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    conf.set("http.proxy.host", PROXY_HOST);
+    conf.set("http.proxy.port", PROXY_PORT.toString());
+    http.setConf(conf);
+
+    HttpProxyServer server = DefaultHttpProxyServer.bootstrap()
+        .withPort(PROXY_PORT).start();
+  }
+
+  @Override
+  protected String getPluginClassName() {
+    return "org.apache.nutch.protocol.http.Http";
+  }
+
+  @Test
+  public void testRequestByProxy() throws Exception {
+    Http httpObj = new Http();
+    httpObj.setConf(conf);
+
+    String url = "https://" + TARGET_HOST;
+    ProtocolOutput out = httpObj.getProtocolOutput(new Text(url),
+        new CrawlDatum());
+    assertNotNull(out);
+
+    ProtocolStatus status = out.getStatus();
+    assertNotNull(status);
+    assertTrue(status.isSuccess());
+
+    Content content = out.getContent();
+    assertNotNull(content);
+    assertTrue(content.toString().length() > 250);
+  }
+}


### PR DESCRIPTION
[NUTCH-3106](https://issues.apache.org/jira/projects/NUTCH/issues/NUTCH-3106) Fix SSLHandshakeException with proxy in protocol-http plugin.

Additionally, I added the TestProtocolHttpByProxy unit test using [LittleProxy](https://github.com/adamfisk/LittleProxy), though its error message differs from NUTCH-3106.

2025-02-02 22:35:43,575 ERROR o.a.n.p.h.Http [main] Failed to get protocol output
org.apache.nutch.protocol.http.api.HttpException: SSL connect to https://www.baidu.com failed with: **Unsupported or unrecognized SSL message**
	at org.apache.nutch.protocol.http.HttpResponse.<init>(HttpResponse.java:156) ~[classes/:?]
	at org.apache.nutch.protocol.http.Http.getResponse(Http.java:65) ~[classes/:?]
	at org.apache.nutch.protocol.http.api.HttpBase.getProtocolOutput(HttpBase.java:361) [classes/:?]
	at org.apache.nutch.protocol.http.TestProtocolHttpByProxy.testRequestByProxy(TestProtocolHttpByProxy.java:88) [classes/:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59) [junit-4.13.2.jar:4.13.2]
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12) [junit-4.13.2.jar:4.13.2]
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56) [junit-4.13.2.jar:4.13.2]
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17) [junit-4.13.2.jar:4.13.2]
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26) [junit-4.13.2.jar:4.13.2]
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27) [junit-4.13.2.jar:4.13.2]
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306) [junit-4.13.2.jar:4.13.2]
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100) [junit-4.13.2.jar:4.13.2]
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366) [junit-4.13.2.jar:4.13.2]
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103) [junit-4.13.2.jar:4.13.2]
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63) [junit-4.13.2.jar:4.13.2]
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331) [junit-4.13.2.jar:4.13.2]
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79) [junit-4.13.2.jar:4.13.2]
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329) [junit-4.13.2.jar:4.13.2]
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66) [junit-4.13.2.jar:4.13.2]
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293) [junit-4.13.2.jar:4.13.2]
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306) [junit-4.13.2.jar:4.13.2]
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413) [junit-4.13.2.jar:4.13.2]
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137) [junit-4.13.2.jar:4.13.2]
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69) [junit-rt.jar:?]
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38) [junit-rt.jar:?]
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11) [idea_rt.jar:?]
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35) [junit-rt.jar:?]
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:232) [junit-rt.jar:?]
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55) [junit-rt.jar:?]
Caused by: javax.net.ssl.SSLException: Unsupported or unrecognized SSL message
	at java.base/sun.security.ssl.SSLSocketInputRecord.handleUnknownRecord(SSLSocketInputRecord.java:457) ~[?:?]
	at java.base/sun.security.ssl.SSLSocketInputRecord.decode(SSLSocketInputRecord.java:175) ~[?:?]
	at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:111) ~[?:?]
	at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1506) ~[?:?]
	at java.base/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1421) ~[?:?]
	at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:455) ~[?:?]
	at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:426) ~[?:?]
	at org.apache.nutch.protocol.http.HttpResponse.<init>(HttpResponse.java:136) ~[classes/:?]
	... 32 more
Status: exception(16), lastModified=0: org.apache.nutch.protocol.http.api.HttpException: SSL connect to https://www.baidu.com failed with: Unsupported or unrecognized SSL message
