### PR TITLE
Add AGENTS.md + SECURITY.md linking the project's security model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Agent guidance
+
+This file is read by automated agents (security scanners, code
+analyzers, AI assistants) operating on this repository. It
+points them at the human-authored references they should
+consult before producing output.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md), which links to
+the canonical model document at
+<https://nutch.apache.org/documentation/security/#security-model>.
+
+Agents that scan this repository should consult the linked
+security model for the project's threat model, in-scope /
+out-of-scope declarations, and known non-findings before
+reporting issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security
+
+Apache Nutch's security model and disclosure process are
+published on the project website rather than in the
+repository:
+
+- **Threat and security model**:
+  <https://nutch.apache.org/documentation/security/#security-model>
+- **Security policy, vulnerability reporting, advisories,
+  and CVEs**:
+  <https://nutch.apache.org/documentation/security/>
+
+The project website is the authoritative source; this file
+exists so agents and tooling that look for `SECURITY.md` in
+the repository can mechanically follow the link to the
+canonical documents.
+
+Please report any security issues to
+[security@apache.org](mailto:security@apache.org).


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or discuss as needed.** Nothing here is a requirement; the maintainer is the decision-maker.

## What this PR does

Adds two new files at the repo root:

- **`AGENTS.md`** — agent-instructions file with a Security section linking to `SECURITY.md`. The conventional first stop for automated agents (security scanners, code analyzers, AI assistants) operating on this repository.
- **`SECURITY.md`** — short pointer to the canonical security documents on the project website at <https://nutch.apache.org/documentation/security/>, plus the standard ASF reporting flow (`security@apache.org`). No threat-model content is duplicated — the website stays the source of truth.

Together they make the conventional `AGENTS.md → SECURITY.md → website` discoverability chain mechanically followable.

## Why

Two practical drivers:

1. **GitHub UI affordance.** GitHub's "Report a vulnerability" button surfaces the contents of `SECURITY.md` at the repo root. Without one, well-meaning reporters file public issues against perceived security gaps. The new `SECURITY.md` redirects them to the website's threat-model + reporting flow.

2. **Agent-driven security tooling discovery.** An automated agentic security scan the ASF Security team is piloting needs to mechanically locate the project's threat model via the conventional `AGENTS.md → SECURITY.md` chain at the designated commit. Without that chain resolving, the scan refuses to run (refusing upfront beats wasting reviewer cycles on a noise-heavy run against an unknown model).

The PMC opted in on a private thread with the ASF Security team; Sebastian Nagel picked option (b) — Security team opens the PR — in his 2026-05-26 reply.

## What this PR does NOT do

- It does **not** alter the existing security model. The model at <https://nutch.apache.org/documentation/security/#security-model> stays the source of truth.
- It does **not** introduce a new reporting alias. Reports continue to flow through `security@apache.org`.
- It does **not** touch other repository files.

Per Sebastian's "template or incomplete version, we can complete during PR review" note: this is exactly that — minimal scaffolding that lets the discoverability chain pass mechanically. The PMC can extend `AGENTS.md` over time with project-specific guidance for AI coding agents (general contribution rules, build conventions, etc.) — it's the agent-instruction file the security pointer lives in.

Questions / pushback / scope expansion welcome.
