### PR TITLE
NUTCH-3124 Github workflow not run because of uncertified action "paths-changes-filter"

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - uses: dorny/paths-filter@v3.0.0
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter
         with:
           filters: |


### PR DESCRIPTION
Upgrade "paths-changes-filter" action to version 3.0.2 but pin the version using the Git commit hash.
