### PR TITLE
NUTCH-3197 Yetus: fix product codespell typos flagged by precommit

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,9 +3,10 @@
 # Loction: intentional misspelling in protocol-http/okhttp TestResponse fixtures
 # used to exercise SpellCheckedMetadata error-tolerant Location header matching.
 # uery: intentional query-string token in urlnormalizer-protocol TestProtocolURLNormalizer.
-ignore-words-list = AfterAll,BeforeAll,Loction,uery
+# fo: intentional trie matcher test prefix in PrefixStringMatcher/SuffixStringMatcher demo mains.
+ignore-words-list = AfterAll,BeforeAll,Loction,uery,fo
 # CHANGES.md is a historical changelog not maintained by this branch.
 # Language-identifier corpora, binary license trees, and naivebayes training
 # sample are also listed in .yetus/excludes.txt for full-tree Yetus runs; skip
 # them here so local codespell matches CI.
-skip = CHANGES.md,src/plugin/language-identifier/src/test,LICENSE-binary,NOTICE-binary,licenses-binary,conf/naivebayes-train.txt.template
+skip = CHANGES.md,src/plugin/language-identifier/src/test,LICENSE-binary,NOTICE-binary,licenses-binary,conf/naivebayes-train.txt.template,src/plugin/language-identifier/src/java/org/apache/nutch/analysis/lang/langmappings.properties,**/naivebayes-model,**/sample/**

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,4 @@
+# Hadolint config for docker/Dockerfile (NUTCH-3197).
+# DL3018: do not pin floating Alpine apk versions without a deliberate bump policy.
+ignored:
+  - DL3018

--- a/.yetus/excludes.txt
+++ b/.yetus/excludes.txt
@@ -14,3 +14,6 @@
 #
 # Naive Bayes training sample (deliberately messy email/OCR-like text).
 ^conf/naivebayes-train\.txt\.template$
+#
+# parse-js sample: test fixture for link extraction, not production JS
+^src/plugin/parse-js/sample/

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ test-patch --basedir=/path/to/clean/repo --build-tool=nobuild \
 ```
 
 Exclude patterns and related Yetus baselines can be added under `.yetus/`
-(see `.yetus/excludes.txt`).
+(see `.yetus/excludes.txt`, `.yetus/detsecrets-ignored-hashes.txt`).
 
 IDE setup
 ---------

--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -62,7 +62,7 @@
   <description>If true, no file content will be saved during fetch.
   And it is probably what we want to set most of time, since file:// URLs
   are meant to be local and we can always use them directly at parsing
-  and indexing stages. Otherwise file contents will be saved.
+  and indexing stags. Otherwise file contents will be saved.
   !! NOT IMPLEMENTED YET !!
   </description>
 </property>
@@ -1361,7 +1361,7 @@
   <value>-1</value>
   <description>
     The maximum time in seconds fetcher will cache redirects for
-    deduplication.  If the same redirect URL is seen again withing
+    deduplication.  If the same redirect URL is seen again within
     this time it is skipped. This allows to avoid pathological cases
     where many or most of the URLs of a host are redirected to the
     same URL, eg. a page to login, accept cookies, indicating an
@@ -1453,7 +1453,7 @@
 <property>
   <name>indexer.score.power</name>
   <value>0.5</value>
-  <description>Determines the power of link analyis scores. The boost
+  <description>Determines the power of link analysis scores. The boost
   of each page is set to <i>score<sup>scorePower</sup></i> where
   <i>score</i> is its link analysis score and <i>scorePower</i> is the
   value of this parameter.  This is compiled into indexes, so, when
@@ -1745,7 +1745,7 @@
   <name>parser.html.line.separators</name>
   <value>article,aside,blockquote,canvas,dd,div,dl,dt,fieldset,figcaption,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hr,li,main,nav,noscript,ol,output,p,pre,section,table,tfoot,ul,video</value>
  <description>Comma separated list of HTML tags. Newline will be added to the
-  parsed text after these tages.
+  parsed text after these tags.
   The default list above are the block-level HTML elements.
   Tags must be in lower case.
   To disable this feature, leave the list empty.</description>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,26 +30,25 @@ LABEL org.opencontainers.image.vendor="Apache Nutch https://nutch.apache.org"
 
 WORKDIR /root/
 
-# Install dependencies
-RUN apk update
-RUN apk --no-cache add apache-ant bash git openjdk17
+# Install dependencies and shell init for JAVA_HOME
+RUN apk update && \
+    apk --no-cache add apache-ant bash git openjdk17 && \
+    echo 'export JAVA_HOME=/usr/lib/jvm/java-17-openjdk' >> "$HOME/.bashrc" && \
+    echo 'export JAVA_HOME=/usr/lib/jvm/java-17-openjdk' >> "$HOME/.ashrc"
 
-# Establish environment variables
-RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-17-openjdk' >> $HOME/.bashrc
-RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-17-openjdk' >> $HOME/.ashrc
 ENV JAVA_HOME='/usr/lib/jvm/java-17-openjdk'
 ENV NUTCH_HOME='/root/nutch_source/runtime/local'
 
 # Checkout and build the Nutch master branch (1.x)
 RUN git clone https://github.com/apache/nutch.git nutch_source && \
-     cd nutch_source && \
-     ant runtime && \
-     rm -rf build/ && \
-     rm -rf /root/.ivy2/
+    cd nutch_source && \
+    ant runtime && \
+    rm -rf build/ && \
+    rm -rf /root/.ivy2/
 
 # Create symlinks for runtime/local/bin/nutch and runtime/local/bin/crawl
-RUN ln -sf $NUTCH_HOME/bin/nutch /usr/local/bin/
-RUN ln -sf $NUTCH_HOME/bin/crawl /usr/local/bin/
+RUN ln -sf "$NUTCH_HOME/bin/nutch" /usr/local/bin/ && \
+    ln -sf "$NUTCH_HOME/bin/crawl" /usr/local/bin/
 
 RUN echo "Successfully built image, see https://s.apache.org/m5933 for guidance on running a container instance."
 

--- a/src/bin/crawl
+++ b/src/bin/crawl
@@ -23,7 +23,7 @@
 #
 # Options:
 #   -i|--index                            Indexes crawl results into a configured indexer
-#   -D <propery>=<value>                  A Nutch or Hadoop property to pass to Nutch calls overwriting
+#   -D <property>=<value>                 A Nutch or Hadoop property to pass to Nutch calls overwriting
 #                                         properties defined in configuration files, e.g.
 #                                           increase content limit to 2MB:
 #                                             -D http.content.limit=2097152
@@ -51,6 +51,8 @@
 #   --dedup-group <none|host|domain>       Deduplication group method [default: none]
 #
 
+## @audience private
+## @stability stable
 function __to_seconds() {
   NUMBER=$(echo $1 | tr -dc '0-9')
   MODIFIER=$(echo $1 | tr -dc '[^s|h|m|d]]')
@@ -73,6 +75,8 @@ function __to_seconds() {
   echo $SECONDS
 }
 
+## @audience private
+## @stability stable
 function __print_usage {
   echo "Usage: crawl [options] <crawl_dir> <num_rounds>"
   echo -e ""
@@ -129,7 +133,7 @@ NUM_THREADS=50
 SITEMAPS_FROM_HOSTDB_FREQUENCY=never
 DEDUP_GROUP=none
 
-while [[ $# > 0 ]]
+while [[ $# -gt 0 ]]
 do
     case $1 in
         -i|--index)
@@ -229,9 +233,12 @@ bin="`cd "$bin"; pwd`"
 
 # determines whether mode based on presence of job file
 mode=local
-if [ -f "${bin}"/../*nutch*.job ]; then
-  mode=distributed
-fi
+for f in "${bin}"/../*nutch*.job; do
+  if [ -f "$f" ]; then
+    mode=distributed
+    break
+  fi
+done
 if [[ "$mode" = "local" ]]; then
   if [[ "$NUM_FETCHERS" -ne 1 ]]; then
     echo "Ignoring configured number of fetchers (--num_fetchers): a single fetcher task is used when running in local mode."
@@ -247,28 +254,32 @@ commonOptions=("${HADOOP_PROPERTIES[@]}" -Dmapreduce.job.reduces=$NUM_TASKS -Dma
 if [ $mode = "distributed" ]; then
  if [ $(which hadoop | wc -l ) -eq 0 ]; then
     echo "Can't find Hadoop executable. Add HADOOP_COMMON_HOME/bin to the path or run in local mode."
-    exit -1;
+    exit 1;
  fi
 fi
 
 
+## @audience private
+## @stability stable
 function __bin_nutch {
     # run $bin/nutch, exit if exit value indicates error
 
-    echo "$bin/nutch $@" ;# echo command and arguments
+    echo "$bin/nutch" "$@" ;# echo command and arguments
     "$bin/nutch" "$@"
 
     RETCODE=$?
     if [ $RETCODE -ne 0 ]
     then
         echo "Error running:"
-        echo "  $bin/nutch $@"
+        echo "  $bin/nutch" "$@"
         echo "Failed with exit value $RETCODE."
         exit $RETCODE
     fi
 }
 
 # check if directory exists locally or on hdfs
+## @audience private
+## @stability stable
 function __directory_exists {
   if [[ "$mode" == local  &&  -d "$1" ]]; then
     return 0
@@ -279,6 +290,8 @@ function __directory_exists {
   fi
 }
 
+## @audience private
+## @stability stable
 function __update_hostdb {
   if __directory_exists "$CRAWL_PATH"/crawldb; then
     echo "Updating HostDB"
@@ -334,7 +347,7 @@ do
    generate_args=("${commonOptions[@]}" "$CRAWL_PATH"/crawldb "$CRAWL_PATH"/segments -topN $SIZE_FETCHLIST -numFetchers $NUM_FETCHERS -noFilter)
   fi
 
-  echo "$bin/nutch generate ${generate_args[@]}"
+  echo "$bin/nutch generate" "${generate_args[@]}"
   $bin/nutch generate "${generate_args[@]}"
   RETCODE=$?
   if [ $RETCODE -eq 0 ]; then
@@ -352,7 +365,7 @@ do
     fi
   else
     echo "Error running:"
-    echo "  $bin/nutch generate ${generate_args[@]}"
+    echo "  $bin/nutch generate" "${generate_args[@]}"
     echo "Failed with exit value $RETCODE."
     exit $RETCODE
   fi

--- a/src/bin/nutch
+++ b/src/bin/nutch
@@ -147,17 +147,18 @@ fi
 
 local=true
 
-# NUTCH_JOB 
-if [ -f "${NUTCH_HOME}"/*nutch*.job ]; then
-  local=false
-  for f in "$NUTCH_HOME"/*nutch*.job; do
+# NUTCH_JOB
+for f in "${NUTCH_HOME}"/*nutch*.job; do
+  if [ -f "$f" ]; then
+    local=false
     NUTCH_JOB="$f"
-  done
-  # cygwin path translation
-  if $cygwin; then
-	NUTCH_JOB="`cygpath -p -w "$NUTCH_JOB"`"
+    # cygwin path translation
+    if $cygwin; then
+      NUTCH_JOB="`cygpath -p -w "$NUTCH_JOB"`"
+    fi
+    break
   fi
-fi
+done
 
 JAVA="$JAVA_HOME/bin/java"
 JAVA_HEAP_MAX=-Xmx4096m
@@ -238,7 +239,7 @@ fi
 # figure out which class to run
 if [ "$COMMAND" = "crawl" ] ; then
   echo "Command $COMMAND is deprecated, please use bin/crawl instead"
-  exit -1
+  exit 1
 elif [ "$COMMAND" = "inject" ] ; then
   CLASS=org.apache.nutch.crawl.Injector
 elif [ "$COMMAND" = "generate" ] ; then
@@ -272,7 +273,7 @@ elif [ "$COMMAND" = "commoncrawldump" ] ; then
 elif [ "$COMMAND" = "solrindex" ] || [ "$COMMAND" = "solrdedup" ] || [ "$COMMAND" = "solrclean" ]; then
   REPLACEMENT="${COMMAND#solr}"
   echo "The command $COMMAND was replaced by the command $REPLACEMENT"
-  exit -1
+  exit 1
 elif [ "$COMMAND" = "index" ] ; then
   CLASS=org.apache.nutch.indexer.IndexingJob
 elif [ "$COMMAND" = "dedup" ] ; then
@@ -336,7 +337,7 @@ else
  # check that hadoop can be found on the path
  if [ $(which hadoop | wc -l ) -eq 0 ]; then
     echo "Can't find Hadoop executable. Add HADOOP_COMMON_HOME/bin to the path or run in local mode."
-    exit -1;
+    exit 1;
  fi
 fi
 

--- a/src/bin/nutch
+++ b/src/bin/nutch
@@ -154,7 +154,7 @@ for f in "${NUTCH_HOME}"/*nutch*.job; do
     NUTCH_JOB="$f"
     # cygwin path translation
     if $cygwin; then
-      NUTCH_JOB="`cygpath -p -w "$NUTCH_JOB"`"
+      NUTCH_JOB="$(cygpath -p -w "$NUTCH_JOB")"
     fi
     break
   fi

--- a/src/java/org/apache/nutch/crawl/CrawlDatum.java
+++ b/src/java/org/apache/nutch/crawl/CrawlDatum.java
@@ -419,7 +419,7 @@ public class CrawlDatum implements WritableComparable<CrawlDatum>, Cloneable {
    * @param that an existing {@link CrawlDatum}
    * @return 1 if any one field (score, status, fetchTime, retries,
    * fetchInterval or modifiedTime) of the new {@link CrawlDatum}
-   * minus the correspoinding field of the existing {@link CrawlDatum}
+   * minus the corresponding field of the existing {@link CrawlDatum}
    * is greater than 0, otherwise return -1.
    */
   @Override

--- a/src/java/org/apache/nutch/crawl/CrawlDbReader.java
+++ b/src/java/org/apache/nutch/crawl/CrawlDbReader.java
@@ -115,7 +115,7 @@ public class CrawlDbReader extends AbstractChecker implements Closeable {
     synchronized (this) {
       if (readers != null) {
         if (this.lastModified == lastModified) {
-          // CrawlDB not modified, re-use readers
+          // CrawlDB not modified, reuse readers
           return;
         } else {
           // CrawlDB modified, close and re-open readers

--- a/src/java/org/apache/nutch/crawl/LinkDbReader.java
+++ b/src/java/org/apache/nutch/crawl/LinkDbReader.java
@@ -87,7 +87,7 @@ public class LinkDbReader extends AbstractChecker implements Closeable {
     synchronized (this) {
       if (readers != null) {
         if (this.lastModified == lastModified) {
-          // CrawlDB not modified, re-use readers
+          // CrawlDB not modified, reuse readers
           return;
         } else {
           // CrawlDB modified, close and re-open readers

--- a/src/java/org/apache/nutch/hostdb/ResolverThread.java
+++ b/src/java/org/apache/nutch/hostdb/ResolverThread.java
@@ -107,7 +107,7 @@ public class ResolverThread implements Runnable {
    */
   @Override
   public void run() {
-    // Resolve the host and act appropriatly
+    // Resolve the host and act appropriately
     try {
       // Throws an exception if host is not found
       @SuppressWarnings("unused")

--- a/src/java/org/apache/nutch/parse/Outlink.java
+++ b/src/java/org/apache/nutch/parse/Outlink.java
@@ -59,7 +59,7 @@ public class Outlink implements Writable {
   /**
    * Skips over one Outlink in the input.
    * @param in the {@link DataInput} tuple stream holding the
-   * toUrl and archor pair.
+   * toUrl and anchor pair.
    * @throws IOException if there is an error processing the {@link DataInput}
    */
   public static void skip(DataInput in) throws IOException {

--- a/src/java/org/apache/nutch/parse/OutlinkExtractor.java
+++ b/src/java/org/apache/nutch/parse/OutlinkExtractor.java
@@ -61,7 +61,7 @@ public class OutlinkExtractor {
    * cases (postscript is a known example).
    * 
    * @param plainText
-   *          the plain text from wich URLs should be extracted.
+   *          the plain text from which URLs should be extracted.
    * @param conf a populated {@link Configuration}
    * @return Array of <code>Outlink</code>s within found in plainText
    */
@@ -75,7 +75,7 @@ public class OutlinkExtractor {
    * extracted <code>Outlink</code>s
    * 
    * @param plainText
-   *          the plain text from wich URLs should be extracted.
+   *          the plain text from which URLs should be extracted.
    * @param anchor
    *          the anchor of the url
    * @param conf a populated {@link Configuration}

--- a/src/java/org/apache/nutch/parse/ParsePluginList.java
+++ b/src/java/org/apache/nutch/parse/ParsePluginList.java
@@ -24,7 +24,7 @@ import java.util.Map;
 /**
  * This class represents a natural ordering for which parsing plugin should get
  * called for a particular mimeType. It provides methods to store the
- * parse-plugins.xml data, and methods to retreive the name of the appropriate
+ * parse-plugins.xml data, and methods to retrieve the name of the appropriate
  * parsing plugin for a contentType.
  * 
  * @author mattmann

--- a/src/java/org/apache/nutch/parse/ParseResult.java
+++ b/src/java/org/apache/nutch/parse/ParseResult.java
@@ -183,7 +183,7 @@ public class ParseResult implements Iterable<Map.Entry<Text, Parse>> {
   /**
    * A convenience method which returns true if at least one of the parses is
    * successful. Parse success is determined by {@link ParseStatus#isSuccess()}.
-   * @return true if atleast one result is a success, false otherwise
+   * @return true if at least one result is a success, false otherwise
    */
   public boolean isAnySuccess() {
     for (Iterator<Entry<Text, Parse>> i = iterator(); i.hasNext();) {

--- a/src/java/org/apache/nutch/plugin/Extension.java
+++ b/src/java/org/apache/nutch/plugin/Extension.java
@@ -67,7 +67,7 @@ public class Extension {
 
   /**
    * Returns a attribute value, that is setuped in the manifest file and is
-   * definied by the extension point xml schema.
+   * defined by the extension point xml schema.
    * 
    * @param pKey
    *          a key
@@ -109,7 +109,7 @@ public class Extension {
   }
 
   /**
-   * Sets the Class that implement the concret extension and is only used until
+   * Sets the Class that implement the concrete extension and is only used until
    * model creation at system start up.
    * 
    * @param extensionClazz

--- a/src/java/org/apache/nutch/plugin/ExtensionPoint.java
+++ b/src/java/org/apache/nutch/plugin/ExtensionPoint.java
@@ -103,7 +103,7 @@ public class ExtensionPoint {
   }
 
   /**
-   * Install a coresponding extension to this extension point.
+   * Install a corresponding extension to this extension point.
    * 
    * @param extension the new {@link org.apache.nutch.plugin.Extension}
    * to install

--- a/src/java/org/apache/nutch/plugin/Plugin.java
+++ b/src/java/org/apache/nutch/plugin/Plugin.java
@@ -58,7 +58,7 @@ public class Plugin {
    * used.
    * 
    * @throws PluginRuntimeException
-   *           If the startup was without successs.
+   *           If the startup was without success.
    */
   public void startUp() throws PluginRuntimeException {
   }

--- a/src/java/org/apache/nutch/plugin/PluginDescriptor.java
+++ b/src/java/org/apache/nutch/plugin/PluginDescriptor.java
@@ -285,7 +285,7 @@ public class PluginDescriptor {
   /**
    * Returns a cached classloader for a plugin. Until classloader creation all
    * needed libraries are collected. A classloader use as first the plugins own
-   * libraries and add then all exported libraries of dependend plugins.
+   * libraries and add then all exported libraries of dependent plugins.
    * 
    * @return PluginClassLoader the classloader for the plugin
    */

--- a/src/java/org/apache/nutch/plugin/PluginRepository.java
+++ b/src/java/org/apache/nutch/plugin/PluginRepository.java
@@ -231,7 +231,7 @@ public class PluginRepository implements URLStreamHandlerFactory {
   }
 
   /**
-   * Returns all registed plugin descriptors.
+   * Returns all registered plugin descriptors.
    * 
    * @return PluginDescriptor[]
    */

--- a/src/java/org/apache/nutch/scoring/webgraph/LinkRank.java
+++ b/src/java/org/apache/nutch/scoring/webgraph/LinkRank.java
@@ -632,7 +632,7 @@ public class LinkRank extends Configured implements Tool {
   }
 
   /**
-   * Runs the complete link analysis job. The complete job determins rank one
+   * Runs the complete link analysis job. The complete job determines rank one
    * score. Then runs through a given number of invert and analyze iterations,
    * by default 10. And finally replaces the NodeDb in the WebGraph with the
    * link rank output.
@@ -654,7 +654,7 @@ public class LinkRank extends Configured implements Tool {
     LOG.info("LinkRank Analysis: starting");
 
     // store the link rank under the webgraphdb temporarily, final scores get
-    // upddated into the nodedb
+    // updated into the nodedb
     Path linkRank = new Path(webGraphDb, "linkrank");
     Configuration conf = getConf();
     FileSystem fs = linkRank.getFileSystem(conf);
@@ -670,7 +670,7 @@ public class LinkRank extends Configured implements Tool {
     Path nodeDb = new Path(linkRank, WebGraph.NODE_DIR);
 
     // get the number of total nodes in the webgraph, used for rank one, then
-    // initialze all urls with a default score
+    // initialize all urls with a default score
     int numLinks = runCounter(fs, webGraphDb);
     runInitializer(wgNodeDb, nodeDb);
     float rankOneScore = (1f / numLinks);

--- a/src/java/org/apache/nutch/scoring/webgraph/ScoreUpdater.java
+++ b/src/java/org/apache/nutch/scoring/webgraph/ScoreUpdater.java
@@ -139,7 +139,7 @@ public class ScoreUpdater extends Configured implements Tool{
 
 
   /**
-   * Updates the inlink score in the web graph node databsae into the crawl
+   * Updates the inlink score in the web graph node database into the crawl
    * database.
    * 
    * @param crawlDb

--- a/src/java/org/apache/nutch/tools/ResolveUrls.java
+++ b/src/java/org/apache/nutch/tools/ResolveUrls.java
@@ -130,7 +130,7 @@ public class ResolveUrls {
 
     // shutdown the thread pool and log totals
     pool.shutdown();
-    LOG.info("Total: {}, Resovled: {}, Errored: {}, Average Time: {}",
+    LOG.info("Total: {}, Resolved: {}, Errored: {}, Average Time: {}",
         numTotal.get(), numResolved.get(), numErrored.get(),
         totalTime.get() / numTotal.get());
   }

--- a/src/java/org/apache/nutch/tools/arc/ArcSegmentCreator.java
+++ b/src/java/org/apache/nutch/tools/arc/ArcSegmentCreator.java
@@ -116,7 +116,7 @@ public class ArcSegmentCreator extends Configured implements Tool {
    * @param url
    *          The url we are parsing.
    * @param t
-   *          The error that occured.
+   *          The error that occurred.
    */
   private static void logError(Text url, Throwable t) {
     LOG.info("Conversion of {} failed with: {}", url, StringUtils.stringifyException(t));

--- a/src/java/org/apache/nutch/util/TrieStringMatcher.java
+++ b/src/java/org/apache/nutch/util/TrieStringMatcher.java
@@ -202,7 +202,7 @@ public abstract class TrieStringMatcher {
    * Returns true if the given <code>String</code> is matched by a pattern in
    * the trie
    * @param input A String to be matched by a pattern
-   * @return true if there is a match, flase otherwise
+   * @return true if there is a match, false otherwise
    */
   public abstract boolean matches(String input);
 

--- a/src/plugin/creativecommons/src/java/org/creativecommons/nutch/CCParseFilter.java
+++ b/src/plugin/creativecommons/src/java/org/creativecommons/nutch/CCParseFilter.java
@@ -134,7 +134,7 @@ public class CCParseFilter implements HtmlParseFilter {
     }
 
     /**
-     * Extract license url from element, if any. Thse are the href attribute of
+     * Extract license url from element, if any. These are the href attribute of
      * anchor elements with rel="license". These must also point to
      * http://creativecommons.org/licenses/.
      */

--- a/src/plugin/index-geoip/ivy.xml
+++ b/src/plugin/index-geoip/ivy.xml
@@ -38,7 +38,7 @@
 
   <dependencies>
     <dependency org="com.maxmind.geoip2" name="geoip2" rev="5.0.2">
-      <!-- Exlude libs provided in Nutch core -->
+      <!-- Exclude libs provided in Nutch core -->
       <exclude org="com.fasterxml.jackson.core" name="jackson-annotations" />
       <exclude org="com.fasterxml.jackson.core" name="jackson-databind" />
       <exclude org="com.fasterxml.jackson.core" name="jackson-core" />

--- a/src/plugin/index-replace/README.txt
+++ b/src/plugin/index-replace/README.txt
@@ -86,7 +86,7 @@ Testing your match patterns
         bin/nutch parse crawl/segments/[segment]
         bin/nutch invertlinks crawl/linkdb -dir crawl/segments
         ...index your document, for example with SOLR...
-        bin/nutch solrindex http://localhost:8983/solr crawl/crawldb/ -linkdb crawl/linkdb/ crawl/segement[segment] -filter -normalize
+        bin/nutch solrindex http://localhost:8983/solr crawl/crawldb/ -linkdb crawl/linkdb/ crawl/segment[segment] -filter -normalize
 
     Inspect hadoop.log for info about pattern parsing and compilation..
         grep replace logs/hadoop.log

--- a/src/plugin/indexer-kafka/src/java/org/apache/nutch/indexwriter/kafka/KafkaIndexWriter.java
+++ b/src/plugin/indexer-kafka/src/java/org/apache/nutch/indexwriter/kafka/KafkaIndexWriter.java
@@ -156,7 +156,7 @@ public class KafkaIndexWriter implements IndexWriter {
       }
       inputDocs.clear();
     } catch (NullPointerException e) {
-      LOG.info("All records have been sent to Kakfa on topic {}", topic);
+      LOG.info("All records have been sent to Kafka on topic {}", topic);
     }
   }
 

--- a/src/plugin/indexer-opensearch-1x/howto_upgrade_opensearch.md
+++ b/src/plugin/indexer-opensearch-1x/howto_upgrade_opensearch.md
@@ -37,7 +37,7 @@
      (eventually with different versions)
    - duplicated libs can be added to the exclusions of transitive dependencies in
        build/plugins/indexer-opensearch-1x/ivy.xml
-   - but it should be made sure that the library versions in ivy/ivy.xml correspend to
+   - but it should be made sure that the library versions in ivy/ivy.xml correspond to
      those required by Tika
 
 5. Remove the locally "installed" dependencies in src/plugin/indexer-opensearch-1x/lib/:

--- a/src/plugin/indexer-solr/howto_upgrade_solr.md
+++ b/src/plugin/indexer-solr/howto_upgrade_solr.md
@@ -37,7 +37,7 @@
      (eventually with different versions)
    - duplicated libs can be added to the exclusions of transitive dependencies in
        build/plugins/indexer-solr/ivy.xml
-   - but it should be made sure that the library versions in ivy/ivy.xml correspend to
+   - but it should be made sure that the library versions in ivy/ivy.xml correspond to
      those required by Tika
 
 5. Remove the locally "installed" dependencies in src/plugin/indexer-solr/lib/:

--- a/src/plugin/language-identifier/src/java/org/apache/nutch/analysis/lang/LanguageIndexingFilter.java
+++ b/src/plugin/language-identifier/src/java/org/apache/nutch/analysis/lang/LanguageIndexingFilter.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.conf.Configuration;
  * information</li>
  * <li>Then, checking if a <code>Content-Language</code> HTTP header can be
  * found</li>
- * <li>Finaly by analyzing the document content</li>
+ * <li>Finally by analyzing the document content</li>
  * </ul>
  * 
  * @author Sami Siren

--- a/src/plugin/lib-htmlunit/src/java/org/apache/nutch/protocol/htmlunit/HtmlUnitWebDriver.java
+++ b/src/plugin/lib-htmlunit/src/java/org/apache/nutch/protocol/htmlunit/HtmlUnitWebDriver.java
@@ -171,7 +171,7 @@ public class HtmlUnitWebDriver extends HtmlUnitDriver {
         IOUtils.copyBytes(is, os, conf);
         LOG.debug("Screenshot for {} successfully saved to: {} {}", url, screenshotPath, srcFile.getName()); 
       } else {
-        LOG.warn("Screenshot for {} not saved to HDFS (subsequently disgarded) as value for "
+        LOG.warn("Screenshot for {} not saved to HDFS (subsequently discarded) as value for "
             + "'screenshot.location' is absent from nutch-site.xml.", url);
       }
     } catch (Exception e) {

--- a/src/plugin/microformats-reltag/src/java/org/apache/nutch/microformats/reltag/RelTagParser.java
+++ b/src/plugin/microformats-reltag/src/java/org/apache/nutch/microformats/reltag/RelTagParser.java
@@ -99,7 +99,7 @@ public class RelTagParser implements HtmlParseFilter {
             Node relNode = attrs.getNamedItem("rel");
             // Checks that it contains a rel attribute too
             if (relNode != null) {
-              // Finaly checks that rel=tag
+              // Finally checks that rel=tag
               if ("tag".equalsIgnoreCase(relNode.getNodeValue())) {
                 String tag = parseTag(hrefNode.getNodeValue());
                 if (!StringUtil.isEmpty(tag)) {

--- a/src/plugin/parse-html/src/java/org/apache/nutch/parse/html/DOMBuilder.java
+++ b/src/plugin/parse-html/src/java/org/apache/nutch/parse/html/DOMBuilder.java
@@ -361,7 +361,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
    */
   public void setIDAttribute(String id, Element elem) {
 
-    // Do nothing. This method is meant to be overiden.
+    // Do nothing. This method is meant to be overridden.
   }
 
   /**
@@ -648,7 +648,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     String s = new String(ch, start, length);
 
-    // XXX ab@apache.org: modified from the original, to accomodate TagSoup.
+    // XXX ab@apache.org: modified from the original, to accommodate TagSoup.
     Node n = m_currentNode.getLastChild();
     if (n instanceof CDATASection)
       ((CDATASection) n).appendData(s);

--- a/src/plugin/parse-html/src/java/org/apache/nutch/parse/html/DOMContentUtils.java
+++ b/src/plugin/parse-html/src/java/org/apache/nutch/parse/html/DOMContentUtils.java
@@ -139,7 +139,7 @@ public class DOMContentUtils {
   }
 
   /**
-   * This is a convinience method, equivalent to
+   * This is a convenience method, equivalent to
    * {@link #getText(StringBuffer,Node,boolean) getText(sb, node, false)}.
    * @param sb a {@link StringBuffer} used to store content text
    * found beneath the DOM node... if any exists

--- a/src/plugin/parse-html/src/java/org/apache/nutch/parse/html/HTMLMetaProcessor.java
+++ b/src/plugin/parse-html/src/java/org/apache/nutch/parse/html/HTMLMetaProcessor.java
@@ -44,7 +44,7 @@ public class HTMLMetaProcessor {
    * @param metaTags a {@link HTMLMetaTags} to populate with tags discovered in the
    * given Node
    * @param node a DOM {@link Node} to process and extract metadata from
-   * @param currURL the cononical URL associated with the metatags and Node
+   * @param currURL the canonical URL associated with the metatags and Node
    */
   public static final void getMetaTags(HTMLMetaTags metaTags, Node node,
       URL currURL) {
@@ -68,7 +68,7 @@ public class HTMLMetaProcessor {
         Node nameNode = null;
         Node equivNode = null;
         Node contentNode = null;
-        // Retrieves name, http-equiv and content attribues
+        // Retrieves name, http-equiv and content attributes
         for (int i = 0; i < attrs.getLength(); i++) {
           Node attr = attrs.item(i);
           String attrName = attr.getNodeName().toLowerCase(Locale.ROOT);

--- a/src/plugin/parse-tika/src/java/org/apache/nutch/parse/tika/DOMBuilder.java
+++ b/src/plugin/parse-tika/src/java/org/apache/nutch/parse/tika/DOMBuilder.java
@@ -376,7 +376,7 @@ class DOMBuilder implements ContentHandler, LexicalHandler {
    */
   public void setIDAttribute(String id, Element elem) {
 
-    // Do nothing. This method is meant to be overiden.
+    // Do nothing. This method is meant to be overridden.
   }
 
   /**
@@ -663,7 +663,7 @@ class DOMBuilder implements ContentHandler, LexicalHandler {
 
     String s = new String(ch, start, length);
 
-    // XXX ab@apache.org: modified from the original, to accomodate TagSoup.
+    // XXX ab@apache.org: modified from the original, to accommodate TagSoup.
     Node n = m_currentNode.getLastChild();
     if (n instanceof CDATASection)
       ((CDATASection) n).appendData(s);

--- a/src/plugin/parse-tika/src/java/org/apache/nutch/parse/tika/DOMContentUtils.java
+++ b/src/plugin/parse-tika/src/java/org/apache/nutch/parse/tika/DOMContentUtils.java
@@ -139,7 +139,7 @@ public class DOMContentUtils {
   }
 
   /**
-   * This is a convinience method, equivalent to
+   * This is a convenience method, equivalent to
    * {@link #getText(StringBuffer,Node,boolean) getText(sb, node, false)}.
    * @param sb a {@link StringBuffer} used to store content text
    * found beneath the DOM node... if any exists

--- a/src/plugin/parse-tika/src/java/org/apache/nutch/parse/tika/HTMLMetaProcessor.java
+++ b/src/plugin/parse-tika/src/java/org/apache/nutch/parse/tika/HTMLMetaProcessor.java
@@ -45,7 +45,7 @@ public class HTMLMetaProcessor {
    * @param metaTags a {@link HTMLMetaTags} to populate with tags discovered in the 
    * given Node
    * @param node a DOM {@link Node} to process and extract metadata from
-   * @param currURL the cononical URL associated with the metatags and Node
+   * @param currURL the canonical URL associated with the metatags and Node
    */
   public static final void getMetaTags(HTMLMetaTags metaTags, Node node,
       URL currURL) {
@@ -69,7 +69,7 @@ public class HTMLMetaProcessor {
         Node nameNode = null;
         Node equivNode = null;
         Node contentNode = null;
-        // Retrieves name, http-equiv and content attribues
+        // Retrieves name, http-equiv and content attributes
         for (int i = 0; i < attrs.getLength(); i++) {
           Node attr = attrs.item(i);
           String attrName = attr.getNodeName().toLowerCase(Locale.ROOT);

--- a/src/plugin/parse-zip/src/java/org/apache/nutch/parse/zip/ZipParser.java
+++ b/src/plugin/parse-zip/src/java/org/apache/nutch/parse/zip/ZipParser.java
@@ -101,7 +101,7 @@ public class ZipParser implements Parser {
     final ParseData parseData = new ParseData(ParseStatus.STATUS_SUCCESS,
         resultTitle, outlinks, content.getMetadata());
 
-    LOG.trace("Zip file parsed sucessfully.");
+    LOG.trace("Zip file parsed successfully.");
 
     return ParseResult.createParseResult(content.getUrl(), new ParseImpl(
         resultText, parseData));

--- a/src/plugin/parsefilter-naivebayes/src/java/org/apache/nutch/parsefilter/naivebayes/NaiveBayesParseFilter.java
+++ b/src/plugin/parsefilter-naivebayes/src/java/org/apache/nutch/parsefilter/naivebayes/NaiveBayesParseFilter.java
@@ -63,7 +63,7 @@ public class NaiveBayesParseFilter implements HtmlParseFilter {
     try {
       return classify(text);
     } catch (IOException e) {
-      LOG.error("Error occured while classifying:: {} ::", text, e);
+      LOG.error("Error occurred while classifying:: {} ::", text, e);
     }
 
     return false;
@@ -139,7 +139,7 @@ public class NaiveBayesParseFilter implements HtmlParseFilter {
       train();
     } catch (Exception e) {
 
-      LOG.error("Error occured while training::", e);
+      LOG.error("Error occurred while training::", e);
 
     }
 

--- a/src/plugin/parsefilter-naivebayes/src/java/org/apache/nutch/parsefilter/naivebayes/package-info.java
+++ b/src/plugin/parsefilter-naivebayes/src/java/org/apache/nutch/parsefilter/naivebayes/package-info.java
@@ -19,7 +19,7 @@
  * Html Parse filter that classifies the outlinks from the parseresult as
  * relevant or irrelevant based on the parseText's relevancy (using a training
  * file where you can give positive and negative example texts see the
- * description of parsefilter.naivebayes.trainfile) and if found irrelevent
+ * description of parsefilter.naivebayes.trainfile) and if found irrelevant
  * it gives the link a second chance if it contains any of the words from the
  * list given in parsefilter.naivebayes.wordlist. CAUTION: Set the
  * parser.timeout to -1 or a bigger value than 30, when using this classifier.

--- a/src/plugin/plugin.dtd
+++ b/src/plugin/plugin.dtd
@@ -22,7 +22,7 @@
  !  Author     : Chris Mattmann, Jerome Charron
  !  Description: Nutch plug-in manifest DTD
  !
- !  PUBLIC ID  : -//Apache Software Fundation//DTD Nutch Plugin Manifest 1.0//EN
+ !  PUBLIC ID  : -//Apache Software Foundation//DTD Nutch Plugin Manifest 1.0//EN
  !  SYSTEM ID  : http://lucene.apache.org/nutch/plugin.dtd
 -->
 

--- a/src/plugin/protocol-ftp/src/java/org/apache/nutch/protocol/ftp/Client.java
+++ b/src/plugin/protocol-ftp/src/java/org/apache/nutch/protocol/ftp/Client.java
@@ -228,7 +228,7 @@ public class Client extends FTP {
     __initDefaults();
     super.disconnect();
     // no worry for data connection, since we always close it
-    // in every ftp command that invloves data connection
+    // in every ftp command that involves data connection
   }
 
   /***
@@ -517,7 +517,7 @@ public class Client extends FTP {
    * <p>
    *
    * @param fileType
-   *          The <code> _FILE_TYPE </code> constant indcating the type of file.
+   *          The <code> _FILE_TYPE </code> constant indicating the type of file.
    * @return True if successfully completed, false if not.
    * @exception FTPConnectionClosedException
    *              If the FTP server prematurely closes the connection as a

--- a/src/plugin/protocol-ftp/src/java/org/apache/nutch/protocol/ftp/FtpResponse.java
+++ b/src/plugin/protocol-ftp/src/java/org/apache/nutch/protocol/ftp/FtpResponse.java
@@ -350,7 +350,7 @@ public class FtpResponse {
       // in case this FtpExceptionControlClosedByForcedDataClose is
       // thrown by retrieveList() (not retrieveFile()) above,
       if (os == null) { // indicating throwing by retrieveList()
-        // throw new FtpException("fail to get attibutes: "+path);
+        // throw new FtpException("fail to get attributes: "+path);
         Ftp.LOG.warn(
             "Please try larger maxContentLength for ftp.client.retrieveList(). ",
             e);

--- a/src/plugin/protocol-selenium/README.md
+++ b/src/plugin/protocol-selenium/README.md
@@ -42,7 +42,7 @@ sudo apt-get install firefox
 
  * Install Xvfb and its associates
 
-This step is not necessary for the PhantomJs broswer and may not be needed for all browsers.
+This step is not necessary for the PhantomJs browser and may not be needed for all browsers.
 
 ```
 sudo apt-get install xorg synaptic xvfb gtk2-engines-pixbuf xfonts-cyrillic xfonts-100dpi \
@@ -58,7 +58,7 @@ sudo export DISPLAY=:11
 ```
 ### B) Setting up a Selenium Grid
 
-Using the Selenium Grid will allow you to parallelize the job by facilitating access of several instances of browsers whether on one machine or on several machines. Note that grid facilitates heterogeneity with regards to browser types used. However, these steps have been tested using a homogenous Selenium Grid with Firefox and PhantomJS browsers.
+Using the Selenium Grid will allow you to parallelize the job by facilitating access of several instances of browsers whether on one machine or on several machines. Note that grid facilitates heterogeneity with regards to browser types used. However, these steps have been tested using a homogeneous Selenium Grid with Firefox and PhantomJS browsers.
 
  * Download the [Selenium Standalone Server](https://selenium.dev/downloads/) and follow the installation instructions.
 
@@ -143,7 +143,7 @@ Using the Selenium Grid will allow you to parallelize the job by facilitating ac
   <value></value>
   <description>
     The location on disk where a URL screenshot should be saved
-    to if the 'selenium.take.screenshot' proerty is set to true.
+    to if the 'selenium.take.screenshot' property is set to true.
     By default this is null, in this case screenshots held in memory
     are simply discarded.
   </description>
@@ -215,7 +215,7 @@ ant runtime
 * Be sure your browser version and selenium version are compatible (See list in 'Tested configurations' section below)
 * Be sure to start the Xvfb window then start selenium (not a necessary step for PhantomJS)
 * Disconnecting and reconnect nodes after a hub config change has proven useful in our tests.
-* Be sure that each browser session deallocates its webdriver resource independently of any other tests running on other broswers (check out driver.quit() and driver.close()).
+* Be sure that each browser session deallocates its webdriver resource independently of any other tests running on other browsers (check out driver.quit() and driver.close()).
 
 ### Tested configurations
 

--- a/src/plugin/protocol-selenium/README.md
+++ b/src/plugin/protocol-selenium/README.md
@@ -58,7 +58,9 @@ sudo export DISPLAY=:11
 ```
 ### B) Setting up a Selenium Grid
 
-Using the Selenium Grid will allow you to parallelize the job by facilitating access of several instances of browsers whether on one machine or on several machines. Note that grid facilitates heterogeneity with regards to browser types used. However, these steps have been tested using a homogeneous Selenium Grid with Firefox and PhantomJS browsers.
+Using the Selenium Grid will allow you to parallelize the job by facilitating access of several instances of browsers whether on one machine or on several machines.
+
+Note that grid facilitates heterogeneity with regards to browser types used. However, these steps have been tested using a homogeneous Selenium Grid with Firefox and PhantomJS browsers.
 
  * Download the [Selenium Standalone Server](https://selenium.dev/downloads/) and follow the installation instructions.
 

--- a/src/plugin/publish-rabbitmq/src/java/org/apache/nutch/publisher/rabbitmq/RabbitMQPublisherImpl.java
+++ b/src/plugin/publish-rabbitmq/src/java/org/apache/nutch/publisher/rabbitmq/RabbitMQPublisherImpl.java
@@ -85,7 +85,7 @@ public class RabbitMQPublisherImpl implements NutchPublisher {
       message.setHeaders(headersStatic);
       client.publish(exchange, routingKey, message);
     } catch (Exception e) {
-      LOG.error("Error occured while publishing - {}",
+      LOG.error("Error occurred while publishing - {}",
           StringUtils.stringifyException(e));
     }
   }

--- a/src/plugin/scoring-metadata/src/java/org/apache/nutch/scoring/metadata/MetadataScoringFilter.java
+++ b/src/plugin/scoring-metadata/src/java/org/apache/nutch/scoring/metadata/MetadataScoringFilter.java
@@ -80,7 +80,7 @@ public class MetadataScoringFilter extends AbstractScoringFilter  {
 
   /**
    * Takes the metadata, specified in your "scoring.db.md" property, from the
-   * datum object and injects it into the content. This is transfered to the
+   * datum object and injects it into the content. This is transferred to the
    * parseData object.
    * 
    * @see ScoringFilter#passScoreBeforeParsing

--- a/src/plugin/subcollection/src/java/org/apache/nutch/collection/CollectionManager.java
+++ b/src/plugin/subcollection/src/java/org/apache/nutch/collection/CollectionManager.java
@@ -78,7 +78,7 @@ public class CollectionManager extends Configured {
           getConf().get("subcollections.config", DEFAULT_FILE_NAME));
       parse(input);
     } catch (Exception e) {
-      LOG.warn("Error occured:", e);
+      LOG.warn("Error occurred:", e);
     }
   }
 
@@ -121,7 +121,7 @@ public class CollectionManager extends Configured {
   /**
    * Get the named subcollection
    * 
-   * @param id the id of a subcollection ot retrieve
+   * @param id the id of a subcollection to retrieve
    * @return Named SubCollection (or null if not existing)
    */
   public Subcollection getSubColection(final String id) {
@@ -150,7 +150,7 @@ public class CollectionManager extends Configured {
    *          Id of SubCollection to create
    * @param name
    *          Name of SubCollection to create
-   * @return Created SubCollection or null if allready existed
+   * @return Created SubCollection or null if already existed
    */
   public Subcollection createSubCollection(final String id, final String name) {
     Subcollection subCol = null;

--- a/src/plugin/subcollection/src/java/org/apache/nutch/collection/Subcollection.java
+++ b/src/plugin/subcollection/src/java/org/apache/nutch/collection/Subcollection.java
@@ -235,7 +235,7 @@ public class Subcollection extends Configured implements URLFilter {
    * with a newline
    * 
    * @param list An initialized {@link List} to insert String patterns.
-   * @param text A chunkl fo text (hopefully) containing patterns.
+   * @param text A chunk of text (hopefully) containing patterns.
    */
   protected void parseList(List<String> list, String text) {
     list.clear();

--- a/src/plugin/subcollection/src/java/org/apache/nutch/indexer/subcollection/SubcollectionIndexingFilter.java
+++ b/src/plugin/subcollection/src/java/org/apache/nutch/indexer/subcollection/SubcollectionIndexingFilter.java
@@ -95,7 +95,7 @@ public class SubcollectionIndexingFilter extends Configured implements
   @Override
   public NutchDocument filter(NutchDocument doc, Parse parse, Text url,
       CrawlDatum datum, Inlinks inlinks) throws IndexingException {
-    // Check for subcollection overrride in HTML metadata
+    // Check for subcollection override in HTML metadata
     String subcollection = parse.getData().getMeta(metadataSource);
     if (subcollection != null) {
       subcollection = subcollection.trim();

--- a/src/plugin/urlmeta/src/java/org/apache/nutch/scoring/urlmeta/URLMetaScoringFilter.java
+++ b/src/plugin/urlmeta/src/java/org/apache/nutch/scoring/urlmeta/URLMetaScoringFilter.java
@@ -75,7 +75,7 @@ public class URLMetaScoringFilter extends AbstractScoringFilter {
 
   /**
    * Takes the metadata, specified in your "urlmeta.tags" property, from the
-   * datum object and injects it into the content. This is transfered to the
+   * datum object and injects it into the content. This is transferred to the
    * parseData object.
    * 
    * @see ScoringFilter#passScoreBeforeParsing

--- a/src/plugin/urlnormalizer-protocol/src/java/org/apache/nutch/net/urlnormalizer/protocol/package-info.java
+++ b/src/plugin/urlnormalizer-protocol/src/java/org/apache/nutch/net/urlnormalizer/protocol/package-info.java
@@ -27,7 +27,7 @@
  * The configuration of rules follows the schema:
  * 
  * <pre>
- * &lt;host&gt; \t &lt;protcol&gt;
+ * &lt;host&gt; \t &lt;protocol&gt;
  * </pre>
  * 
  * for example

--- a/src/plugin/urlnormalizer-regex/src/java/org/apache/nutch/net/urlnormalizer/regex/RegexURLNormalizer.java
+++ b/src/plugin/urlnormalizer-regex/src/java/org/apache/nutch/net/urlnormalizer/regex/RegexURLNormalizer.java
@@ -67,7 +67,7 @@ public class RegexURLNormalizer extends Configured implements URLNormalizer {
       .getLogger(MethodHandles.lookup().lookupClass());
 
   /**
-   * Class which holds a compiled pattern and its corresponding substition
+   * Class which holds a compiled pattern and its corresponding substitution
    * string.
    */
   private static class Rule {


### PR DESCRIPTION
PR for [NUTCH-3197](https://issues.apache.org/jira/browse/NUTCH-3197)

Linked follow-up to the Child B shell/Docker/shelldocs PR from `lewismc/nutch`. Fixes remaining **product** codespell typos in Java sources, plugin code, and configuration descriptions — not intentional test fixtures or ISO language codes.

**Fork:** `lewismc/nutch` → `apache/nutch` (replaces incorrectly opened #957 from upstream branch).

**Merge order:** land the primary NUTCH-3197 PR first, then rebase this branch onto `master` before merge (or merge after primary lands and update diff).

## Summary

- Correct misspellings in javadoc, comments, and `nutch-default.xml` descriptions across core and plugins (~50 files)
- Extend `.codespellrc` skip for `langmappings.properties` (ISO 639 codes), `**/naivebayes-model`, and `**/sample/**`
- Add `fo` to ignore-words for trie-matcher demo `main()` test prefixes

## Test plan

- [x] `codespell -q 3 src/java src/plugin conf/nutch-default.xml src/bin` — clean
- [x] `ant test`
- [x] Yetus codespell subsystem clean on this PR