### PR TITLE
Nutch 3115 Extend access to all filter plugin constructor call args to user's POJO in Arbitrary Indexer

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -2337,19 +2337,19 @@ CAUTION: Set the parser.timeout to -1 or a bigger value than 30, when using this
 
 <property>
   <name>index.arbitrary.overwrite.0</name>
+  <value></value>
   <description>Whether to overwrite any existing value in the doc for
     for fieldName. Default is false if not specified in config</description>
-  <value></value>
 </property>
 
 <property>
   <name>index.arbitrary.all.fields.access</name>
+  <value></value>
   <description>Whether to pass all indexing filter fields to constructor
   for the user POJO. These are the NutchDocument doc, Parse parse,
   url (as org.apache.hadoop.io.Text), CrawlDatum datum, and
   Inlinks inlinks objects. Default value is false to preserve
   compatibility with previous index-arbitrary behavior.</description>
-  <value></value>
 </property>
 
 <!-- parse-metatags plugin properties -->

--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -2342,6 +2342,16 @@ CAUTION: Set the parser.timeout to -1 or a bigger value than 30, when using this
   <value></value>
 </property>
 
+<property>
+  <name>index.arbitrary.all.fields.access</name>
+  <description>Whether to pass all indexing filter fields to constructor
+  for the user POJO. These are the NutchDocument doc, Parse parse,
+  url (as org.apache.hadoop.io.Text), CrawlDatum datum, and
+  Inlinks inlinks objects. Default value is false to preserve
+  compatibility with previous index-arbitrary behavior.</description>
+  <value></value>
+</property>
+
 <!-- parse-metatags plugin properties -->
 <property>
   <name>metatags.names</name>

--- a/src/plugin/index-arbitrary/src/java/org/apache/nutch/indexer/arbitrary/ArbitraryIndexingFilter.java
+++ b/src/plugin/index-arbitrary/src/java/org/apache/nutch/indexer/arbitrary/ArbitraryIndexingFilter.java
@@ -118,7 +118,13 @@ public class ArbitraryIndexingFilter implements IndexingFilter {
    *  NutchDocument fieldName if this is set to true. Default behavior is to
    *  add the value from calling methodName to existing values for fieldName. */
   private boolean overwrite = false;
-  
+
+  /** Optional flag to determine whether to pass all inputs to the filter
+   *  method in the plugin to the POJO class. Default is false to preserve
+   *  backward compatibility with earlier plugin. Note that the url is still
+   *  included in the POJO constructor. */
+  private boolean allFieldsAccess = false;
+
   /** Hadoop Configuration object to pass these values into the plugin. */
   private Configuration conf;
 
@@ -180,7 +186,16 @@ public class ArbitraryIndexingFilter implements IndexingFilter {
         } else {
           theMethod = theClass.getMethod(methodName);
         }
-        theConstructor = theClass.getDeclaredConstructor(String[].class);
+        if (allFieldsAccess) {
+          theConstructor = theClass.getDeclaredConstructor(String[].class,
+							   NutchDocument.class,
+							   Parse.class,
+							   Text.class,
+							   CrawlDatum.class,
+							   Inlinks.class);
+	} else {
+          theConstructor = theClass.getDeclaredConstructor(String[].class);
+	}
       } catch (Exception e) {
         LOG.error("Exception preparing reflection tasks. className was {}",
 		 String.valueOf(className));
@@ -189,9 +204,20 @@ public class ArbitraryIndexingFilter implements IndexingFilter {
       }
       try {
         constrArgs = new String[userConstrArgs.length + 1];
-        constrArgs[0] = url.toString();
         System.arraycopy(userConstrArgs,0,constrArgs,1,userConstrArgs.length);
-        instance = theConstructor.newInstance(new Object[]{constrArgs});
+	if (allFieldsAccess) {
+          instance = theConstructor.newInstance(constrArgs,
+						doc,
+						parse,
+						url,
+						datum,
+						inlinks);
+	} else {
+          constrArgs[0] = url.toString();
+          //System.arraycopy(userConstrArgs,0,constrArgs,1,userConstrArgs.length);
+          instance = theConstructor.newInstance(new Object[]{constrArgs});
+	}
+
         if (methodArgs.length > 0) {
           result = theMethod.invoke(instance, new Object[]{methodArgs});
         } else {
@@ -201,10 +227,10 @@ public class ArbitraryIndexingFilter implements IndexingFilter {
         LOG.error("Exception in reflection trying to instantiate/invoke. "
 		  + "url was {} & className was {}",
 		  String.valueOf(url), String.valueOf(className));
-        if (constrArgs.length > 0) {
+        if (constrArgs.length > 1) {
           LOG.error("constrArgs[1] was {}", String.valueOf(constrArgs[1]));
         }
-        LOG.error("methodName was {}", String.valueOf(className));
+        LOG.error("methodName was {}", String.valueOf(methodName));
         if (methodArgs.length > 0) {
           LOG.error("methodArgs[0] was {}", String.valueOf(methodArgs[0]));
         }
@@ -243,6 +269,8 @@ public class ArbitraryIndexingFilter implements IndexingFilter {
     this.conf = conf;
     arbitraryAddsCount = conf.getInt("index.arbitrary.function.count",1);
     LOG.info("Will process the first {} fieldName defs in config.", String.valueOf(arbitraryAddsCount));
+    allFieldsAccess = conf.getBoolean("index.arbitrary.all.fields.access",false);
+    LOG.info("POJO classes will " + (allFieldsAccess ? "" : "not ") + "have access to all filter constructor args.");
   }
 
   /**

--- a/src/plugin/index-arbitrary/src/test/org/apache/nutch/indexer/arbitrary/PopularityGauge.java
+++ b/src/plugin/index-arbitrary/src/test/org/apache/nutch/indexer/arbitrary/PopularityGauge.java
@@ -1,0 +1,69 @@
+package org.apache.nutch.indexer.arbitrary;
+
+import org.apache.nutch.parse.Parse;
+import org.apache.nutch.indexer.NutchDocument;
+import org.apache.nutch.crawl.CrawlDatum;
+import org.apache.nutch.crawl.Inlinks;
+import org.apache.hadoop.io.Text;
+
+import java.io.PrintStream;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Arrays;
+
+public class PopularityGauge {
+
+  private static PrintStream out = System.out;
+  private String words;
+  private NutchDocument doc;
+  private Parse parse;
+  private CrawlDatum datum;
+  private Inlinks inlinks;
+  private double popularityBoost;
+
+  public PopularityGauge(String args[],
+	      NutchDocument docIn,
+              Parse parseIn,
+              Text urlIn,
+              CrawlDatum datumIn,
+              Inlinks inlinksIn){
+    super();
+    doc = docIn;
+    inlinks = inlinksIn;
+    datum = datumIn;
+  }
+
+  public double getPopularityBoost() {
+    popularityBoost = (Double) doc.getFieldValue("popularityBoost");
+    if (datum.getStatus() == CrawlDatum.STATUS_FETCH_SUCCESS) {
+      Set anchorSet = new HashSet<>(Arrays.asList(inlinks.getAnchors()));
+      if(anchorSet.contains("dinosaur")){
+        popularityBoost = popularityBoost + 0.50;
+      } else {
+	popularityBoost = popularityBoost - 0.20;
+      }
+      if (anchorSet.contains("baseball")) {
+        popularityBoost = popularityBoost + 0.25;
+      } else {
+	popularityBoost = popularityBoost - 0.15;
+      }
+      if (anchorSet.contains("source code")) {
+        popularityBoost = popularityBoost + 0.25;
+      } else {
+	popularityBoost = popularityBoost - 0.15;
+      }
+    }
+    return popularityBoost;
+  }
+
+  public static void main(String[] args,
+			  NutchDocument doc,
+                          Parse parse,
+			  Text url,
+                          CrawlDatum datum,
+                          Inlinks inlinks) {
+    
+    PopularityGauge popGauge = new PopularityGauge(args,doc,parse,url,datum,inlinks);
+    out.println(popGauge.getPopularityBoost());
+  }
+}


### PR DESCRIPTION
This is the update to the Arbitrary Indexing Filter plugin that lets it optionally pass all its own constructor args (NutchDocument, Parse, Text (from Hadoop), CrawlDatum, and Inlinks) to the user's POJO constructor for their custom processing. There's a small typo correction in a logging statement, too, that output a class name when it claimed to output a method name, included here at no extra cost! :) 
