### PR TITLE
NUTCH-3189 Upgrade core dependencies

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -77,12 +77,14 @@ jobs:
       - name: Run Apache Rat
         run: ant clean releaseaudit -buildfile build.xml
       - name: Cache unknown licenses
-        run: echo "UNKNOWN_LICENSES=$(sed -n 18p /home/runner/work/nutch/nutch/build/apache-rat-report.txt)" >> $GITHUB_ENV
+        # Note: Apache RAT 0.18 only reports unknown licenses as "Unknown license: N" (if there are any)
+        run: |
+          echo "UNKNOWN_LICENSES=$(grep -E '^Unknown license: [0-9]+' /home/runner/work/nutch/nutch/build/apache-rat-report.txt)" >> $GITHUB_ENV
       - name: Versions
         run: |
           echo $UNKNOWN_LICENSES
       - name: Fail if any unknown licenses
-        if: ${{ env.UNKNOWN_LICENSES != '0 Unknown Licenses' }}
+        if: ${{ env.UNKNOWN_LICENSES != '' }}
         run: exit 1
 
   openapi-lint:

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -222,6 +222,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-csv
 com.fasterxml.jackson.dataformat:jackson-dataformat-smile
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8
+com.fasterxml.jackson.datatype:jackson-datatype-jsr310
 com.fasterxml.jackson.jaxrs:jackson-jaxrs-base
 com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations
@@ -230,7 +231,6 @@ com.fasterxml.woodstox:woodstox-core
 com.github.ben-manes.caffeine:caffeine
 com.github.crawler-commons:crawler-commons
 com.github.spullara.mustache.java:compiler
-com.github.stephenc.jcip:jcip-annotations
 com.google.auto:auto-common
 com.google.auto.service:auto-service
 com.google.auto.service:auto-service-annotations
@@ -336,10 +336,12 @@ io.opentelemetry:opentelemetry-semconv
 io.opentelemetry.semconv:opentelemetry-semconv
 io.ous:jtoml
 io.sgr:s2-geometry-library-java
+jakarta.validation:jakarta.validation-api
 javax.inject:javax.inject
 joda-time:joda-time
 net.arnx:jsonic
 net.bytebuddy:byte-buddy
+net.jodah:failsafe
 net.sourceforge.htmlunit:htmlunit
 net.sourceforge.htmlunit:htmlunit-cssparser
 net.sourceforge.htmlunit:htmlunit-xpath
@@ -358,19 +360,6 @@ org.apache.commons:commons-text
 org.apache.curator:curator-client
 org.apache.curator:curator-framework
 org.apache.curator:curator-recipes
-org.apache.cxf:cxf-core
-org.apache.cxf:cxf-rt-bindings-soap
-org.apache.cxf:cxf-rt-bindings-xml
-org.apache.cxf:cxf-rt-databinding-jaxb
-org.apache.cxf:cxf-rt-frontend-jaxrs
-org.apache.cxf:cxf-rt-frontend-jaxws
-org.apache.cxf:cxf-rt-frontend-simple
-org.apache.cxf:cxf-rt-security
-org.apache.cxf:cxf-rt-transports-http
-org.apache.cxf:cxf-rt-transports-http-jetty
-org.apache.cxf:cxf-rt-ws-addr
-org.apache.cxf:cxf-rt-ws-policy
-org.apache.cxf:cxf-rt-wsdl
 org.apache.hadoop:hadoop-annotations
 org.apache.hadoop:hadoop-auth
 org.apache.hadoop:hadoop-common
@@ -427,7 +416,6 @@ org.apache.lucene:lucene-sandbox
 org.apache.lucene:lucene-spatial-extras
 org.apache.lucene:lucene-spatial3d
 org.apache.lucene:lucene-suggest
-org.apache.neethi:neethi
 org.apache.pdfbox:fontbox
 org.apache.pdfbox:jbig2-imageio
 org.apache.pdfbox:jempbox
@@ -437,7 +425,7 @@ org.apache.pdfbox:pdfbox-tools
 org.apache.pdfbox:xmpbox
 org.apache.poi:poi
 org.apache.poi:poi-ooxml
-org.apache.poi:poi-ooxml-lite
+org.apache.poi:poi-ooxml-full
 org.apache.poi:poi-scratchpad
 org.apache.solr:solr-solrj
 org.apache.tika:tika-core
@@ -466,7 +454,6 @@ org.apache.tika:tika-parser-xml-module
 org.apache.tika:tika-parser-xmp-commons
 org.apache.tika:tika-parser-zip-commons
 org.apache.tika:tika-parsers-standard-package
-org.apache.ws.xmlschema:xmlschema-core
 org.apache.xmlbeans:xmlbeans
 org.apache.yetus:audience-annotations
 org.apache.zookeeper:zookeeper
@@ -481,6 +468,8 @@ org.eclipse.jetty:jetty-alpn-java-client
 org.eclipse.jetty:jetty-client
 org.eclipse.jetty:jetty-http
 org.eclipse.jetty:jetty-io
+org.eclipse.jetty:jetty-security
+org.eclipse.jetty:jetty-server
 org.eclipse.jetty:jetty-servlet
 org.eclipse.jetty:jetty-util
 org.eclipse.jetty:jetty-util-ajax
@@ -490,7 +479,6 @@ org.eclipse.jetty.http2:http2-client
 org.eclipse.jetty.http2:http2-common
 org.eclipse.jetty.http2:http2-hpack
 org.eclipse.jetty.http2:http2-http-client-transport
-org.eclipse.jetty.toolchain:jetty-servlet-api
 org.eclipse.jetty.websocket:websocket-api
 org.eclipse.jetty.websocket:websocket-client
 org.eclipse.jetty.websocket:websocket-common
@@ -562,7 +550,6 @@ org.xerial.snappy:snappy-java
 org.yaml:snakeyaml
 xerces:xercesImpl
 xml-apis:xml-apis
-xml-resolver:xml-resolver
 
 
 --------------------------------------------------------------------------------
@@ -612,6 +599,12 @@ BSD 3-clause License w/nuclear disclaimer
 com.github.jai-imageio:jai-imageio-core
 
 
+BSD License 2.0
+---------------
+
+jaxen:jaxen
+
+
 BSD licence
 -----------
 
@@ -635,7 +628,7 @@ org.bouncycastle:bcutil-jdk18on
 CDDL 1.0
 --------
 
-(licenses-binary/LICENSE-cddl-v1.0.txt)
+(licenses-binary/LICENSE-cddl-1.0.txt)
 
 org.codelibs:jhighlight
 
@@ -645,22 +638,7 @@ CDDL 1.1
 
 (licenses-binary/LICENSE-cddl-1.1.txt)
 
-com.github.pjfanning:jersey-json
-com.sun.jersey:jersey-client
-com.sun.jersey:jersey-core
-com.sun.jersey:jersey-server
-com.sun.jersey:jersey-servlet
-com.sun.jersey.contribs:jersey-guice
-com.sun.xml.bind:jaxb-impl
 javax.xml.bind:jaxb-api
-
-
-CDDL License
-------------
-
-(licenses-binary/LICENSE-cddl-license.txt)
-
-javax.ws.rs:jsr311-api
 
 
 CDDL/GPLv2+CE
@@ -669,14 +647,6 @@ CDDL/GPLv2+CE
 (licenses-binary/LICENSE-cddl-gplv2-ce.txt)
 
 javax.servlet:javax.servlet-api
-
-
-CPL
----
-
-(licenses-binary/LICENSE-cpl.txt)
-
-wsdl4j:wsdl4j
 
 
 Common Public License
@@ -694,8 +664,22 @@ EPL 2.0
 (licenses-binary/LICENSE-epl-2.0.txt)
 
 jakarta.annotation:jakarta.annotation-api
+jakarta.servlet:jakarta.servlet-api
+jakarta.servlet.jsp:jakarta.servlet.jsp-api
 jakarta.ws.rs:jakarta.ws.rs-api
 javax.ws.rs:javax.ws.rs-api
+org.glassfish.hk2:hk2-api
+org.glassfish.hk2:hk2-locator
+org.glassfish.hk2:hk2-utils
+org.glassfish.hk2:osgi-resource-locator
+org.glassfish.hk2.external:aopalliance-repackaged
+org.glassfish.hk2.external:jakarta.inject
+org.glassfish.jersey.containers:jersey-container-servlet
+org.glassfish.jersey.containers:jersey-container-servlet-core
+org.glassfish.jersey.core:jersey-client
+org.glassfish.jersey.core:jersey-common
+org.glassfish.jersey.core:jersey-server
+org.glassfish.jersey.inject:jersey-hk2
 
 
 Eclipse Distribution License v1.0
@@ -706,26 +690,11 @@ Eclipse Distribution License v1.0
 com.sun.activation:jakarta.activation
 com.sun.istack:istack-commons-runtime
 jakarta.activation:jakarta.activation-api
-jakarta.jws:jakarta.jws-api
 jakarta.xml.bind:jakarta.xml.bind-api
-jakarta.xml.soap:jakarta.xml.soap-api
-jakarta.xml.ws:jakarta.xml.ws-api
 org.eclipse.angus:angus-activation
 org.glassfish.jaxb:jaxb-core
 org.glassfish.jaxb:jaxb-runtime
 org.glassfish.jaxb:txw2
-
-
-Eclipse Public License - Version 2.0
-------------------------------------
-
-(licenses-binary/LICENSE-eclipse-public-license---version-2.0.txt)
-
-org.eclipse.jetty:jetty-http
-org.eclipse.jetty:jetty-io
-org.eclipse.jetty:jetty-security
-org.eclipse.jetty:jetty-server
-org.eclipse.jetty:jetty-util
 
 
 MIT
@@ -750,6 +719,12 @@ org.checkerframework:checker-qual
 org.jsoup:jsoup
 org.pcollections:pcollections
 org.slf4j:slf4j-api
+
+
+MPL 1.1
+-------
+
+org.javassist:javassist
 
 
 Mozilla Public License 1.1 (MPL 1.1)
@@ -796,3 +771,9 @@ UnRar License
 (licenses-binary/LICENSE-unrar-license.txt)
 
 com.github.junrar:junrar
+
+
+Zero-Clause BSD (0BSD)
+----------------------
+
+org.tukaani:xz

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -80,33 +80,6 @@ Apache Curator Framework
 # org.apache.curator:curator-recipes
 Apache Curator Recipes
 
-# org.apache.cxf:cxf-core
-Apache CXF Core (https://cxf.apache.org)
-# org.apache.cxf:cxf-rt-bindings-soap
-Apache CXF Runtime SOAP Binding (https://cxf.apache.org)
-# org.apache.cxf:cxf-rt-bindings-xml
-Apache CXF Runtime XML Binding (https://cxf.apache.org)
-# org.apache.cxf:cxf-rt-databinding-jaxb
-Apache CXF Runtime JAXB DataBinding (https://cxf.apache.org)
-# org.apache.cxf:cxf-rt-frontend-jaxrs
-Apache CXF Runtime JAX-RS Frontend (https://cxf.apache.org)
-# org.apache.cxf:cxf-rt-frontend-jaxws
-Apache CXF Runtime JAX-WS Frontend (https://cxf.apache.org)
-# org.apache.cxf:cxf-rt-frontend-simple
-Apache CXF Runtime Simple Frontend (https://cxf.apache.org)
-# org.apache.cxf:cxf-rt-security
-Apache CXF Runtime Security functionality (https://cxf.apache.org)
-# org.apache.cxf:cxf-rt-transports-http
-Apache CXF Runtime HTTP Transport (https://cxf.apache.org)
-# org.apache.cxf:cxf-rt-transports-http-jetty
-Apache CXF Runtime HTTP Jetty Transport (https://cxf.apache.org)
-# org.apache.cxf:cxf-rt-ws-addr
-Apache CXF Runtime WS Addressing (https://cxf.apache.org)
-# org.apache.cxf:cxf-rt-ws-policy
-Apache CXF Runtime WS Policy (https://cxf.apache.org)
-# org.apache.cxf:cxf-rt-wsdl
-Apache CXF Runtime Core for WSDL (https://cxf.apache.org)
-
 # org.apache.hadoop:hadoop-annotations
 Apache Hadoop Annotations
 # org.apache.hadoop:hadoop-auth
@@ -233,9 +206,6 @@ Apache Lucene Spatial 3D
 # org.apache.lucene:lucene-suggest
 Apache Lucene Suggest
 
-# org.apache.neethi:neethi
-Apache Neethi (https://ws.apache.org/neethi/)
-
 # org.apache.pdfbox:fontbox
 Apache FontBox (http://pdfbox.apache.org/)
 # org.apache.pdfbox:jbig2-imageio
@@ -255,8 +225,8 @@ Apache XmpBox
 Apache POI - Common (https://poi.apache.org/)
 # org.apache.poi:poi-ooxml
 Apache POI - API based on OPC and OOXML schemas (https://poi.apache.org/)
-# org.apache.poi:poi-ooxml-lite
-Apache POI (https://poi.apache.org/)
+# org.apache.poi:poi-ooxml-full
+Apache POI - OOXML schemas (full) (https://poi.apache.org/)
 # org.apache.poi:poi-scratchpad
 Apache POI (https://poi.apache.org/)
 
@@ -316,9 +286,6 @@ Apache Tika ZIP commons
 # org.apache.tika:tika-parsers-standard-package
 Apache Tika standard parser package
 
-# org.apache.ws.xmlschema:xmlschema-core
-Apache XmlSchema Core
-
 # org.apache.xmlbeans:xmlbeans
 Apache XmlBeans (https://xmlbeans.apache.org/)
 
@@ -367,7 +334,7 @@ HPPC Collections
 - license: The Apache Software License, Version 2.0
 
 # com.drewnoakes:metadata-extractor
-${project.groupId}:${project.artifactId} (https://drewnoakes.com/code/exif/)
+com.drewnoakes:metadata-extractor (https://drewnoakes.com/code/exif/)
 - license: The Apache Software License, Version 2.0
 
 # com.epam:parso
@@ -381,10 +348,10 @@ Jackson-annotations (http://github.com/FasterXML/jackson)
 Jackson-annotations (https://github.com/FasterXML/jackson)
 - license: The Apache Software License, Version 2.0
 # com.fasterxml.jackson.core:jackson-core
-Jackson-core (https://github.com/FasterXML/jackson-core)
+Jackson-core (https://github.com/FasterXML/jackson)
 - license: The Apache Software License, Version 2.0
 # com.fasterxml.jackson.core:jackson-core
-Jackson-core (https://github.com/FasterXML/jackson)
+Jackson-core (https://github.com/FasterXML/jackson-core)
 - license: The Apache Software License, Version 2.0
 # com.fasterxml.jackson.core:jackson-databind
 jackson-databind (http://github.com/FasterXML/jackson)
@@ -414,6 +381,9 @@ Jackson-dataformat-YAML (https://github.com/FasterXML/jackson-dataformats-text)
 
 # com.fasterxml.jackson.datatype:jackson-datatype-jdk8
 Jackson datatype: jdk8
+- license: The Apache Software License, Version 2.0
+# com.fasterxml.jackson.datatype:jackson-datatype-jsr310
+Jackson datatype: JSR310
 - license: The Apache Software License, Version 2.0
 
 # com.fasterxml.jackson.jaxrs:jackson-jaxrs-base
@@ -460,18 +430,9 @@ BSD 2-Clause License (https://github.com/luben/zstd-jni)
 - license: BSD 2-Clause License
   (licenses-binary/LICENSE-bsd-2-clause.txt)
 
-# com.github.pjfanning:jersey-json
-jersey-json (https://github.com/pjfanning/jersey-1.x)
-- license: CDDL 1.1
-  (licenses-binary/LICENSE-cddl-1.1.txt)
-
 # com.github.spullara.mustache.java:compiler
 compiler (http://github.com/spullara/mustache.java)
 - license: Apache License 2.0
-
-# com.github.stephenc.jcip:jcip-annotations
-JCIP Annotations under Apache License (http://stephenc.github.com/jcip-annotations)
-- license: Apache License, Version 2.0
 
 # com.github.virtuald:curvesapi
 curvesapi (https://github.com/virtuald/curvesapi)
@@ -541,7 +502,6 @@ J2ObjC Annotations (https://github.com/google/j2objc/)
 # com.google.re2j:re2j
 re2j (http://github.com/google/re2j)
 - license: The Go license
-  (licenses-binary/LICENSE-the-go-license.txt)
 
 # com.googlecode.juniversalchardet:juniversalchardet
 juniversalchardet (http://juniversalchardet.googlecode.com/)
@@ -563,7 +523,6 @@ Jackcess Encrypt (http://jackcessencrypt.sf.net)
 # com.ibm.icu:icu4j
 ICU4J (https://icu.unicode.org/)
 - license: Unicode-3.0
-  (licenses-binary/LICENSE-unicode-icu-license.txt)
 
 # com.jcraft:jsch
 JSch (http://www.jcraft.com/jsch/)
@@ -651,33 +610,6 @@ Jakarta Activation
 istack common utility code runtime
 - license: Eclipse Distribution License - v 1.0
   (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
-
-# com.sun.jersey:jersey-client
-jersey-client
-- license: CDDL 1.1
-  (licenses-binary/LICENSE-cddl-1.1.txt)
-# com.sun.jersey:jersey-core
-jersey-core
-- license: CDDL 1.1
-  (licenses-binary/LICENSE-cddl-1.1.txt)
-# com.sun.jersey:jersey-server
-jersey-server
-- license: CDDL 1.1
-  (licenses-binary/LICENSE-cddl-1.1.txt)
-# com.sun.jersey:jersey-servlet
-jersey-servlet
-- license: CDDL 1.1
-  (licenses-binary/LICENSE-cddl-1.1.txt)
-
-# com.sun.jersey.contribs:jersey-guice
-jersey-guice
-- license: CDDL 1.1
-  (licenses-binary/LICENSE-cddl-1.1.txt)
-
-# com.sun.xml.bind:jaxb-impl
-JAXB RI (http://jaxb.java.net/)
-- license: CDDL 1.1
-  (licenses-binary/LICENSE-cddl-1.1.txt)
 
 # com.tdunning:t-digest
 T-Digest (https://github.com/tdunning/t-digest)
@@ -771,7 +703,6 @@ Apache Commons Logging (https://commons.apache.org/proper/commons-logging/)
 # commons-net:commons-net
 Apache Commons Net (https://commons.apache.org/proper/commons-net/)
 - license: Apache License, Version 2.0
-# commons-net:commons-net
 
 # commons-validator:commons-validator
 Apache Commons Validator (http://commons.apache.org/proper/commons-validator/)
@@ -799,7 +730,7 @@ Failsafe
 - license: Apache License, Version 2.0
 
 # dk.brics:automaton
-dk.brics.automaton (https://www.brics.dk/automaton)
+dk.brics.automaton (http://www.brics.dk/automaton)
 - license: BSD
   (licenses-binary/LICENSE-bsd-2-clause.txt)
 
@@ -972,7 +903,7 @@ Google S2 geometry library (https://github.com/sgr-io/s2-geometry-library-java)
 - license: The Apache Software License, Version 2.0
 
 # jakarta.activation:jakarta.activation-api
-Jakarta Activation API jar
+JavaBeans Activation Framework API jar
 - license: EDL 1.0
   (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
 # jakarta.activation:jakarta.activation-api
@@ -985,10 +916,19 @@ Jakarta Annotations API (https://projects.eclipse.org/projects/ee4j.ca)
 - license: EPL 2.0
   (licenses-binary/LICENSE-epl-2.0.txt)
 
-# jakarta.jws:jakarta.jws-api
-Jakarta Web Services Metadata API (https://github.com/eclipse-ee4j/jws-api)
-- license: Eclipse Distribution License - v 1.0
-  (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
+# jakarta.servlet:jakarta.servlet-api
+Jakarta Servlet (https://projects.eclipse.org/projects/ee4j.servlet)
+- license: EPL 2.0
+  (licenses-binary/LICENSE-epl-2.0.txt)
+
+# jakarta.servlet.jsp:jakarta.servlet.jsp-api
+Jakarta Server Pages API (https://projects.eclipse.org/projects/ee4j.jsp)
+- license: EPL 2.0
+  (licenses-binary/LICENSE-epl-2.0.txt)
+
+# jakarta.validation:jakarta.validation-api
+Jakarta Bean Validation API (https://beanvalidation.org)
+- license: Apache License 2.0
 
 # jakarta.ws.rs:jakarta.ws.rs-api
 jakarta.ws.rs-api (https://github.com/eclipse-ee4j/jaxrs-api)
@@ -997,16 +937,6 @@ jakarta.ws.rs-api (https://github.com/eclipse-ee4j/jaxrs-api)
 
 # jakarta.xml.bind:jakarta.xml.bind-api
 Jakarta XML Binding API
-- license: Eclipse Distribution License - v 1.0
-  (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
-
-# jakarta.xml.soap:jakarta.xml.soap-api
-Jakarta SOAP with Attachments API (https://github.com/eclipse-ee4j/saaj-api)
-- license: Eclipse Distribution License - v 1.0
-  (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
-
-# jakarta.xml.ws:jakarta.xml.ws-api
-Jakarta XML Web Services API (https://github.com/eclipse-ee4j/jax-ws-api)
 - license: Eclipse Distribution License - v 1.0
   (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
 
@@ -1019,16 +949,10 @@ Java Servlet API (http://servlet-spec.java.net)
 - license: CDDL + GPLv2 with classpath exception
   (licenses-binary/LICENSE-cddl-gplv2-ce.txt)
 
-# javax.servlet.jsp:jsp-api
-
 # javax.ws.rs:javax.ws.rs-api
 javax.ws.rs-api (https://github.com/eclipse-ee4j/jaxrs-api)
 - license: EPL 2.0
   (licenses-binary/LICENSE-epl-2.0.txt)
-# javax.ws.rs:jsr311-api
-jsr311-api (https://jsr311.dev.java.net)
-- license:                  CDDL License             
-  (licenses-binary/LICENSE-cddl-license.txt)
 
 # javax.xml.bind:jaxb-api
 Java Architecture for XML Binding (http://jaxb.java.net/)
@@ -1036,6 +960,8 @@ Java Architecture for XML Binding (http://jaxb.java.net/)
   (licenses-binary/LICENSE-cddl-1.1.txt)
 
 # jaxen:jaxen
+jaxen
+- license: BSD License 2.0
 
 # joda-time:joda-time
 Joda-Time (http://www.joda.org/joda-time/)
@@ -1055,6 +981,10 @@ Byte Buddy (without dependencies)
 # net.java.dev.jna:jna
 Java Native Access (https://github.com/java-native-access/jna)
 - license: LGPL, version 2.1
+
+# net.jodah:failsafe
+Failsafe (https://failsafe.dev)
+- license: Apache License, Version 2.0
 
 # net.sf.jopt-simple:jopt-simple
 JOpt Simple (http://pholser.github.io/jopt-simple)
@@ -1123,10 +1053,6 @@ Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs (https://www.b
 - license: Bouncy Castle Licence
   (licenses-binary/LICENSE-bouncy-castle-licence.txt)
 # org.bouncycastle:bcprov-jdk18on
-Bouncy Castle Provider (https://www.bouncycastle.org/java.html)
-- license: Bouncy Castle Licence
-  (licenses-binary/LICENSE-bouncy-castle-licence.txt)
-# org.bouncycastle:bcprov-jdk18on
 Bouncy Castle Provider (https://www.bouncycastle.org/download/bouncy-castle-java/)
 - license: Bouncy Castle Licence
   (licenses-binary/LICENSE-bouncy-castle-licence.txt)
@@ -1161,10 +1087,6 @@ Jettison (https://github.com/jettison-json/jettison)
 Stax2 API (http://github.com/FasterXML/stax2-api)
 - license: The BSD License
   (licenses-binary/LICENSE-bsd-2-clause.txt)
-# org.codehaus.woodstox:stax2-api
-Stax2 API (http://github.com/FasterXML/stax2-api)
-- license: The BSD 2-Clause License
-  (licenses-binary/LICENSE-bsd-2-clause.txt)
 
 # org.codelibs:jhighlight
 JHighlight (https://github.com/codelibs/jhighlight)
@@ -1188,35 +1110,21 @@ Jetty :: Asynchronous HTTP Client
 # org.eclipse.jetty:jetty-http
 Jetty :: Http Utility
 - license: Apache Software License - Version 2.0
-# org.eclipse.jetty:jetty-http
-Jetty :: Http Utility
-- license: Eclipse Public License - Version 2.0
-  (licenses-binary/LICENSE-epl-2.0.txt)
 # org.eclipse.jetty:jetty-io
 Jetty :: IO Utility
 - license: Apache Software License - Version 2.0
-# org.eclipse.jetty:jetty-io
-Jetty :: IO Utility
-- license: Eclipse Public License - Version 2.0
-  (licenses-binary/LICENSE-epl-2.0.txt)
 # org.eclipse.jetty:jetty-security
 Jetty :: Security
-- license: Eclipse Public License - Version 2.0
-  (licenses-binary/LICENSE-epl-2.0.txt)
+- license: Apache Software License - Version 2.0
 # org.eclipse.jetty:jetty-server
 Jetty :: Server Core
-- license: Eclipse Public License - Version 2.0
-  (licenses-binary/LICENSE-epl-2.0.txt)
+- license: Apache Software License - Version 2.0
 # org.eclipse.jetty:jetty-servlet
 Jetty :: Servlet Handling
 - license: Apache Software License - Version 2.0
 # org.eclipse.jetty:jetty-util
 Jetty :: Utilities
 - license: Apache Software License - Version 2.0
-# org.eclipse.jetty:jetty-util
-Jetty :: Utilities
-- license: Eclipse Public License - Version 2.0
-  (licenses-binary/LICENSE-epl-2.0.txt)
 # org.eclipse.jetty:jetty-util-ajax
 Jetty :: Utilities :: Ajax(JSON)
 - license: Apache Software License - Version 2.0
@@ -1238,10 +1146,6 @@ Jetty :: HTTP2 :: HPACK
 - license: Apache Software License - Version 2.0
 # org.eclipse.jetty.http2:http2-http-client-transport
 Jetty :: HTTP2 :: HTTP Client Transport
-- license: Apache Software License - Version 2.0
-
-# org.eclipse.jetty.toolchain:jetty-servlet-api
-Jetty :: Servlet API and Schemas for JPMS and OSGi
 - license: Apache Software License - Version 2.0
 
 # org.eclipse.jetty.websocket:websocket-api
@@ -1311,6 +1215,32 @@ Ogg and Vorbis for Java, Core (https://github.com/Gagravarr/VorbisJava)
 Apache Tika plugin for Ogg, Vorbis and FLAC (https://github.com/Gagravarr/VorbisJava)
 - license: The Apache Software License, Version 2.0
 
+# org.glassfish.hk2:hk2-api
+HK2 API module
+- license: EPL 2.0
+  (licenses-binary/LICENSE-epl-2.0.txt)
+# org.glassfish.hk2:hk2-locator
+ServiceLocator Default Implementation
+- license: EPL 2.0
+  (licenses-binary/LICENSE-epl-2.0.txt)
+# org.glassfish.hk2:hk2-utils
+HK2 Implementation Utilities
+- license: EPL 2.0
+  (licenses-binary/LICENSE-epl-2.0.txt)
+# org.glassfish.hk2:osgi-resource-locator
+OSGi resource locator
+- license: EPL 2.0
+  (licenses-binary/LICENSE-epl-2.0.txt)
+
+# org.glassfish.hk2.external:aopalliance-repackaged
+aopalliance version ${aopalliance.version} repackaged as a module
+- license: EPL 2.0
+  (licenses-binary/LICENSE-epl-2.0.txt)
+# org.glassfish.hk2.external:jakarta.inject
+javax.inject:${javax-inject.version} as OSGi bundle
+- license: EPL 2.0
+  (licenses-binary/LICENSE-epl-2.0.txt)
+
 # org.glassfish.jaxb:jaxb-core
 JAXB Core (https://eclipse-ee4j.github.io/jaxb-ri/)
 - license: Eclipse Distribution License - v 1.0
@@ -1323,6 +1253,33 @@ JAXB Runtime (https://eclipse-ee4j.github.io/jaxb-ri/)
 TXW2 Runtime (https://eclipse-ee4j.github.io/jaxb-ri/)
 - license: Eclipse Distribution License - v 1.0
   (licenses-binary/LICENSE-eclipse-distribution-license-v1.0.txt)
+
+# org.glassfish.jersey.containers:jersey-container-servlet
+jersey-container-servlet
+- license: EPL 2.0
+  (licenses-binary/LICENSE-epl-2.0.txt)
+# org.glassfish.jersey.containers:jersey-container-servlet-core
+jersey-container-servlet-core
+- license: EPL 2.0
+  (licenses-binary/LICENSE-epl-2.0.txt)
+
+# org.glassfish.jersey.core:jersey-client
+jersey-core-client
+- license: EPL 2.0
+  (licenses-binary/LICENSE-epl-2.0.txt)
+# org.glassfish.jersey.core:jersey-common
+jersey-core-common
+- license: EPL 2.0
+  (licenses-binary/LICENSE-epl-2.0.txt)
+# org.glassfish.jersey.core:jersey-server
+jersey-core-server
+- license: EPL 2.0
+  (licenses-binary/LICENSE-epl-2.0.txt)
+
+# org.glassfish.jersey.inject:jersey-hk2
+jersey-inject-hk2
+- license: EPL 2.0
+  (licenses-binary/LICENSE-epl-2.0.txt)
 
 # org.hdrhistogram:HdrHistogram
 HdrHistogram (http://hdrhistogram.github.io/HdrHistogram/)
@@ -1338,10 +1295,13 @@ HTML Parser Jar (http://htmlparser.org)
 - license: Common Public License
   (licenses-binary/LICENSE-common-public-license.txt)
 
+# org.javassist:javassist
+Javassist (https://www.javassist.org/)
+- license: MPL 1.1
+
 # org.jdom:jdom
 JDOM (http://www.jdom.org)
 - license: Similar to Apache License but with the acknowledgment clause removed
-# org.jdom:jdom
 # org.jdom:jdom2
 JDOM (http://www.jdom.org)
 - license: Similar to Apache License but with the acknowledgment clause removed
@@ -1355,7 +1315,7 @@ IntelliJ IDEA Annotations (http://www.jetbrains.org)
 
 # org.jetbrains.kotlin:kotlin-stdlib
 Kotlin Stdlib (https://kotlinlang.org/)
-- license: Apache-2.0
+- license: The Apache License, Version 2.0
 
 # org.jline:jline
 JLine Bundle
@@ -1567,19 +1527,10 @@ SnakeYAML (http://www.snakeyaml.org)
 SnakeYAML (https://bitbucket.org/snakeyaml/snakeyaml)
 - license: Apache License, Version 2.0
 
-# wsdl4j:wsdl4j
-WSDL4J (http://sf.net/projects/wsdl4j)
-- license: CPL
-  (licenses-binary/LICENSE-cpl.txt)
-
 # xerces:xercesImpl
 Xerces2-j (https://xerces.apache.org/xerces2-j/)
 - license: The Apache Software License, Version 2.0
 
 # xml-apis:xml-apis
 XML Commons External Components XML APIs (http://xml.apache.org/commons/components/external/)
-- license: The Apache Software License, Version 2.0
-
-# xml-resolver:xml-resolver
-XML Commons Resolver Component (http://xml.apache.org/commons/components/resolver/)
 - license: The Apache Software License, Version 2.0

--- a/build.xml
+++ b/build.xml
@@ -49,7 +49,7 @@
   <property name="jacoco.ant.jar" value="${jacoco.home}/lib/jacocoant.jar" />
   <property name="coverage.dir" value="${build.dir}/coverage" />
 
-  <property name="apache-rat.version" value="0.16" />
+  <property name="apache-rat.version" value="0.18" />
   <property name="apache-rat.home" value="${ivy.dir}/apache-rat-${apache-rat.version}" />
   <property name="apache-rat.jar" value="${apache-rat.home}/apache-rat-${apache-rat.version}.jar" />
 
@@ -1017,7 +1017,9 @@
       <fileset dir="src">
         <include name="**"/>
         <exclude name="plugin/language-identifier/src/java/org/apache/nutch/analysis/lang/langmappings.properties"/>
+        <exclude name="plugin/language-identifier/src/test/org/apache/nutch/analysis/lang/da.test"/>
         <exclude name="plugin/language-identifier/src/test/org/apache/nutch/analysis/lang/de.test"/>
+        <exclude name="plugin/language-identifier/src/test/org/apache/nutch/analysis/lang/el.test"/>
         <exclude name="plugin/language-identifier/src/test/org/apache/nutch/analysis/lang/en.test"/>
         <exclude name="plugin/language-identifier/src/test/org/apache/nutch/analysis/lang/es.test"/>
         <exclude name="plugin/language-identifier/src/test/org/apache/nutch/analysis/lang/fi.test"/>
@@ -1027,7 +1029,6 @@
         <exclude name="plugin/language-identifier/src/test/org/apache/nutch/analysis/lang/pt.test"/>
         <exclude name="plugin/language-identifier/src/test/org/apache/nutch/analysis/lang/sv.test"/>
         <exclude name="plugin/language-identifier/src/test/org/apache/nutch/analysis/lang/test-referencial.txt"/>
-        <exclude name="plugin/language-identifier/src/test/org/apache/nutch/analysis/lang/da.test"/>
         <exclude name="plugin/parse-tika/sample/ootest.txt"/>
         <exclude name="plugin/parse-tika/sample/test.rtf"/>
         <exclude name="plugin/urlfilter-ignoreexempt/data/.donotdelete"/>

--- a/default.properties
+++ b/default.properties
@@ -44,7 +44,7 @@ test.build.javadoc = ${test.build.dir}/docs/api
 test.failfast = false
 
 # JaCoCo code coverage
-jacoco.version=0.8.12
+jacoco.version=0.8.15
 
 # Apache Hadoop client libraries (Ivy rev for hadoop-common, hadoop-hdfs, mapreduce artifacts)
 hadoop.version=3.5.0

--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -131,10 +131,8 @@
     <dependency org="org.mockftpserver" name="MockFtpServer" rev="3.2.0" conf="test->default"/>
 
     <!-- MockServer (https://www.mock-server.com/) for static HTTP content in unit tests. -->
-    <dependency org="org.mock-server" name="mockserver-netty" rev="5.15.0" conf="test->default">
-      <exclude org="ch.qos.reload4j" module="*" />
-      <exclude org="org.slf4j" module="slf4j-reload" />
-    </dependency>
+    <dependency org="org.mock-server" name="mockserver-netty-no-dependencies" rev="7.2.0" conf="test->default" />
+    <dependency org="org.mock-server" name="mockserver-client-java-no-dependencies" rev="7.2.0" conf="test->default" />
 
     <!--Added Because of Elasticsearch JEST client-->
     <!--TODO refactor these to indexer-elastic-rest plugin somehow, currently doesn't resolve correctly-->

--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -76,7 +76,6 @@
 
     <dependency org="org.apache.tika" name="tika-core" rev="3.3.1" conf="*->default"/>
 
-    <dependency org="xml-apis" name="xml-apis" rev="1.4.01" /><!-- force this version as it is required by Tika -->
     <dependency org="xerces" name="xercesImpl" rev="2.12.2" />
 
     <dependency org="com.ibm.icu" name="icu4j" rev="78.3" />

--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -38,19 +38,19 @@
   </publications>
 
   <dependencies>
-    <dependency org="org.apache.logging.log4j" name="log4j-api" rev="2.25.2" conf="*->master" />
-    <dependency org="org.apache.logging.log4j" name="log4j-core" rev="2.25.2" conf="*->master" />
-    <dependency org="org.apache.logging.log4j" name="log4j-slf4j2-impl" rev="2.25.2" conf="*->master" />
-    <dependency org="org.slf4j" name="slf4j-api" rev="2.0.17" conf="*->master" />
+    <dependency org="org.apache.logging.log4j" name="log4j-api" rev="2.26.0" conf="*->master" />
+    <dependency org="org.apache.logging.log4j" name="log4j-core" rev="2.26.0" conf="*->master" />
+    <dependency org="org.apache.logging.log4j" name="log4j-slf4j2-impl" rev="2.26.0" conf="*->master" />
+    <dependency org="org.slf4j" name="slf4j-api" rev="2.0.18" conf="*->master" />
 
     <dependency org="org.apache.commons" name="commons-lang3" rev="3.20.0" conf="*->default" />
     <dependency org="org.apache.commons" name="commons-collections4" rev="4.5.0" conf="*->master" />
     <dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.14" conf="*->master" />
     <!-- commons-httpclient is still required -->
     <dependency org="commons-httpclient" name="commons-httpclient" rev="3.1"/>
-    <dependency org="commons-codec" name="commons-codec" rev="1.20.0" conf="*->default" />
+    <dependency org="commons-codec" name="commons-codec" rev="1.22.0" conf="*->default" />
 
-    <dependency org="commons-io" name="commons-io" rev="2.21.0" conf="*->default" />
+    <dependency org="commons-io" name="commons-io" rev="2.22.0" conf="*->default" />
     <dependency org="org.apache.commons" name="commons-compress" rev="1.28.0" conf="*->default" />
     <dependency org="org.apache.commons" name="commons-jexl3" rev="3.6.0" conf="*->default" />
     <dependency org="com.tdunning" name="t-digest" rev="3.3" />
@@ -79,9 +79,9 @@
     <dependency org="xml-apis" name="xml-apis" rev="1.4.01" /><!-- force this version as it is required by Tika -->
     <dependency org="xerces" name="xercesImpl" rev="2.12.2" />
 
-    <dependency org="com.ibm.icu" name="icu4j" rev="78.1" />
+    <dependency org="com.ibm.icu" name="icu4j" rev="78.3" />
 
-    <dependency org="com.google.guava" name="guava" rev="33.5.0-jre" />
+    <dependency org="com.google.guava" name="guava" rev="33.6.0-jre" />
 
     <dependency org="com.github.crawler-commons" name="crawler-commons" rev="1.6" />
 
@@ -90,12 +90,12 @@
       <exclude module="hadoop-client" />
     </dependency>
 
-    <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.18.5" conf="*->default" />
-    <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.18.5" conf="*->default" />
-    <dependency org="com.fasterxml.jackson.dataformat" name="jackson-dataformat-cbor" rev="2.18.5" conf="*->default" />
+    <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.18.8" conf="*->default" />
+    <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.18.8" conf="*->default" />
+    <dependency org="com.fasterxml.jackson.dataformat" name="jackson-dataformat-cbor" rev="2.18.8" conf="*->default" />
 
     <!-- WARC artifacts needed -->
-    <dependency org="org.netpreserve.commons" name="webarchive-commons" rev="3.0.2" conf="*->default">
+    <dependency org="org.netpreserve.commons" name="webarchive-commons" rev="3.0.4" conf="*->default">
       <exclude module="hadoop-core" />
       <exclude org="com.google.guava" />
       <exclude org="junit" />
@@ -114,17 +114,17 @@
     <!-- JSpecify nullability annotations for improved null safety -->
     <dependency org="org.jspecify" name="jspecify" rev="1.0.0" conf="*->default"/>
     <!-- Required for <junitlauncher> task -->
-    <dependency org="org.junit.platform" name="junit-platform-launcher" rev="6.0.3" conf="test->default"/>
+    <dependency org="org.junit.platform" name="junit-platform-launcher" rev="6.1.0" conf="test->default"/>
     <!-- Required for JUnit 6 (Jupiter) test execution -->
-    <dependency org="org.junit.jupiter" name="junit-jupiter-engine" rev="6.0.3" conf="test->default"/>
-    <dependency org="org.junit.jupiter" name="junit-jupiter-api" rev="6.0.3" conf="test->default"/>
-    <dependency org="org.junit.jupiter" name="junit-jupiter-params" rev="6.0.3" conf="test->default"/>
+    <dependency org="org.junit.jupiter" name="junit-jupiter-engine" rev="6.1.0" conf="test->default"/>
+    <dependency org="org.junit.jupiter" name="junit-jupiter-api" rev="6.1.0" conf="test->default"/>
+    <dependency org="org.junit.jupiter" name="junit-jupiter-params" rev="6.1.0" conf="test->default"/>
     <!-- Mockito for mocking in tests -->
-    <dependency org="org.mockito" name="mockito-core" rev="5.18.0" conf="test->default"/>
-    <dependency org="org.mockito" name="mockito-junit-jupiter" rev="5.18.0" conf="test->default"/>
+    <dependency org="org.mockito" name="mockito-core" rev="5.23.0" conf="test->default"/>
+    <dependency org="org.mockito" name="mockito-junit-jupiter" rev="5.23.0" conf="test->default"/>
 
     <!-- Testcontainers for indexer and protocol plugin integration tests -->
-    <dependency org="org.testcontainers" name="testcontainers" rev="2.0.3" conf="test->default"/>
+    <dependency org="org.testcontainers" name="testcontainers" rev="2.0.5" conf="test->default"/>
     <dependency org="org.testcontainers" name="junit-jupiter" rev="1.21.4" conf="test->default"/>
     <!-- WireMock for HTTP mock server in protocol-httpclient integration tests -->
     <dependency org="com.github.tomakehurst" name="wiremock-standalone" rev="3.0.1" conf="test->default"/>

--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -128,7 +128,7 @@
     <!-- WireMock for HTTP mock server in protocol-httpclient integration tests -->
     <dependency org="com.github.tomakehurst" name="wiremock-standalone" rev="3.0.1" conf="test->default"/>
     <!-- MockFtpServer for in-process FTP server in protocol-ftp integration tests -->
-    <dependency org="org.mockftpserver" name="MockFtpServer" rev="3.1.0" conf="test->default"/>
+    <dependency org="org.mockftpserver" name="MockFtpServer" rev="3.2.0" conf="test->default"/>
 
     <!-- MockServer (https://www.mock-server.com/) for static HTTP content in unit tests. -->
     <dependency org="org.mock-server" name="mockserver-netty" rev="5.15.0" conf="test->default">

--- a/src/plugin/lib-xml/ivy.xml
+++ b/src/plugin/lib-xml/ivy.xml
@@ -37,9 +37,9 @@
   </publications>
 
   <dependencies>
-    <dependency org="org.jdom" name="jdom" rev="1.1" conf="*->default"/>
-    <dependency org="jaxen" name="jaxen" rev="1.1.1" conf="*->master"/>
-    <dependency org="xerces" name="xercesImpl" rev="2.11.0" conf="*->master"/>
+    <dependency org="org.jdom" name="jdom" rev="2.0.2" conf="*->default"/>
+    <dependency org="jaxen" name="jaxen" rev="2.0.6" conf="*->master"/>
+    <dependency org="xerces" name="xercesImpl" rev="2.12.2" conf="*->master"/>
   </dependencies>
   
 </ivy-module>

--- a/src/plugin/protocol-ftp/ivy.xml
+++ b/src/plugin/protocol-ftp/ivy.xml
@@ -38,7 +38,7 @@
 
   <dependencies>
     <dependency org="commons-net" name="commons-net" rev="3.9.0" conf="*->master"/>
-    <dependency org="org.mockftpserver" name="MockFtpServer" rev="3.1.0" conf="test->default"/>
+    <dependency org="org.mockftpserver" name="MockFtpServer" rev="3.2.0" conf="test->default"/>
   </dependencies>
   
 </ivy-module>


### PR DESCRIPTION
- Upgrade core dependencies: minor upgrades, nothing noteworthy.
- Remove dependency xml-apis (a version override), obsolete because Tika does not depend on xml-apis anymore.
- Upgrade dependencies in lib-xml (used by feed plugin).
- Upgrade test dependencies: MockFtpServer and mockserver-netty.
- Update LICENSE-binary and NOTICE-binary.