### PR TITLE
NUTCH-3208 GitHub Actions JUnit and Yetus workflows do not reliably post PR comments

### DIFF
--- a/.github/workflows/yetus-comment.yml
+++ b/.github/workflows/yetus-comment.yml
@@ -1,0 +1,110 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Companion to yetus.yml. Posts a sticky PR comment using the base-repo
+# GITHUB_TOKEN. Does not check out pull request head.
+
+name: yetus comment
+on:
+  workflow_run:
+    workflows: [Apache Yetus]
+    types: [completed]
+
+concurrency:
+  group: yetus-comment-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.conclusion == 'success' ||
+       github.event.workflow_run.conclusion == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Yetus PR comment artifacts
+        continue-on-error: true
+        uses: dawidd6/action-download-artifact@v24
+        with:
+          name: yetus-pr-comment
+          workflow: yetus.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          path: ./yetus-pr-comment
+      - name: Resolve and validate PR number
+        id: pr
+        run: |
+          set -euo pipefail
+          REPO="${{ github.repository }}"
+          PR_NUMBER=""
+          if [ -f ./yetus-pr-comment/pr-number ]; then
+            PR_NUMBER=$(tr -d '[:space:]' < ./yetus-pr-comment/pr-number)
+          fi
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::notice::No valid pr-number artifact. Skipping comment."
+            echo "has_pr=false" >> "$GITHUB_OUTPUT"
+            echo "number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          BASE=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.base.repo.full_name // empty')
+          if [ "$BASE" != "$REPO" ]; then
+            echo "::notice::PR ${PR_NUMBER} is not in ${REPO} (base=${BASE}). Skipping comment."
+            echo "has_pr=false" >> "$GITHUB_OUTPUT"
+            echo "number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ ! -f ./yetus-pr-comment/yetus-report.md ]; then
+            echo "::notice::yetus-report.md missing. Skipping comment."
+            echo "has_pr=false" >> "$GITHUB_OUTPUT"
+            echo "number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "has_pr=true" >> "$GITHUB_OUTPUT"
+          echo "Resolved PR number=${PR_NUMBER} repo=${REPO}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+      # peter-evans/find-comment is not on ASF approved_patterns.yml; use gh instead.
+      - name: Find sticky Yetus comment
+        if: steps.pr.outputs.has_pr == 'true'
+        id: find
+        run: |
+          set -euo pipefail
+          REPO="${{ github.repository }}"
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+          COMMENT_ID=""
+          while IFS= read -r line; do
+            COMMENT_ID="$line"
+            break
+          done < <(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- nutch-yetus-report -->"))) | .id')
+          echo "comment-id=${COMMENT_ID:-}" >> "$GITHUB_OUTPUT"
+          echo "Found sticky comment id='${COMMENT_ID:-}'"
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Upsert sticky Yetus comment
+        if: steps.pr.outputs.has_pr == 'true'
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          issue-number: ${{ steps.pr.outputs.number }}
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          edit-mode: replace
+          body-path: ./yetus-pr-comment/yetus-report.md

--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -17,6 +17,9 @@
 # The action runs inside ghcr.io/apache/yetus:0.15.1 — javahome must be a JDK path
 # inside that image (OpenJDK 11 on amd64), not actions/setup-java on the runner.
 # See https://yetus.apache.org/documentation/0.15.1/precommit/
+#
+# PR comments are posted by yetus-comment.yml (workflow_run). Fork pull_request
+# jobs cannot write comments with GITHUB_TOKEN; do not use pull_request_target.
 ---
 name: Apache Yetus
 on:
@@ -30,13 +33,9 @@ concurrency:
   group: yetus-${{ github.ref }}
   cancel-in-progress: true
 
-# GITHUB_TOKEN cannot comment on PRs from forks (403). Use a PAT secret
-# (e.g. YETUS_COMMENT_TOKEN) if you need comments on fork PRs.
 permissions:
   contents: read
   statuses: write
-  pull-requests: write
-  issues: write
 
 jobs:
   yetus:
@@ -72,10 +71,10 @@ jobs:
           name: apacheyetuspatchdir
           path: ${{ env.PATCH_DIR }}
       - name: Install pandoc
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         run: sudo apt-get update && sudo apt-get install -y pandoc
       - name: Convert HTML report to Markdown
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         run: |
           OUT="${{ env.PATCH_DIR }}"
           echo "## Apache Yetus test-patch report" > yetus-report.md
@@ -95,7 +94,7 @@ jobs:
             echo "No Yetus report or brief found." >> yetus-report.md
           fi
       - name: Truncate if over comment limit
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         run: |
           MAX=60000
           if [ $(wc -c < yetus-report.md) -gt $MAX ]; then
@@ -105,12 +104,17 @@ jobs:
             echo "_Report truncated (GitHub comment limit). Full HTML in apacheyetuspatchdir artifact as report.html._" >> yetus-report-trimmed.md
             mv yetus-report-trimmed.md yetus-report.md
           fi
-      - name: Comment PR with Yetus report
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
-        continue-on-error: true
+      - name: Record PR number and sticky marker
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          echo "" >> yetus-report.md
+          echo "<!-- nutch-yetus-report -->" >> yetus-report.md
+          echo "${{ github.event.pull_request.number }}" > pr-number
+      - name: Upload Yetus PR comment artifacts
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
         with:
-          token: ${{ secrets.YETUS_COMMENT_TOKEN || secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body-path: yetus-report.md
+          name: yetus-pr-comment
+          path: |
+            yetus-report.md
+            pr-number


### PR DESCRIPTION
(yetus): post a sticky report from a `workflow_run` companion so fork PRs can comment. Find the existing comment with `gh`; generate markdown on `pull_request` only.

PR fixes part 2 of [NUTCH-3208](https://issues.apache.org/jira/browse/NUTCH-3208)

Again, unfortunately, the GitHub workflow result cannot be properly validated unless it is merged into `master` and then the workflow is run on a new incoming PR...which is what I did in my local setup.
