### PR TITLE
NUTCH-3119 Log4j package scanning is deprecated

### DIFF
--- a/conf/log4j2.xml
+++ b/conf/log4j2.xml
@@ -14,7 +14,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<Configuration status="INFO" name="Nutch" packages="">
+<Configuration status="INFO" name="Nutch">
   <Properties>
     <!-- default values that can be overridden by system properties:
            Note: the script bin/nutch sets these properties from the environment variables


### PR DESCRIPTION
- remove "package" attribute in log4j2.xml
