### PR TITLE
[NUTCH-3160] Remove System.exit(..) from reusable code

### DIFF
--- a/src/java/org/apache/nutch/metrics/NutchMetrics.java
+++ b/src/java/org/apache/nutch/metrics/NutchMetrics.java
@@ -82,6 +82,9 @@ public final class NutchMetrics {
   /** Counter group for WARC export operations. */
   public static final String GROUP_WARC_EXPORTER = "nutch_warc_exporter";
 
+  /** Counter group for Common Crawl data dumper tool. */
+  public static final String GROUP_COMMONCRAWL_DUMPER = "nutch_commoncrawl_dumper";
+
   /** Counter group for domain statistics operations. */
   public static final String GROUP_DOMAIN_STATS = "nutch_domain_stats";
 

--- a/src/java/org/apache/nutch/tools/CommonCrawlDataDumper.java
+++ b/src/java/org/apache/nutch/tools/CommonCrawlDataDumper.java
@@ -67,6 +67,8 @@ import org.apache.nutch.crawl.Inlinks;
 import org.apache.nutch.crawl.LinkDbReader;
 import org.apache.nutch.metadata.Metadata;
 import org.apache.nutch.metadata.Nutch;
+import org.apache.nutch.metrics.ErrorTracker;
+import org.apache.nutch.metrics.NutchMetrics;
 import org.apache.nutch.protocol.Content;
 import org.apache.nutch.util.DumpFileUtil;
 import org.apache.nutch.util.NutchConfiguration;
@@ -188,6 +190,7 @@ public class CommonCrawlDataDumper extends NutchTool implements Tool {
   private GzipCompressorOutputStream gzipOutput = null;
   private TarArchiveOutputStream tarOutput = null;
   private ArrayList<String> fileList = null;
+  private ErrorTracker errorTracker;
 
   /**
    * Main method for invoking this tool
@@ -210,6 +213,7 @@ public class CommonCrawlDataDumper extends NutchTool implements Tool {
    * @param config A populated {@link CommonCrawlConfig}
    */
   public CommonCrawlDataDumper(CommonCrawlConfig config) {
+    this();
     this.config = config;
   }
 
@@ -217,6 +221,7 @@ public class CommonCrawlDataDumper extends NutchTool implements Tool {
    * Constructor
    */
   public CommonCrawlDataDumper() {
+    this.errorTracker = new ErrorTracker(NutchMetrics.ERROR_OTHER_TOTAL);
   }
 
   /**
@@ -274,6 +279,7 @@ public class CommonCrawlDataDumper extends NutchTool implements Tool {
     if (parts == null || parts.size() == 0) {
       LOG.error( "No segment directories found in {} ",
           segmentRootDir.getAbsolutePath());
+      this.errorTracker.recordError(ErrorTracker.ErrorType.OTHER);
       return;
     }
     LOG.info("Found {} segment parts", parts.size());

--- a/src/java/org/apache/nutch/tools/CommonCrawlDataDumper.java
+++ b/src/java/org/apache/nutch/tools/CommonCrawlDataDumper.java
@@ -274,7 +274,7 @@ public class CommonCrawlDataDumper extends NutchTool implements Tool {
     if (parts == null || parts.size() == 0) {
       LOG.error( "No segment directories found in {} ",
           segmentRootDir.getAbsolutePath());
-      System.exit(1);
+      return;
     }
     LOG.info("Found {} segment parts", parts.size());
     if (gzip && !warc) {

--- a/src/java/org/apache/nutch/tools/CommonCrawlDataDumper.java
+++ b/src/java/org/apache/nutch/tools/CommonCrawlDataDumper.java
@@ -221,7 +221,7 @@ public class CommonCrawlDataDumper extends NutchTool implements Tool {
    * Constructor
    */
   public CommonCrawlDataDumper() {
-    this.errorTracker = new ErrorTracker(NutchMetrics.ERROR_OTHER_TOTAL);
+    this.errorTracker = new ErrorTracker(NutchMetrics.GROUP_COMMONCRAWL_DUMPER);
   }
 
   /**


### PR DESCRIPTION
This small patch removes a `System.exit()` within the code, causing e.g. tests to be terminated without notice. 

