### PR TITLE
parse: fix 'occured' -> 'occurred' typo in ParseStatus FAILED javadoc

### DIFF
--- a/src/java/org/apache/nutch/parse/ParseStatus.java
+++ b/src/java/org/apache/nutch/parse/ParseStatus.java
@@ -56,7 +56,7 @@ public class ParseStatus implements Writable {
   // Secondary failure codes go here:
 
   /**
-   * Parsing failed. An Exception occured (which may be retrieved from the
+   * Parsing failed. An Exception occurred (which may be retrieved from the
    * arguments).
    */
   public static final short FAILED_EXCEPTION = 200;


### PR DESCRIPTION
Javadoc on the `FAILED` `ParseStatus` constant in `src/java/org/apache/nutch/parse/ParseStatus.java:59` read `Parsing failed. An Exception occured`. Doc-only change.