### PR TITLE
NUTCH-3185 Upgrade NekoHTML to 1.9.22

### DIFF
--- a/src/plugin/headings/ivy.xml
+++ b/src/plugin/headings/ivy.xml
@@ -36,8 +36,4 @@
     <artifact conf="master"/>
   </publications>
 
-  <dependencies>
-    <dependency org="net.sourceforge.nekohtml" name="nekohtml" rev="1.9.19" conf="test->master"/>
-  </dependencies>
-  
 </ivy-module>

--- a/src/plugin/headings/plugin.xml
+++ b/src/plugin/headings/plugin.xml
@@ -30,6 +30,7 @@
 
    <requires>
       <import plugin="nutch-extensionpoints"/>
+      <import plugin="lib-nekohtml"/>
    </requires>
 
    <extension id="org.apache.nutch.parse.headings"

--- a/src/plugin/lib-nekohtml/ivy.xml
+++ b/src/plugin/lib-nekohtml/ivy.xml
@@ -37,7 +37,7 @@
   </publications>
 
   <dependencies>
-    <dependency org="net.sourceforge.nekohtml" name="nekohtml" rev="1.9.19" conf="*->master"/>
+    <dependency org="net.sourceforge.nekohtml" name="nekohtml" rev="1.9.22" conf="*->master"/>
   </dependencies>
   
 </ivy-module>

--- a/src/plugin/lib-nekohtml/plugin.xml
+++ b/src/plugin/lib-nekohtml/plugin.xml
@@ -30,7 +30,7 @@
    provider-name="net.sourceforge.nekohtml">
 
    <runtime>
-     <library name="nekohtml-1.9.19.jar">
+     <library name="nekohtml-1.9.22.jar">
         <export name="*"/>
      </library>
    </runtime>


### PR DESCRIPTION
- Upgrade the Neko version in lib-nekohtml (used by parse-html and headings plugins)
- Remove the dependency in the headings plugin, import the lib-nekohtml plugin instead. This is done in the build file of the headings plugin.