### PR TITLE
NUTCH-3201 Fetcher launches only a single reduce task, ignoring the configuration

### DIFF
--- a/src/java/org/apache/nutch/fetcher/Fetcher.java
+++ b/src/java/org/apache/nutch/fetcher/Fetcher.java
@@ -631,7 +631,6 @@ public class Fetcher extends NutchTool implements Tool {
     job.setJarByClass(Fetcher.class);
     job.setMapperClass(Fetcher.FetcherRun.class);
     job.setReducerClass(Fetcher.FetcherReducer.class);
-    job.setNumReduceTasks(1);
 
     FileOutputFormat.setOutputPath(job, segment);
     job.setOutputFormatClass(FetcherOutputFormat.class);


### PR DESCRIPTION
Remove the instruction which configures the single reduce task.