### PR TITLE
NUTCH-3193 Exclude Jacoco files from source release package

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -882,6 +882,9 @@
       <tarfileset dir="${src.dist.version.dir}" mode="664" prefix="${final.name}">
         <exclude name="src/bin/*" />
         <exclude name="ivy/ivy*.jar" />
+        <exclude name="ivy/jacoco-*/**" />
+        <exclude name="ivy/spotbugs-*/**" />
+        <exclude name="ivy/apache-rat-*/**" />
         <include name="**" />
       </tarfileset>
       <tarfileset dir="${src.dist.version.dir}" mode="755" prefix="${final.name}">
@@ -912,14 +915,17 @@
   <target name="zip-src" depends="package-src" description="--> generate src.zip distribution package">
    <zip compress="true" casesensitive="yes"
      destfile="${src.dist.version.dir}.zip">
-   <zipfileset dir="${src.dist.version.dir}" filemode="664" prefix="${final.name}">
+     <zipfileset dir="${src.dist.version.dir}" filemode="664" prefix="${final.name}">
        <exclude name="src/bin/*" />
-        <exclude name="ivy/ivy*.jar" />
+       <exclude name="ivy/ivy*.jar" />
+       <exclude name="ivy/jacoco-*/**" />
+       <exclude name="ivy/spotbugs-*/**" />
+       <exclude name="ivy/apache-rat-*/**" />
        <include name="**" />
-   </zipfileset>
-   <zipfileset dir="${src.dist.version.dir}" filemode="755" prefix="${final.name}">
+     </zipfileset>
+     <zipfileset dir="${src.dist.version.dir}" filemode="755" prefix="${final.name}">
        <include name="src/bin/*" />
-   </zipfileset>
+     </zipfileset>
    </zip>
   </target>
 
@@ -929,13 +935,13 @@
   <target name="zip-bin" depends="package-bin" description="--> generate bin.zip distribution package">
    <zip compress="true" casesensitive="yes"
      destfile="${bin.dist.version.dir}.zip">
-   <zipfileset dir="${bin.dist.version.dir}" filemode="664" prefix="${final.name}">
+     <zipfileset dir="${bin.dist.version.dir}" filemode="664" prefix="${final.name}">
        <exclude name="bin/*" />
        <include name="**" />
-   </zipfileset>
-   <zipfileset dir="${bin.dist.version.dir}" filemode="755" prefix="${final.name}">
+     </zipfileset>
+     <zipfileset dir="${bin.dist.version.dir}" filemode="755" prefix="${final.name}">
        <include name="bin/*" />
-   </zipfileset>
+     </zipfileset>
    </zip>
   </target>
 


### PR DESCRIPTION
Excludes everything below `ivy/jacoco*`. Already excluded by `.gitignore`.

Will merge quickly. It's required to spin the 1.23 release package.