### PR TITLE
NUTCH-3205 Improve SonarCloud classpath, launcher coverage, and scan workflow reliability

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -62,7 +62,6 @@ jobs:
           workflow: master-build.yml
           run_id: ${{ github.event.workflow_run.id }}
           path: ./build/
-        continue-on-error: true
 
       - name: Download coverage data (Ubuntu JDK 17)
         uses: dawidd6/action-download-artifact@v21
@@ -71,7 +70,6 @@ jobs:
           workflow: master-build.yml
           run_id: ${{ github.event.workflow_run.id }}
           path: ./build/coverage/
-        continue-on-error: true
 
       - name: Download test reports (Ubuntu JDK 17)
         uses: dawidd6/action-download-artifact@v21
@@ -82,13 +80,39 @@ jobs:
           # Artifact has build/ stripped (upload-artifact LCA); re-root under build/
           # so paths match build/test/... and build/<plugin>/test/...
           path: ./build/
-        continue-on-error: true
 
       - name: Flatten test reports (JDK 17 only)
         run: |
           mkdir -p ./build/test-reports
-          find ./build/test ./build/*/test/ -name 'TEST-*.xml' -exec cp {} ./build/test-reports/ \; 2>/dev/null || true
-        continue-on-error: true
+          find ./build/test ./build/*/test/ -name 'TEST-*.xml' -exec cp {} ./build/test-reports/ \;
+
+      - name: Verify Sonar inputs
+        run: |
+          set -euo pipefail
+          if ! find ./build -name '*.class' -print -quit | grep -q .; then
+            echo "::error::No compiled class files found under build/"
+            exit 1
+          fi
+          if [ ! -s ./build/coverage/jacoco.xml ]; then
+            echo "::error::Missing or empty build/coverage/jacoco.xml"
+            exit 1
+          fi
+          if ! ls ./build/test-reports/TEST-*.xml >/dev/null 2>&1; then
+            echo "::error::No JUnit TEST-*.xml reports in build/test-reports/"
+            exit 1
+          fi
+          echo "Sonar inputs OK: classes, jacoco.xml, and JUnit reports present."
+
+      - name: Set Sonar project version
+        id: version
+        run: |
+          NUTCH_VERSION=$(grep '^version=' default.properties | cut -d= -f2)
+          if [ -z "$NUTCH_VERSION" ]; then
+            echo "::error::Could not read version from default.properties"
+            exit 1
+          fi
+          echo "value=${NUTCH_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Sonar project version: ${NUTCH_VERSION}"
 
       - name: Resolve PR number
         id: pr
@@ -131,6 +155,7 @@ jobs:
             -Dsonar.pullrequest.key=${{ steps.pr.outputs.number }}
             -Dsonar.pullrequest.branch=${{ github.event.workflow_run.head_branch }}
             -Dsonar.pullrequest.base=master
+            -Dsonar.projectVersion=${{ steps.version.outputs.value }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io
@@ -141,6 +166,7 @@ jobs:
         with:
           args: >
             -Dsonar.branch.name=${{ github.event.workflow_run.head_branch }}
+            -Dsonar.projectVersion=${{ steps.version.outputs.value }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,26 +17,27 @@ sonar.projectKey=apache_nutch
 sonar.organization=apache
 sonar.projectName=Apache Nutch
 sonar.projectDescription=Apache Nutch is an extensible and scalable web crawler and indexing framework built on Apache Hadoop.
-sonar.tags=apache,crawler,hadoop,search,indexing
+sonar.tags=apache,crawler,hadoop,search,indexing,nutch
 
 sonar.links.homepage=https://nutch.apache.org
 sonar.links.scm=https://github.com/apache/nutch
 sonar.links.issue=https://issues.apache.org/jira/projects/NUTCH/issues
 sonar.links.ci=https://github.com/apache/nutch/actions
 
-sonar.sources=src/java,src/plugin
+sonar.sources=src/java,src/plugin,src/bin
 sonar.tests=src/test,src/plugin
 sonar.test.inclusions=**/src/test/**/*.java,**/Test*.java,**/*IT.java
 sonar.exclusions=**/build.xml,**/build-ivy.xml,**/build-plugin.xml,**/ivy.xml,**/plugin.xml,**/sample/**,**/data/**,**/logs/**
-sonar.source.encoding=UTF-8
+sonar.sourceEncoding=UTF-8
 sonar.java.source=17
 
 sonar.java.binaries=build/classes,build/*/classes
 sonar.java.test.binaries=build/test/classes,build/*/test
-sonar.java.libraries=build/lib/*.jar
-sonar.java.test.libraries=build/test/lib/*.jar
+sonar.java.libraries=build/lib/*.jar,build/*/lib/*.jar,build/*/classes
+sonar.java.test.libraries=build/test/lib/*.jar,build/*/test/lib/*.jar,build/lib/*.jar,build/*/lib/*.jar,build/classes,build/*/classes
 
 sonar.cpd.exclusions=**/package-info.java
+sonar.coverage.exclusions=**/package-info.java
 sonar.scm.exclusions.disabled=false
 
 sonar.coverage.jacoco.xmlReportPaths=build/coverage/jacoco.xml


### PR DESCRIPTION
PR for [NUTCH-3205](https://issues.apache.org/jira/browse/NUTCH-3205)

- Harden `sonar-project.properties`: fix `sonar.sourceEncoding`, set `projectVersion`, include `src/bin` launchers, widen Java libraries/test libraries for plugin deps, and exclude `package-info.java` from coverage.
- Harden `.github/workflows/sonarcloud.yml`: remove `continue-on-error` on artifact/flatten steps, fail fast if classes/JaCoCo/JUnit inputs are missing, and pass `-Dsonar.projectVersion` from `default.properties`.

Validation may also depend on this code being merged for the benefits to be realized on `master` branch.