### PR TITLE
NUTCH-2887 Remove all dependencies on JUnit 4

### DIFF
--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -127,6 +127,9 @@
 		<dependency org="org.apache.mrunit" name="mrunit" rev="1.1.0" conf="test->default">
 			<artifact name="mrunit" ns0:classifier="hadoop2" />
 			<exclude org="log4j" module="log4j" />
+			<exclude org="junit" module="junit" />
+			<exclude org="org.powermock" module="powermock-module-junit4" />
+			<exclude org="com.google.guava" name="guava" />
 		</dependency>
 
 		<!-- Jetty used to serve test pages for unit tests, but is also provided as dependency of Hadoop -->

--- a/src/plugin/parse-js/src/test/org/apache/nutch/parse/js/TestJSParseFilter.java
+++ b/src/plugin/parse-js/src/test/org/apache/nutch/parse/js/TestJSParseFilter.java
@@ -16,8 +16,8 @@
  */
 package org.apache.nutch.parse.js;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -95,20 +95,23 @@ public class TestJSParseFilter {
     for (int i = 0; i < filenames.length; i++) {
       Outlink[] outlinks = getOutlinks(filenames[i]);
       if (filenames[i].endsWith("parse_pure_js_test.js")) {
-        assertEquals("number of outlinks in .js test file should be X", 2,
-            outlinks.length);
-        assertEquals("http://search.lucidimagination.com/p:nutch", outlinks[0].getToUrl());
+        assertEquals(2, outlinks.length,
+            "number of outlinks in .js test file should be X");
+        assertEquals("http://search.lucidimagination.com/p:nutch",
+            outlinks[0].getToUrl());
         assertEquals("http://search-lucene.com/nutch", outlinks[1].getToUrl());
       } else {
-        assertTrue("number of outlinks in .html file should be at least 2", outlinks.length >= 2);
+        assertTrue(outlinks.length >= 2,
+            "number of outlinks in .html file should be at least 2");
         Set<String> outlinkSet = new TreeSet<>();
         for (Outlink o : outlinks) {
           outlinkSet.add(o.getToUrl());
         }
-        assertTrue("http://search.lucidimagination.com/p:nutch not in outlinks",
-            outlinkSet.contains("http://search.lucidimagination.com/p:nutch"));
-        assertTrue("http://search-lucene.com/nutch not in outlinks",
-            outlinkSet.contains("http://search-lucene.com/nutch"));
+        assertTrue(
+            outlinkSet.contains("http://search.lucidimagination.com/p:nutch"),
+            "http://search.lucidimagination.com/p:nutch not in outlinks");
+        assertTrue(outlinkSet.contains("http://search-lucene.com/nutch"),
+            "http://search-lucene.com/nutch not in outlinks");
       }
     }
   }

--- a/src/test/org/apache/nutch/protocol/AbstractHttpProtocolPluginTest.java
+++ b/src/test/org/apache/nutch/protocol/AbstractHttpProtocolPluginTest.java
@@ -17,7 +17,7 @@
 package org.apache.nutch.protocol;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -286,10 +286,10 @@ public abstract class AbstractHttpProtocolPluginTest {
       httpStatusCode = Integer.parseInt(crawlDatum.getMetaData()
           .get(Nutch.PROTOCOL_STATUS_CODE_KEY).toString());
     }
-    assertEquals("HTTP Status Code for " + url, expectedCode, httpStatusCode);
+    assertEquals(expectedCode, httpStatusCode, "HTTP Status Code for " + url);
     if (httpStatusCode == 200 && expectedContentType != null) {
       Content content = protocolOutput.getContent();
-      assertEquals("ContentType " + url, "text/html", content.getContentType());
+      assertEquals("text/html", content.getContentType(), "ContentType " + url);
     }
     return protocolOutput;
   }


### PR DESCRIPTION
This PR removes all dependencies on JUnit 4:
- migrate unit tests of plugin parse-js
- finish migration of AbstractHttpProtocolPluginTest
- exclude transitive dependencies from MRUnit on
  - JUnit 4
  - further outdated but unused test libraries

