### PR TITLE
NUTCH-3110 Upgrade to Tika 3.1.0

### DIFF
--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -74,7 +74,7 @@
 			<exclude org="org.slf4j" name="*" />
 		</dependency><!-- End of Hadoop Dependencies -->
 
-		<dependency org="org.tallison.tika" name="tika-core-shaded" rev="2.9.1.0" conf="*->default" transitive="false"/>
+		<dependency org="org.tallison.tika" name="tika-core-shaded" rev="3.1.0.0" conf="*->default" transitive="false"/>
 
 		<dependency org="xml-apis" name="xml-apis" rev="1.4.01" /><!-- force this version as it is required by Tika -->
 		<dependency org="xerces" name="xercesImpl" rev="2.12.2" />

--- a/src/plugin/language-identifier/ivy.xml
+++ b/src/plugin/language-identifier/ivy.xml
@@ -37,7 +37,7 @@
   </publications>
 
   <dependencies>
-    <dependency org="org.tallison.tika" name="tika-langdetect-optimaize-shaded" rev="2.9.1.0" conf="*->default" transitive="false"/>
+    <dependency org="org.tallison.tika" name="tika-langdetect-optimaize-shaded" rev="3.1.0.0" conf="*->default" transitive="false"/>
   </dependencies>
   
 </ivy-module>

--- a/src/plugin/language-identifier/plugin.xml
+++ b/src/plugin/language-identifier/plugin.xml
@@ -26,7 +26,7 @@
          <export name="*"/>
       </library>
       <!-- dependencies of Tika's Optimaize language detector (tika-langdetect-optimaize) -->
-      <library name="tika-langdetect-optimaize-shaded-2.9.1.0.jar"/>
+      <library name="tika-langdetect-optimaize-shaded-3.1.0.0.jar"/>
     </runtime>
 
    <requires>

--- a/src/plugin/parse-js/plugin.xml
+++ b/src/plugin/parse-js/plugin.xml
@@ -36,7 +36,7 @@
               point="org.apache.nutch.parse.Parser">
       <implementation id="JSParser"
          class="org.apache.nutch.parse.js.JSParseFilter">
-        <parameter name="contentType" value="application/x-javascript|application/javascript"/>
+        <parameter name="contentType" value="(?:application/(?:x-)?|text/)javascript"/>
         <parameter name="pathSuffix"  value="js"/>
       </implementation>
    </extension>
@@ -45,7 +45,7 @@
               point="org.apache.nutch.parse.HtmlParseFilter">
       <implementation id="JSParseFilter"
          class="org.apache.nutch.parse.js.JSParseFilter">
-        <parameter name="contentType" value="application/x-javascript|application/javascript"/>
+        <parameter name="contentType" value="(?:application/(?:x-)?|text/)javascript"/>
         <parameter name="pathSuffix"  value=""/>
       </implementation>
    </extension>

--- a/src/plugin/parse-tika/ivy.xml
+++ b/src/plugin/parse-tika/ivy.xml
@@ -37,7 +37,7 @@
   </publications>
 
   <dependencies>
-    <dependency org="org.tallison.tika" name="tika-parsers-standard-package-shaded" rev="2.9.1.0" conf="*->default" transitive="false"/>
+    <dependency org="org.tallison.tika" name="tika-parsers-standard-package-shaded" rev="3.1.0.0" conf="*->default" transitive="false"/>
   </dependencies>
   
 </ivy-module>

--- a/src/plugin/parse-tika/plugin.xml
+++ b/src/plugin/parse-tika/plugin.xml
@@ -25,7 +25,7 @@
       <library name="parse-tika.jar">
          <export name="*"/>
       </library>
-      <library name="tika-parsers-standard-package-shaded-2.9.1.0.jar"/>
+      <library name="tika-parsers-standard-package-shaded-3.1.0.0.jar"/>
    </runtime>
 
    <requires>


### PR DESCRIPTION
- Upgrade to shaded Tika packages 3.1.0.0 provided by Tim Allison.
  The shaded packages are required to avoid version conflicts when running in distributed mode caused by incompatible versions of the commons-io jar shipped with Hadoop and required by Tika, cf. NUTCH-2959.
- Add "text/javascript" as MIME type supported by "parse-js". Note: This fixes the parse-js unit tests. Tika 3.1.0 identifies the Javascript test document as "text/javascript" instead of "application/javascript".

Todo:
- [ ] fix unit test o.a.n.parse.tika.TestDOMContentUtils : duplicated outlinks
- [ ] fix unit test o.a.n.parse.tika.TestHtmlParser : parsing a UTF-16 encoded HTML fails partially (no title, no keywords). Note: it might be that there are two BOMs in the test document.