### PR TITLE
NUTCH-3164 Catch specific exceptions in CrawlDbFilter so plugin errors no longer silently drop URLs

### DIFF
--- a/src/java/org/apache/nutch/crawl/CrawlDbFilter.java
+++ b/src/java/org/apache/nutch/crawl/CrawlDbFilter.java
@@ -18,6 +18,7 @@ package org.apache.nutch.crawl;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.net.MalformedURLException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +26,9 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Counter;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.nutch.metrics.ErrorTracker;
 import org.apache.nutch.metrics.NutchMetrics;
+import org.apache.nutch.net.URLFilterException;
 import org.apache.nutch.net.URLFilters;
 import org.apache.nutch.net.URLNormalizers;
 
@@ -56,6 +59,8 @@ public class CrawlDbFilter extends
   private Counter orphanRecordsRemovedCounter;
   private Counter urlsFilteredCounter;
 
+  private ErrorTracker errorTracker;
+
   private static final Logger LOG = LoggerFactory
       .getLogger(MethodHandles.lookup().lookupClass());
 
@@ -77,6 +82,9 @@ public class CrawlDbFilter extends
     
     // Initialize cached counter references
     initCounters(context);
+
+    // Initialize error tracker with cached counters (NUTCH-3164)
+    errorTracker = new ErrorTracker(NutchMetrics.GROUP_CRAWLDB_FILTER, context);
   }
 
   /**
@@ -114,17 +122,32 @@ public class CrawlDbFilter extends
     if (url != null && urlNormalizers) {
       try {
         url = normalizers.normalize(url, scope); // normalize the url
-      } catch (Exception e) {
-        LOG.warn("Skipping {}: ", url, e);
-        url = null;
+      } catch (MalformedURLException e) {
+        // NUTCH-3164: malformed URL is a legitimate reason to drop; tracked via
+        // ErrorTracker, not urlsFilteredCounter (which conflates filtering with
+        // malformed input).
+        LOG.error("Skipping malformed URL {}: {}", url, e.getMessage());
+        errorTracker.incrementCounters(e);
+        return;
+      } catch (RuntimeException e) {
+        // NUTCH-3164: a normalizer plugin bug must not silently delete URLs.
+        LOG.error("Unexpected exception normalizing {}, keeping URL: ", url, e);
+        errorTracker.incrementCounters(e);
       }
     }
     if (url != null && urlFiltering) {
       try {
         url = filters.filter(url); // filter the url
-      } catch (Exception e) {
-        LOG.warn("Skipping {}: ", url, e);
-        url = null;
+      } catch (URLFilterException e) {
+        // NUTCH-3164: URLFilterException signals an internal filter failure,
+        // not URL rejection (rejection is communicated by returning null).
+        // Track via ErrorTracker; do not drop the URL.
+        LOG.error("Filter error for {}, keeping URL: {}", url, e.getMessage());
+        errorTracker.incrementCounters(e);
+      } catch (RuntimeException e) {
+        // NUTCH-3164: a filter plugin bug must not silently delete URLs.
+        LOG.error("Unexpected exception filtering {}, keeping URL: ", url, e);
+        errorTracker.incrementCounters(e);
       }
     }
     if (url == null) {

--- a/src/test/org/apache/nutch/crawl/TestCrawlDbFilterExceptionHandling.java
+++ b/src/test/org/apache/nutch/crawl/TestCrawlDbFilterExceptionHandling.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nutch.crawl;
+
+import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Counter;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.nutch.metrics.ErrorTracker;
+import org.apache.nutch.net.URLFilterException;
+import org.apache.nutch.net.URLFilters;
+import org.apache.nutch.net.URLNormalizers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link CrawlDbFilter} exception handling (NUTCH-3164).
+ *
+ * <p>Verifies that:
+ * <ul>
+ * <li>{@link MalformedURLException} from the normalizer drops the URL but does
+ * NOT increment {@code urlsFilteredCounter} — malformed-input losses are no
+ * longer conflated with filtering.
+ * <li>{@link RuntimeException} from either the normalizer or filter does NOT
+ * drop the URL, so plugin bugs no longer silently delete data.
+ * <li>{@link URLFilterException} does NOT drop the URL: per the
+ * {@link org.apache.nutch.net.URLFilter} contract, rejection is signaled by
+ * returning {@code null}, not by an exception.
+ * <li>Every error path routes through {@link ErrorTracker}.
+ * </ul>
+ *
+ * <p>The mapper's {@link CrawlDbFilter#setup} method is bypassed because it
+ * would load real plugins from the {@code PluginRepository}. Private fields are
+ * populated by reflection, mirroring the pattern used in
+ * {@code TestCommonCrawlDataDumper}.
+ */
+@ExtendWith(MockitoExtension.class)
+public class TestCrawlDbFilterExceptionHandling {
+
+  @SuppressWarnings("rawtypes")
+  @Mock
+  private Mapper.Context context;
+
+  @Mock
+  private URLNormalizers normalizers;
+
+  @Mock
+  private URLFilters filters;
+
+  @Mock
+  private ErrorTracker errorTracker;
+
+  @Mock
+  private Counter urlsFilteredCounter;
+
+  private CrawlDbFilter mapper;
+  private Text key;
+  private CrawlDatum value;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    mapper = new CrawlDbFilter();
+    setField("urlNormalizers", true);
+    setField("urlFiltering", true);
+    setField("scope", URLNormalizers.SCOPE_CRAWLDB);
+    setField("normalizers", normalizers);
+    setField("filters", filters);
+    setField("errorTracker", errorTracker);
+    setField("urlsFilteredCounter", urlsFilteredCounter);
+
+    key = new Text("http://example.com");
+    value = new CrawlDatum(CrawlDatum.STATUS_DB_FETCHED, 0, 0.0f);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void malformedUrlFromNormalizer_isDroppedWithoutCountingAsFiltered()
+      throws Exception {
+    MalformedURLException ex = new MalformedURLException("bad URL");
+    when(normalizers.normalize(anyString(), anyString())).thenThrow(ex);
+
+    mapper.map(key, value, context);
+
+    verify(context, never()).write(any(), any());
+    verify(errorTracker, times(1)).incrementCounters(ex);
+    verify(urlsFilteredCounter, never()).increment(anyLong());
+    verify(filters, never()).filter(anyString());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void runtimeExceptionFromNormalizer_keepsUrl() throws Exception {
+    RuntimeException ex = new RuntimeException("normalizer plugin bug");
+    when(normalizers.normalize(anyString(), anyString())).thenThrow(ex);
+    when(filters.filter(anyString())).thenAnswer(inv -> inv.getArgument(0));
+
+    mapper.map(key, value, context);
+
+    verify(context, times(1)).write(eq(key), eq(value));
+    verify(errorTracker, times(1)).incrementCounters(ex);
+    verify(urlsFilteredCounter, never()).increment(anyLong());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void urlFilterException_keepsUrl() throws Exception {
+    when(normalizers.normalize(anyString(), anyString()))
+        .thenAnswer(inv -> inv.getArgument(0));
+    URLFilterException ex = new URLFilterException("internal filter error");
+    when(filters.filter(anyString())).thenThrow(ex);
+
+    mapper.map(key, value, context);
+
+    verify(context, times(1)).write(eq(key), eq(value));
+    verify(errorTracker, times(1)).incrementCounters(ex);
+    verify(urlsFilteredCounter, never()).increment(anyLong());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void runtimeExceptionFromFilter_keepsUrl() throws Exception {
+    when(normalizers.normalize(anyString(), anyString()))
+        .thenAnswer(inv -> inv.getArgument(0));
+    RuntimeException ex = new RuntimeException("filter plugin bug");
+    when(filters.filter(anyString())).thenThrow(ex);
+
+    mapper.map(key, value, context);
+
+    verify(context, times(1)).write(eq(key), eq(value));
+    verify(errorTracker, times(1)).incrementCounters(ex);
+    verify(urlsFilteredCounter, never()).increment(anyLong());
+  }
+
+  private void setField(String name, Object fieldValue) throws Exception {
+    Field f = CrawlDbFilter.class.getDeclaredField(name);
+    f.setAccessible(true);
+    f.set(mapper, fieldValue);
+  }
+}


### PR DESCRIPTION
## Summary

  Both catch blocks in `CrawlDbFilter.map()` caught generic `Exception` and set `url = null`, which silently dropped URLs both for legitimate filtering reasons and for plugin
  programming errors (NPE, etc.). The latter masked plugin bugs as ordinary filtering decisions.
  
  ## Changes

  **Normalizer block**
  - `MalformedURLException` — the only legitimate reason to drop. Tracked via `ErrorTracker` (`ErrorType.URL`) and no longer increments `urlsFilteredCounter`, which conflated
  filtering with malformed input.
  - `RuntimeException` — logged at ERROR and tracked, URL is **not** dropped so plugin bugs do not silently delete data.
  
  **Filter block**
  - `URLFilterException` — per the `URLFilter` contract, reserved for internal filter failures (rejection is signaled by returning `null`). Logged at ERROR and tracked, URL is
  **not** dropped.
  - `RuntimeException` — same handling as above.
  
  All error paths now use `ErrorTracker` for categorized counters and log at ERROR rather than WARN, per [@lewismc's recommendation in the JIRA 
  discussion](https://issues.apache.org/jira/browse/NUTCH-3164).
  
  ## JIRA

  [NUTCH-3164](https://issues.apache.org/jira/browse/NUTCH-3164)
  
  ## Test plan

  - [x] `ant compile` passes locally
  - [ ] No new unit tests in this PR; happy to add one if reviewers want a mock plugin throwing each exception type (flag as follow-up otherwise)
  
  ## Out of scope (separate tickets if desired)
  
  - Same `catch (Exception)` pattern exists in `Injector.filterNormalize` and ~20 other call sites of `normalizers.normalize` / `filters.filter` — per lewismc comment, those
  should be rolled out separately.
  - Whether to track normalized URLs as a metric system-wide.