### PR TITLE
NUTCH-2887 Migrate to JUnit 5 Jupiter

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -475,55 +475,56 @@
     </antcall>
   </target>
 
-  <target name="test-core" depends="compile-core-test, job" description="--> run core JUnit tests only">
-
+  <target name="test-core" depends="compile-core-test, job" description="--> run core JUnit tests">
     <delete dir="${test.build.data}"/>
     <mkdir dir="${test.build.data}"/>
-    <!--
-     copy resources needed in junit tests
-    -->
     <copy todir="${test.build.data}">
       <fileset dir="src/testresources" includes="**/*"/>
     </copy>
+    <copy file="${test.src.dir}/log4j.properties" todir="${test.build.classes}"/>
+    <copy file="${test.src.dir}/crawl-tests.xml" todir="${test.build.classes}"/>
+    <copy file="${test.src.dir}/domain-urlfilter.txt" todir="${test.build.classes}"/>
+    <copy file="${test.src.dir}/filter-all.txt" todir="${test.build.classes}"/>
 
-    <copy file="${test.src.dir}/log4j.properties"
-          todir="${test.build.classes}"/>
-
-    <copy file="${test.src.dir}/crawl-tests.xml"
-        todir="${test.build.classes}"/>
-
-    <copy file="${test.src.dir}/domain-urlfilter.txt"
-        todir="${test.build.classes}"/>
-
-    <copy file="${test.src.dir}/filter-all.txt"
-        todir="${test.build.classes}"/>
-
-    <junit printsummary="yes" haltonfailure="no" fork="yes" dir="${basedir}"
-      errorProperty="tests.failed" failureProperty="tests.failed" maxmemory="1000m">
-      <sysproperty key="test.build.data" value="${test.build.data}"/>
-      <sysproperty key="test.src.dir" value="${test.src.dir}"/>
-      <sysproperty key="test.include.slow" value="${test.include.slow}"/>
-      <sysproperty key="javax.xml.parsers.DocumentBuilderFactory" value="com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"/>
+    <junitlauncher printSummary="true" haltOnFailure="true" failureProperty="tests.failed">
       <classpath refid="test.classpath"/>
-      <formatter type="${test.junit.output.format}" />
-      <batchtest todir="${test.build.dir}" unless="testcase">
-        <fileset dir="${test.src.dir}"
-                 includes="**/Test*.java" excludes="**/${test.exclude}.java" />
-      </batchtest>
-      <batchtest todir="${test.build.dir}" if="testcase">
-        <fileset dir="${test.src.dir}" includes="**/${testcase}.java"/>
-      </batchtest>
-    </junit>
+      <testclasses outputDir="${test.build.dir}" unless="testcase" includeEngines="junit-vintage">
+        <listener type="${test.junit.output.format}" sendSysOut="true" sendSysErr="true"/>
+        <fork dir="${basedir}">
+          <jvmarg value="-Xmx1000m"/>
+          <sysproperty key="test.build.data" value="${test.build.data}"/>
+          <sysproperty key="test.src.dir" value="${test.src.dir}"/>
+          <sysproperty key="test.include.slow" value="${test.include.slow}"/>
+          <sysproperty key="javax.xml.parsers.DocumentBuilderFactory" value="com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"/>
+        </fork>
+        <fileset dir="${test.build.classes}">
+          <include name="**/Test*.class"/>
+          <exclude name="**/${test.exclude}.class"/>
+        </fileset>
+      </testclasses>
+      <testclasses outputDir="${test.build.dir}" if="testcase" includeEngines="junit-vintage">
+        <listener type="${test.junit.output.format}" sendSysOut="true" sendSysErr="true"/>
+        <fork dir="${basedir}">
+          <jvmarg value="-Xmx1000m"/>
+          <sysproperty key="test.build.data" value="${test.build.data}"/>
+          <sysproperty key="test.src.dir" value="${test.src.dir}"/>
+          <sysproperty key="test.include.slow" value="${test.include.slow}"/>
+          <sysproperty key="javax.xml.parsers.DocumentBuilderFactory" value="com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"/>
+        </fork>
+        <fileset dir="${test.build.classes}">
+          <include name="**/${testcase}.class"/>
+        </fileset>
+      </testclasses>
+    </junitlauncher>
 
     <fail if="tests.failed">Tests failed!</fail>
-
   </target>
 
-  <target name="test-plugins" depends="resolve-test, compile, compile-core-test" description="--> run plugin JUnit tests only">
+  <target name="test-plugins" depends="resolve-test, compile, compile-core-test" description="--> run JUnit tests for all plugins">
     <ant dir="src/plugin" target="test" inheritAll="false"/>
   </target>
 
-  <target name="test-plugin" depends="resolve-test, compile, compile-core-test" description="--> run a single plugin's JUnit tests">
+  <target name="test-plugin" depends="resolve-test, compile, compile-core-test" description="--> run JUnit tests for a single plugin">
     <ant dir="src/plugin" target="test-single" inheritAll="false"/>
   </target>
 
@@ -541,7 +542,7 @@
     <antcall target="copy-libs"/>
   </target>
 
-  <target name="resolve-test" depends="clean-test-lib, init" description="--> resolve and retrieve dependencies with ivy">
+  <target name="resolve-test" depends="clean-test-lib, init" description="--> resolve and retrieve test dependencies with ivy">
     <ivy:resolve file="${ivy.file}" conf="test" log="download-only"/>
     <ivy:retrieve pattern="${test.build.lib.dir}/[artifact]-[revision](-[classifier]).[ext]" symlink="false" log="quiet"/>
     <antcall target="copy-libs"/>

--- a/default.properties
+++ b/default.properties
@@ -38,7 +38,7 @@ test.build.lib.dir = ${test.build.dir}/lib
 test.build.data =  ${test.build.dir}/data
 test.build.classes = ${test.build.dir}/classes
 test.build.javadoc = ${test.build.dir}/docs/api
-test.junit.output.format = plain
+test.junit.output.format = legacy-plain
 
 # Proxy Host and Port to use for building JavaDoc
 javadoc.proxy.host=-J-DproxyHost=

--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -118,8 +118,12 @@
 			<exclude org="org.gnu.inet" module="libidn" /><!-- LGPL 2.1 -->
 		</dependency>
 
-		<!--artifacts needed for testing -->
+		<!-- Keep the JUnit 4 dependency for test compilation and runtime support. Remove once migration is complete -->
 		<dependency org="junit" name="junit" rev="4.13.2" conf="test->default" />
+        <!-- JUnit 5 Platform Launcher (required for <junitlauncher> task) -->
+        <dependency org="org.junit.platform" name="junit-platform-launcher" rev="1.13.4" conf="test->default"/>
+        <!-- JUnit Vintage Engine (to run existing JUnit 4 tests). Remove once migration is complete -->
+        <dependency org="org.junit.vintage" name="junit-vintage-engine" rev="5.13.4" conf="test->default"/>
 		<dependency org="org.apache.mrunit" name="mrunit" rev="1.1.0" conf="test->default">
 			<artifact name="mrunit" ns0:classifier="hadoop2" />
 			<exclude org="log4j" module="log4j" />


### PR DESCRIPTION
# Whats in this PR?

Phase 1 of [NUTCH-2887](https://issues.apache.org/jira/browse/NUTCH-2887) which
1. introduces the JUnit 5 (Jupiter) dependencies including the `junit-vintage-engine` which allows us to run JUnit 4 tests as we gradually migrate `core` and `plugins` to JUnit 5.
1. replaces the (old) `<junit>` Ant task with `<junitlauncher` for the `test-core` Ant target.

# Next steps

## Phase 2 - core

1. Replace all JUnit 4 API usage in `core` tests with JUnit 5 implementations.
2. Investigate and use [annotations](https://docs.junit.org/current/user-guide/#writing-tests-annotations) in `core` tests which will reduce duplicate boilerplate and improve test filtering.

## Phase 3 - core

Same as in core above but replace `core` with `plugins`.

# Questions

1. Should we decompose this issue into three parts? In my opinion #791 ended up a mess and I would like to avoid that happening again. My proposal is therefore to merge this initial PR first. We then then merge phase 2 and finally phase 3. Any thoughts on this approach?
2. I'm going to also compile a list of out of scope nice to have items I uncover whilst working on this task.

Thanks for any comments. 👍 

